### PR TITLE
Remove DHCP server reference from ComputerName parameter description

### DIFF
--- a/docset/.markdownlint.json
+++ b/docset/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+    "default": true,
+    "MD013": false,
+    "MD024": false,
+    "MD041": false,
+    "no-hard-tabs": false
+}

--- a/docset/windows/nettcpip/test-netconnection.md
+++ b/docset/windows/nettcpip/test-netconnection.md
@@ -11,7 +11,7 @@ ms.date: 12/20/2016
 ms.prod: w10
 ms.technology: powershell-windows
 ms.topic: reference
-online version: 
+online version:
 schema: 2.0.0
 title: Test-NetConnection
 ms.assetid: F76921D4-3657-40BF-A99F-2E83609EA048
@@ -109,7 +109,7 @@ NameResolutionResults   : 2a01:111:2003::52
 
                           13.107.4.52
 
-MatchingIPsecRules      : Ipsec/Domain-TrafficFromInternet-v6 
+MatchingIPsecRules      : Ipsec/Domain-TrafficFromInternet-v6
 
 NetworkIsolationContext : Internet
 
@@ -165,12 +165,12 @@ OutgoingInterfaceIndex : 4
 
 SelectedNetRoute : DestinationPrefix: ::/0 NextHop: fe80::200:5eff:fe00:202
 
-RouteSelectionEvents : IP: Route [DestinationPrefix: ::/0 NextHop: fe80::200:5eff:fe00:202 InterfaceIndex: 4 InterfaceMetric: 10 RouteMetric: 256] is preferred over 
+RouteSelectionEvents : IP: Route [DestinationPrefix: ::/0 NextHop: fe80::200:5eff:fe00:202 InterfaceIndex: 4 InterfaceMetric: 10 RouteMetric: 256] is preferred over
 
 Route [DestinationPrefix: ::/0 NextHop: fe80::200:5eff:fe00:202 InterfaceIndex: 5 InterfaceMetric: 10 RouteMetric: 256] for
-Destination: 2001:428:3805:187::2768 in Compartment: 1, Reason: RouteOrder. 
+Destination: 2001:428:3805:187::2768 in Compartment: 1, Reason: RouteOrder.
 
-SourceAddressSelectionEvents : IP: Source address 2001:4898:e0:79:f17c:d212:8743:43c2 is preferred over fe80::f17c:d212:8743:43c2 for destination 2001:428:3805:187::2768 Rule = 2.0. 
+SourceAddressSelectionEvents : IP: Source address 2001:4898:e0:79:f17c:d212:8743:43c2 is preferred over fe80::f17c:d212:8743:43c2 for destination 2001:428:3805:187::2768 Rule = 2.0.
 
 RouteDiagnosticsSucceeded : True
 ```
@@ -196,11 +196,11 @@ NextHop: fe80::200:5eff:fe00:202
 
 RouteSelectionEvents : IP: Route [DestinationPrefix: ::/0 NextHop: fe80::200:5eff:fe00:202 InterfaceIndex: 4
 
-RouteMetric: 256] is blocked for Destination: 2600:1409:a:185::2768 ConstrainInterfaceIndex: 5 ConstrainScopeZone: 1 in Compartment: 1, Reason: InterfaceConstraint. 
+RouteMetric: 256] is blocked for Destination: 2600:1409:a:185::2768 ConstrainInterfaceIndex: 5 ConstrainScopeZone: 1 in Compartment: 1, Reason: InterfaceConstraint.
 
-SourceAddressSelectionEvents : IP: Source address 2001:4898:e0:79:75dd:64cf:d9ff:f86 is preferred over fe80::75dd:64cf:d9ff:f86 for destination 2600:1409:a:185::2768 Rule = 2.0. 
+SourceAddressSelectionEvents : IP: Source address 2001:4898:e0:79:75dd:64cf:d9ff:f86 is preferred over fe80::75dd:64cf:d9ff:f86 for destination 2600:1409:a:185::2768 Rule = 2.0.
 
-IP: Source address 2001:4898:e0:79:75dd:64cf:d9ff:f86 is preferred over fe80::75dd:64cf:d9ff:f86 for destination 2600:1409:a:185::2768 Rule = 2.0. 
+IP: Source address 2001:4898:e0:79:75dd:64cf:d9ff:f86 is preferred over fe80::75dd:64cf:d9ff:f86 for destination 2600:1409:a:185::2768 Rule = 2.0.
 
 RouteDiagnosticsSucceeded : True
 ```
