### PR TITLE
Fixed broken hyperlink for appvsequencer

### DIFF
--- a/docset/docs-conceptual/windows/get-started.md
+++ b/docset/docs-conceptual/windows/get-started.md
@@ -28,7 +28,7 @@ The table below also shows the latest published version of the Help for each mod
 | AppBackgroundTask | [App Background Task](/powershell/module/appbackgroundtask) |
 | AppLocker | [AppLocker](/powershell/module/applocker) |
 | AppvClient | [App-V Client](/powershell/module/appvclient) |
-| AppvSequencer | [App-V Sequencer](/powershell/module//powershell/module/appvsequencer) |
+| AppvSequencer | [App-V Sequencer](/powershell/module/appvsequencer) |
 | Appx | [Appx](/powershell/module/appx) |
 | AssignedAccess | [Assigned Access](/powershell/module/assignedaccess) |
 | BestPractices | [Best Practices Analyser](/powershell/module/bestpractices) |


### PR DESCRIPTION
Hyper link broken. Looks like a simple copy and paste error. Fixed with the proper link.