### PR TITLE
Change Lock-Volume to Lock-BitLocker

### DIFF
--- a/docset/windows/bitlocker/lock-bitlocker.md
+++ b/docset/windows/bitlocker/lock-bitlocker.md
@@ -42,7 +42,7 @@ For an overview of BitLocker, see [BitLocker Drive Encryption Overview](http://t
 
 ### Example 1: Lock a volume
 ```
-PS C:\> Lock-Volume -MountPoint "E:" -ForceDismount
+PS C:\> Lock-BitLocker -MountPoint "E:" -ForceDismount
 ```
 
 This command locks the BitLocker volume specified with the *MountPoint* parameter.


### PR DESCRIPTION
### Rationale:

`Lock-Volume` does not seem to be a supported command and results in `Lock-Volume : The term 'Lock-Volume' is not recognized as the name of a cmdlet, function, script file, or operable program.` error message on Windows 10 Pro. `Lock-Bitlocker` (which is the name of this doc and referenced throughout, except in the example) is the expected command, although someone with deeper PS knowledge than me should review this edit.

### Powershell Version:
```
Major  Minor  Build  Revision
-----  -----  -----  --------
5      1      17134  228
```

### Windows 10 Pro Version:
```
Major  Minor  Build  Revision
-----  -----  -----  --------
10     0      17134  0
```