### PR TITLE
Update get-vmhost.md to correct Output object

### DIFF
--- a/docset/windows/hyper-v/get-vmhost.md
+++ b/docset/windows/hyper-v/get-vmhost.md
@@ -106,7 +106,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### Microsoft.HyperV.PowerShell.Host
+### Microsoft.HyperV.PowerShell.VMHost
 
 ## NOTES
 


### PR DESCRIPTION
Get-VMHost returns a Microsoft.HyperV.PowerShell.VMHost object.
The Get-Help output currently says that it returns a Microsoft.HyperV.PowerShell.Host