@@ -213,15 +213,15 @@ This command performs route diagnostics to reach a remote host named www.contoso
 Specifies the common service TCP port number.
 The acceptable values for this parameter are:
 
-- SMB 
-- HTTP 
+- SMB
+- HTTP
 - RDP
 - WINRM
 
 ```yaml
 Type: String
 Parameter Sets: CommonTCPPort
-Aliases: 
+Aliases:
 Accepted values: HTTP, RDP, SMB, WINRM
 
 Required: True
@@ -232,7 +232,7 @@ Accept wildcard characters: False
 ```
 
 ### -ComputerName
-Specifies the Domain Name System (DNS) name or IP address of the target computer that runs the Dynamic Host Configuration Protocol (DHCP) server service.
+Specifies the Domain Name System (DNS) name or IP address of the target computer.
 
 ```yaml
 Type: String
@@ -252,7 +252,7 @@ Specifies the interface constraint to use for route diagnostics.
 ```yaml
 Type: UInt32
 Parameter Sets: NetRouteDiagnostics
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -267,7 +267,7 @@ Specifies the source address constraint to use for route diagnostics.
 ```yaml
 Type: String
 Parameter Sets: NetRouteDiagnostics
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -282,7 +282,7 @@ Indicates that route diagnostics runs to output the route and source address sel
 ```yaml
 Type: SwitchParameter
 Parameter Sets: NetRouteDiagnostics
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -297,7 +297,7 @@ Specifies the number of hops to traverse in a trace route command.
 ```yaml
 Type: Int32
 Parameter Sets: ICMP
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -311,7 +311,7 @@ Specifies the information level.
 The acceptable values for this parameter are:
 
 - Detailed
-- Quiet 
+- Quiet
 
 If you set this parameter to Quiet, the cmdlet returns basic information.
 For example, for a ping test, this cmdlet returns a Boolean value that indicates whether the attempt to ping a host or port is successful.
@@ -319,7 +319,7 @@ For example, for a ping test, this cmdlet returns a Boolean value that indicates
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: Quiet, Detailed
 
 Required: False
@@ -351,7 +351,7 @@ Indicates that Tracert runs to test connectivity to the remote host.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: ICMP
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/docset/windows/nettcpip/test-netconnection.md
+++ b/docset/windows/nettcpip/test-netconnection.md
@@ -20,34 +20,40 @@ ms.assetid: F76921D4-3657-40BF-A99F-2E83609EA048
 # Test-NetConnection
 
 ## SYNOPSIS
+
 Displays diagnostic information for a connection.
 
 ## SYNTAX
 
 ### ICMP
-```
+
+```powershell
 Test-NetConnection [[-ComputerName] <String>] [-TraceRoute] [-Hops <Int32>] [-InformationLevel <String>]
  [<CommonParameters>]
 ```
 
 ### CommonTCPPort
-```
+
+```powershell
 Test-NetConnection [[-ComputerName] <String>] [-CommonTCPPort] <String> [-InformationLevel <String>]
  [<CommonParameters>]
 ```
 
 ### RemotePort
-```
+
+```powershell
 Test-NetConnection [[-ComputerName] <String>] -Port <Int32> [-InformationLevel <String>] [<CommonParameters>]
 ```
 
 ### NetRouteDiagnostics
