### PR TITLE
Update Example 4's sample code to fix typo's

### DIFF
--- a/docset/winserver2012-ps/activedirectory/Add-ADGroupMember.md
+++ b/docset/winserver2012-ps/activedirectory/Add-ADGroupMember.md
@@ -86,8 +86,8 @@ Gets a group from the Organizational Unit "OU=AccountDeptOU,DC=AppNC" in the AD 
 ### -------------------------- EXAMPLE 4 --------------------------
 ```
 C:\PS>$user = Get-ADUser "CN=Glen John,OU=UserAccounts,DC=NORTHAMERICA,DC=FABRIKAM,DC=COM" -Server "northamerica.fabrikam.com";
-$group = Get-ADGroup "CN=AccountLeads,OU=UserAccounts,DC=EUROPE,DC=FABRIKAM,DC=COM -Server "europe.fabrikam.com";
-Add-ADGroupMember $group -Member $user -Server "europe.fabrikam.com"
+$group = Get-ADGroup "CN=AccountLeads,OU=UserAccounts,DC=EUROPE,DC=FABRIKAM,DC=COM" -Server "europe.fabrikam.com";
+Add-ADGroupMember $group -Members $user -Server "europe.fabrikam.com"
 ```
 
 Description


### PR DESCRIPTION
Fixed some formatting issues within Example 4:

Closed quotes on Get-ADGroup identity parameter
Pluralised -Members parameter of Add-ADGroupMember, as per docs.