### PR TITLE
Update get-hgsattestationpolicy.md

### DIFF
--- a/docset/windows/hgsattestation/get-hgsattestationpolicy.md
+++ b/docset/windows/hgsattestation/get-hgsattestationpolicy.md
@@ -51,7 +51,7 @@ This command gets the policy named BaselineTpmPolicy16.
 
 ### Example 3: Get policies by type
 ```
-PS C:\> Get-HgsAttestationPolicy -PolicyType Tpm
+PS C:\> Get-HgsAttestationPolicy -PolicyType SecureBootSettings
 ```
 
 This command gets policies that have the type Tpm.


### PR DESCRIPTION
The parameter value has changed. Used to be "tpm" at some point, now it's "SecureBootSettings." TPM is no longer a valid enum value, which is correctly reflected below under -PolicyType details.