### PR TITLE
Update the description for -DependencyPath

### DIFF
--- a/docset/windows/appx/add-appxpackage.md
+++ b/docset/windows/appx/add-appxpackage.md
@@ -117,8 +117,8 @@ Accept wildcard characters: False
 
 ### -DependencyPath
 Specifies an array of file paths of dependency packages that  are required for the installation of the app package.
-The app package has an .appx or .appxbundle file name extension.
-You can specify the paths to more than one dependency package.
+The app package has an .appx or .appxbundle file name extension. You can specify the paths to more than one dependency package.
+If a package is already installed for a user, you can skip adding it to the DependencyPath.
 
 ```yaml
 Type: String[]


### PR DESCRIPTION
Found that Add-AppxPackage fails for side loading when Sticky Notes is running. Solved when removing -DependencyPath.