### PR TITLE
`Get-Website`'s `-Name` option accepts wildcards

### DIFF
--- a/docset/winserver2012-ps/webadminstration/Get-Website.md
+++ b/docset/winserver2012-ps/webadminstration/Get-Website.md
@@ -50,7 +50,7 @@ Required: False
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### CommonParameters


### PR DESCRIPTION
As seen in the screenshot below, the `-Name` option in the `Get-Website` command _does_ accept wildcard characters (`*`, `?`), but until now, it wasn't documented:

![screenshot](https://i.imgur.com/Idad4vV.png)

Try yourself:

```powershell
> Get-Website -Name "Default Web *"
> Get-Website -Name "Default Web ????"
```

I should mention, we're running version **8.5** of IIS on a Windows 8 server.