### PR TITLE
Add the default value for TokenLifetime

### DIFF
--- a/docset/windows/adfs/set-adfsrelyingpartytrust.md
+++ b/docset/windows/adfs/set-adfsrelyingpartytrust.md
@@ -854,7 +854,7 @@ Accept wildcard characters: False
 ```
 
 ### -TokenLifetime
-Specifies the duration, in minutes, for which the claims that are issued to the relying party are valid.
+Specifies the duration, in minutes, for which the claims that are issued to the relying party are valid. The default TokenLifetime is 60 minutes.
 
 ```yaml
 Type: Int32


### PR DESCRIPTION
Maybe we should also consider indicating that the value 0 (which is the output of a Get-ADFSRelyingPartyTrust) also means default which then means 60 minutes.