### PR TITLE
Clarifying that PreserveApplicationData can only be used for loose fi…

### DIFF
--- a/docset/windows/appx/remove-appxpackage.md
+++ b/docset/windows/appx/remove-appxpackage.md
@@ -86,7 +86,9 @@ Accept wildcard characters: False
 
 ### -PreserveApplicationData
 Specifies that the cmdlet preserves the application data during the package removal.
-The application data is available for later use.
+The application data is available for later use. Note that this is only applicable
+for apps that are under development so this option can only be specified for apps 
+that are registered from file layout (Loose file registered).
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
…le registered packages

Addressing feedback from Bug 5419191: Remove-AppxPackage -PreserveApplicationData docs don't say DevelopmentMode-only

https://msdn.microsoft.com/en-us/library/windows/apps/windows.management.deployment.removaloptions.aspx
Saying:
This can only apply to packages that were deployed with the DeploymentOptions::DevelopmentMode value.
But the Powershell doc is missing that info:
https://technet.microsoft.com/en-us/library/dn448374.aspx