-```
+
+```powershell
 Test-NetConnection [[-ComputerName] <String>] [-DiagnoseRouting] [-ConstrainSourceAddress <String>]
  [-ConstrainInterface <UInt32>] [-InformationLevel <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 The **Test-NetConnection** cmdlet displays diagnostic information for a connection.
 It supports ping test, TCP test, route tracing, and route selection diagnostics.
 Depending on the input parameters, the output can include the DNS lookup results, a list of IP interfaces, IPsec rules, route/source address selection results, and/or confirmation of connection establishment.
@@ -55,7 +61,8 @@ Depending on the input parameters, the output can include the DNS lookup results
 ## EXAMPLES
 
 ### Example 1: Test ping connectivity
-```
+
+```powershell
 PS C:\> Test-NetConnection
 ComputerName           : internetbeacon.msedge.net
 
@@ -73,7 +80,8 @@ PingReplyDetails (RTT) : 5 ms
 This command tests ping connectivity to a default server.
 
 ### Example 2: Test ping connectivity with detailed results
-```
+
+```powershell
 PS C:\> Test-NetConnection -InformationLevel "Detailed"
 ComputerName           : internetbeacon.msedge.net
 
@@ -97,7 +105,8 @@ PingReplyDetails (RTT) : 6 ms
 This command tests ping connectivity to a default server and sets the *InformationLevel* parameter to Detailed.
 
 ### Example 3: Test TCP connectivity and display detailed results
-```
+
+```powershell
 PS C:\> Test-NetConnection -Port 80 -InformationLevel "Detailed"
 ComputerName            : internetbeacon.msedge.net
 
@@ -127,7 +136,8 @@ TcpTestSucceeded        : True
 This command tests TCP connectivity to a default server and sets the *InformationLevel* parameter to Detailed.
 
 ### Example 4: Test a connection to a remote host
-```
+
+```powershell
 PS C:\> Test-NetConnection -ComputerName "www.contoso.com" -InformationLevel "Detailed"
 PingReplyDetails (RTT) : 164 ms
 
@@ -153,7 +163,8 @@ PingReplyDetails (RTT) : 164 ms
 This command tests ping connectivity to a remote host named www.contoso.com.
 
 ### Example 5: Perform route diagnostics to connect to a remote host
-```
+
+```powershell
 PS C:\> Test-NetConnection -ComputerName www.contoso.com -DiagnoseRouting -InformationLevel Detailed
 ComputerName : www.contoso.com
 
@@ -178,7 +189,8 @@ RouteDiagnosticsSucceeded : True
 This command performs route diagnostics to reach a remote host named www.contoso.com.
 
 ### Example 6: Perform route diagnostics to connect to a remote host with routing constraints
-```
+
+```powershell
 PS C:\> Test-NetConnection -ComputerName "www.contoso.com" -ConstrainInterface 5 -DiagnoseRouting -InformationLevel "Detailed"
 ComputerName : www.contoso.com
 
@@ -210,6 +222,7 @@ This command performs route diagnostics to reach a remote host named www.contoso
 ## PARAMETERS
 
 ### -CommonTCPPort
+
 Specifies the common service TCP port number.
 The acceptable values for this parameter are:
 
@@ -232,6 +245,7 @@ Accept wildcard characters: False
 ```
 
 ### -ComputerName
+
 Specifies the Domain Name System (DNS) name or IP address of the target computer.
 
 ```yaml
@@ -247,6 +261,7 @@ Accept wildcard characters: False
 ```
 
 ### -ConstrainInterface
+
 Specifies the interface constraint to use for route diagnostics.
 
 ```yaml
@@ -262,6 +277,7 @@ Accept wildcard characters: False
 ```
 
 ### -ConstrainSourceAddress
+
 Specifies the source address constraint to use for route diagnostics.
 
 ```yaml
@@ -277,6 +293,7 @@ Accept wildcard characters: False
 ```
 
 ### -DiagnoseRouting
+
 Indicates that route diagnostics runs to output the route and source address selection information for the remote host.
 
 ```yaml
@@ -292,6 +309,7 @@ Accept wildcard characters: False
 ```
 
 ### -Hops
+
 Specifies the number of hops to traverse in a trace route command.
 
 ```yaml
@@ -307,6 +325,7 @@ Accept wildcard characters: False
 ```
 
 ### -InformationLevel
+
 Specifies the information level.
 The acceptable values for this parameter are:
 
@@ -330,6 +349,7 @@ Accept wildcard characters: False
 ```
 
 ### -Port
+
 Specifies the TCP port number on the remote computer.
 The cmdlet uses this port number to test connectivity to the remote computer.
 
@@ -346,6 +366,7 @@ Accept wildcard characters: False
 ```
 
 ### -TraceRoute
+
 Indicates that Tracert runs to test connectivity to the remote host.
 
 ```yaml
@@ -361,6 +382,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -370,12 +392,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### NetRouteDiagnostics
+
 This object displays route diagnostics information and is returned if you specify the NetRouteDiagnostics parameter set.
 
 ### NetConnectionResults
+
 This object displays connection results and is returned if you specify the CommonTCPPort, RemotePort, or ICMP parameter set.
 
 ## NOTES
 
 ## RELATED LINKS
-


### PR DESCRIPTION
The -ComputerName parameter doesn't have any connection or dependency on a a dhcp server instance, so removed reference to that in the description.