### PR TITLE
Fixed examples and typos

### DIFF
--- a/docset/windows/fileserverresourcemanager/get-fsrmquota.md
+++ b/docset/windows/fileserverresourcemanager/get-fsrmquota.md
@@ -36,14 +36,14 @@ The **Get-FsrmQuota** cmdlet gets a File Server Resource Manager (FSRM) quota or
 
 ### Example 1: Get all quotas
 ```
-PS C:\> Get-FsrmQuotaTemplate
+PS C:\> Get-FsrmQuota
 ```
 
 This command gets all quotas on the server.
 
 ### Example 2: Get quotas by using a path
 ```
-PS C:\> Get-FsrmQuotaTemplate -Path "C:\Shares\..."
+PS C:\> Get-FsrmQuota -Path "C:\Share01\..."
 ```
 
 This command gets all of the quotas in C:\Share01 plus all of the quotas in all subfolders of C:\Share01.
@@ -95,10 +95,10 @@ Specifies the local folder that contains the quota.
 This parameter supports recursive and wildcard paths.
 To specify a recursive path, add \...
 to a path.
-For example, C:\ Share01\...
-indicates all of the quotas in C:\ Share1 plus all the quotas in any and all subfolders of C:\ Share01.
-To specify a wildcard in a path, you can add the asterisk (*) and the question mark (?) to a path.
-For example, C:\ Share01\*A indicates all of the quotas in C:\ Share01 plus all the quotas in subfolders of C:\ Share01 that have a name that begins with the letter A.
+For example, C:\Share01\...
+indicates all of the quotas in C:\Share01 plus all the quotas in any and all subfolders of C:\Share01.
+To specify a wildcard in a path, you can add the asterisk (&ast;) and the question mark (?) to a path.
+For example, C:\Share01\&ast;A indicates all of the quotas in C:\Share01 plus all the quotas in subfolders of C:\Share01 that have a name that begins with the letter A.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Fixed the examples to correctly indicate the cmdlet and various typos in the doc.