### PR TITLE
Add link to Cryptographic providers

### DIFF
--- a/docset/windows/pkiclient/new-selfsignedcertificate.md
+++ b/docset/windows/pkiclient/new-selfsignedcertificate.md
@@ -617,8 +617,8 @@ Accept wildcard characters: False
 ```
 
 ### -Provider
-Specifies the name of the KSP or CSP that this cmdlet uses to create the certificate. 
-Some acceptable values for this parameter are:
+Specifies the name of the KSP or CSP that this cmdlet uses to create the certificate. See [Cryptographic Providers](https://docs.microsoft.com/en-us/windows/desktop/SecCertEnroll/understanding-cryptographic-providers) for more information.
+Some acceptable values include:
 
 - Microsoft Software Key Storage Provider
 - Microsoft Smart Card Key Storage Provider


### PR DESCRIPTION
The -Provider option doesn't give nearly enough information and I found it hard to locate list/types of supported providers.  The link is to to a msdoc resource