### PR TITLE
Remove typos in documentation.

### DIFF
--- a/docset/windows/addsadministration/get-adtrust.md
+++ b/docset/windows/addsadministration/get-adtrust.md
@@ -195,7 +195,7 @@ Accept wildcard characters: False
 
 ### -InputObject
 Specifies an Active Directory input object.
-This parameter can accept one of the the following object types:
+This parameter can accept one of the following object types:
 
 - ADForest
 - ADDomain

--- a/docset/windows/scheduledtasks/set-clusteredscheduledtask.md
+++ b/docset/windows/scheduledtasks/set-clusteredscheduledtask.md
@@ -67,7 +67,7 @@ The first command uses the New-ScheduledTaskAction cmdlet to create a task actio
 
 The second command uses the **New-ScheduledTaskAction** cmdlet to create a task action and stores that action in the $Action02 variable.
 
-The final command changes the action assigned to the task named Task03 to the the two actions stored in $Action01 and $Action02.
+The final command changes the action assigned to the task named Task03 to the two actions stored in $Action01 and $Action02.
 The cluster runs more than one action in sequence.
 
 ## PARAMETERS

--- a/docset/windows/scheduledtasks/set-scheduledtask.md
+++ b/docset/windows/scheduledtasks/set-scheduledtask.md
@@ -79,7 +79,7 @@ In this example, the set of commands uses cmdlets and variables to modify a sche
 
 In this example, the first command uses the New-ScheduledTaskAction cmdlet to define an action, to which the $A1 variable is assigned.
 
-The second command uses the **New-ScheduledTaskAction** cmdlet to define a second action, to which the the $A2 variable is assigned.
+The second command uses the **New-ScheduledTaskAction** cmdlet to define a second action, to which the $A2 variable is assigned.
 
 The third command adds the two actions to the scheduled task DeployTools.
 

--- a/docset/winserver2012-ps/netwnv/Set-NetVirtualizationProviderAddress.md
+++ b/docset/winserver2012-ps/netwnv/Set-NetVirtualizationProviderAddress.md
@@ -38,7 +38,7 @@ You can specify which Provider Addresses to modify by using address state, inter
 PS C:\> Set-NetVirtualizationProviderAddress -ProviderAddress "192.168.2.3" -InterfaceIndex 17 -VlanID 201
 ```
 
-This command changes the virtual LAN ID for the Provider Address 192.168.2.3 on the the interface that has the Index 17.
+This command changes the virtual LAN ID for the Provider Address 192.168.2.3 on the interface that has the Index 17.
 
 ### Example 2: Change a virtual LAN ID for specified Provider Addresses
 ```

--- a/docset/winserver2012-ps/scheduledtasks/Set-ClusteredScheduledTask.md
+++ b/docset/winserver2012-ps/scheduledtasks/Set-ClusteredScheduledTask.md
@@ -53,7 +53,7 @@ The first command uses the **New-ScheduledTaskAction** cmdlet to create a task a
 
 The second command uses the **New-ScheduledTaskAction** cmdlet to create a task action and stores that action in the $Action02 variable.
 
-The final command changes the action assigned to the task named Task03 to the the two actions stored in $Action01 and $Action02.
+The final command changes the action assigned to the task named Task03 to the two actions stored in $Action01 and $Action02.
 The cluster runs more than one action in sequence.
 
 ## PARAMETERS

--- a/docset/winserver2012-ps/scheduledtasks/Set-ScheduledTask.md
+++ b/docset/winserver2012-ps/scheduledtasks/Set-ScheduledTask.md
@@ -66,7 +66,7 @@ In this example, the set of commands uses cmdlets and variables to modify a sche
 
 In this example, the first command uses the **New-ScheduledTaskAction** cmdlet to define an action, to which the $A1 variable is assigned.
 
