### PR TITLE
Fix Example 4 in Add-PswaAuthorizationRule

### DIFF
--- a/docset/winserver2012r2-ps/powershellwebaccess/Add-PswaAuthorizationRule.md
+++ b/docset/winserver2012r2-ps/powershellwebaccess/Add-PswaAuthorizationRule.md
@@ -101,7 +101,7 @@ PS C:\>$o = New-Object -TypeName PSObject | Add-Member -Type NoteProperty -Name 
 
 
 
-PS C:\>$o | Add-PswaAuthorizationRule -UserName contoso\user1 -ConfigurationName Microsoft.PowerShell
+PS C:\>$o | Add-PswaAuthorizationRule
 ```
 
 This example illustrates how all parameters take values from pipeline by property name.


### PR DESCRIPTION
There is no need in including parameters -UserName and -ConfigurationName in the command since we specified values for the properties with these names in PSObject in $o variable.