### PR TITLE
Updates to "-CompressionType" and "-SourceImagePath" sections

### DIFF
--- a/docset/windows/dism/export-windowsimage.md
+++ b/docset/windows/dism/export-windowsimage.md
@@ -84,7 +84,8 @@ Specifies the type of compression used for the initial capture operation. Accept
 - **"fast:"** Provides faster image compression, but the resulting files are larger than those compressed by using the maximum option.
 - **"none":** No compression is used at all. This is the default. 
 
-**NOTE:** This cmdlet does not support the "recovery" compression type. Use `dism.exe` instead.
+> [!NOTE]
+> This cmdlet does not support the "recovery" compression type. Use `dism.exe` instead.
 
 the *CompressionType* parameter does not apply when you export an image to an existing .wim file, you can only use this CompressionType when you export an image to a new .wim file.
 

--- a/docset/windows/dism/export-windowsimage.md
+++ b/docset/windows/dism/export-windowsimage.md
@@ -78,12 +78,13 @@ Accept wildcard characters: False
 ```
 
 ### -CompressionType
-Specifies the type of compression used for the initial capture operation: 
+Specifies the type of compression used for the initial capture operation. Acceptable values are:
 
-- The maximum option provides the best compression, but takes more time to capture the image. 
-- The fast option provides faster image compression, but the resulting files are larger than those compressed by using the maximum option.
-This is also the default compression type that is used if you do not specify the argument. 
-- The none option does not compress the captured image at all. 
+- **"max" or "maximum":** Provides the high compression, but takes more time to capture the image
+- **"fast:"** Provides faster image compression, but the resulting files are larger than those compressed by using the maximum option.
+- **"none":** No compression is used at all. This is the default. 
+
+**NOTE:** This cmdlet does not support the "recovery" compression type. Use `dism.exe` instead.
 
 the *CompressionType* parameter does not apply when you export an image to an existing .wim file, you can only use this CompressionType when you export an image to a new .wim file.
 
@@ -94,7 +95,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: "none"
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
@@ -146,7 +147,7 @@ Accepted values: Errors, Warnings, WarningsInfo
 
 Required: False
 Position: Named
-Default value: None
+Default value: 3
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
@@ -210,7 +211,7 @@ Accept wildcard characters: False
 ```
 
 ### -SourceImagePath
-Specifies the location of the source image file.
+Specifies the location of the source image file. Must be used in conjunction with `-SourceIndex` or `-SourceName`. If the source file is a SWM file, `-SplitImageFilePattern` is also required.
 
 ```yaml
 Type: String


### PR DESCRIPTION
1. Updated the "-CompressionType" section to include proper compression type names. Also corrected a mistake: The default compression type is "none". Finally, added a note to the effect that the "recovery" type, supported by `dism.exe` is not supported here.
2. Updated the "-SourcePath" section include information re mounting SWM files.