### PR TITLE
Corrected mis-spelled "consoso" in EXAMPLE 2 to "contoso" to match

### DIFF
--- a/docset/winserver2012r2-ps/updateservices/Invoke-WsusServerCleanup.md
+++ b/docset/winserver2012r2-ps/updateservices/Invoke-WsusServerCleanup.md
@@ -44,7 +44,7 @@ This example runs this cmdlet on the local WSUS Server specifying the option to 
 
 ### EXAMPLE 2
 ```
-PS C:\> Get-WsusServer consoso | Invoke-WsusServerCleanup -CleanupObsoleteComputers -CleanupObsoleteUpdates
+PS C:\> Get-WsusServer contoso | Invoke-WsusServerCleanup -CleanupObsoleteComputers -CleanupObsoleteUpdates
 Obsolete Updates Deleted: 62 
 Obsolete Computers Deleted: 0
 ```


### PR DESCRIPTION
The text in EXAMPLE 2 uses the WSUS server example **consoso** where it should be called **contoso** to match the paragraph below it in Invoke-WsusServerCleanup.md.