-The second command uses the **New-ScheduledTaskAction** cmdlet to define a second action, to which the the $A2 variable is assigned.
+The second command uses the **New-ScheduledTaskAction** cmdlet to define a second action, to which the $A2 variable is assigned.
 
 The third command adds the two actions to the scheduled task DeployTools.
 

--- a/docset/winserver2012r2-ps/addsadministration/Get-ADTrust.md
+++ b/docset/winserver2012r2-ps/addsadministration/Get-ADTrust.md
@@ -193,7 +193,7 @@ Accept wildcard characters: False
 
 ### -InputObject
 Specifies an Active Directory input object.
-This parameter can accept one of the the following object types:
+This parameter can accept one of the following object types:
 
 - ADForest
 - ADDomain

--- a/docset/winserver2012r2-ps/netwnv/Set-NetVirtualizationProviderAddress.md
+++ b/docset/winserver2012r2-ps/netwnv/Set-NetVirtualizationProviderAddress.md
@@ -49,7 +49,7 @@ You can specify which Provider Addresses to modify by using address state, inter
 PS C:\> Set-NetVirtualizationProviderAddress -ProviderAddress "192.168.2.3" -InterfaceIndex 17 -VlanID 201
 ```
 
-This command changes the virtual LAN ID for the Provider Address 192.168.2.3 on the the interface that has the Index 17.
+This command changes the virtual LAN ID for the Provider Address 192.168.2.3 on the interface that has the Index 17.
 
 ### Example 2: Change a virtual LAN ID for specified Provider Addresses
 ```

--- a/docset/winserver2012r2-ps/scheduledtasks/Set-ClusteredScheduledTask.md
+++ b/docset/winserver2012r2-ps/scheduledtasks/Set-ClusteredScheduledTask.md
@@ -65,7 +65,7 @@ The first command uses the **New-ScheduledTaskAction** cmdlet to create a task a
 
 The second command uses the **New-ScheduledTaskAction** cmdlet to create a task action and stores that action in the $Action02 variable.
 
-The final command changes the action assigned to the task named Task03 to the the two actions stored in $Action01 and $Action02.
+The final command changes the action assigned to the task named Task03 to the two actions stored in $Action01 and $Action02.
 The cluster runs more than one action in sequence.
 
 ## PARAMETERS

--- a/docset/winserver2012r2-ps/scheduledtasks/Set-ScheduledTask.md
+++ b/docset/winserver2012r2-ps/scheduledtasks/Set-ScheduledTask.md
@@ -77,7 +77,7 @@ In this example, the set of commands uses cmdlets and variables to modify a sche
 
 In this example, the first command uses the **New-ScheduledTaskAction** cmdlet to define an action, to which the $A1 variable is assigned.
 
-The second command uses the **New-ScheduledTaskAction** cmdlet to define a second action, to which the the $A2 variable is assigned.
+The second command uses the **New-ScheduledTaskAction** cmdlet to define a second action, to which the $A2 variable is assigned.
 
 The third command adds the two actions to the scheduled task DeployTools.
 

--- a/docset/winserver2012r2-ps/servermanagertasks/Get-SMServerBpaResult.md
+++ b/docset/winserver2012r2-ps/servermanagertasks/Get-SMServerBpaResult.md
@@ -132,7 +132,7 @@ Accept wildcard characters: False
 
 ### -BpaXPath
 Specifies one or more BPA XPaths where BPA scan results are available.
-Specify the BPA XPath in the the following format: BpaModelId:BpaFilepath:BpaXPath.
+Specify the BPA XPath in the following format: BpaModelId:BpaFilepath:BpaXPath.
 
 To get the names for BPA models that are installed on the target server, run the cmdlet Get-BpaModelhttp://technet.microsoft.com/library/hh868082.aspx.
 There is no file path available for results for a BPA model on a server until at least one set of scan results is available; that is, at least one scan has been run on the role or feature that is represented by the model.


### PR DESCRIPTION
Remove duplicate 'the'.