### PR TITLE
fixed typo in example 4

### DIFF
--- a/docset/windows/hyper-v/get-vmharddiskdrive.md
+++ b/docset/windows/hyper-v/get-vmharddiskdrive.md
@@ -77,7 +77,7 @@ Gets the virtual hard drives from IDE controller 1 of virtual machine TestVM loc
 
 ### Example 4
 ```
-PS C:\> Get-VMSnapshot -VMName Test -Name 'Before applying updates' | Get-VMHardDrive
+PS C:\> Get-VMSnapshot -VMName Test -Name 'Before applying updates' | Get-VMHardDiskDrive
 ```
 
 Gets the virtual hard drives from snapshot Before applying updates of virtual machine TestVM.


### PR DESCRIPTION
Fixed typo in example 4: "Get-VMHardDrive" -> "Get-VMHardDiskDrive"

Fixes #320