### PR TITLE
Incorrect parameter in the PowerShell example

### DIFF
--- a/docset/windows/adfs/new-adfssamlendpoint.md
+++ b/docset/windows/adfs/new-adfssamlendpoint.md
@@ -38,7 +38,7 @@ The **New-AdfsSamlEndpoint** cmdlet creates a Security Assertion Markup Language
 ### Example 1: Create a SAML endpoint and assign it to a relying party
 ```
 PS C:\> $EP = New-AdfsSamlEndpoint -Binding "POST" -Protocol "SAMLAssertionConsumer" -Uri "https://fabrikam.com/saml/ac"
-PS C:\> Set-AdfsRelyingPartyTrust -Name "My application" -SamlEndpoint $EP
+PS C:\> Set-AdfsRelyingPartyTrust -TargetName "My application" -SamlEndpoint $EP
 ```
 
 The first command creates a SAML endpoint, and then stores it in the $EP variable.


### PR DESCRIPTION
-Name is to used to identified the the Relying Party Trust. It generated the following error at execution:

"Set-AdfsRelyingPartyTrust : Parameter set cannot be resolved using the specified named parameters."

-TargetName should be used instead, or -TargetIdentifier followed by the identifier of the RPT