### PR TITLE
Update example for Export-AdfsDeploymentSQLScript

### DIFF
--- a/docset/windows/adfs/export-adfsdeploymentsqlscript.md
+++ b/docset/windows/adfs/export-adfsdeploymentsqlscript.md
@@ -37,7 +37,7 @@ The **Export-AdfsDeploymentSQLScript** cmdlet generates the SQL scripts that you
 
 ### Example 1: Export SQL deployment scripts
 ```
-PS C:\> Export-AdfsDeploymentSQLScript -ScriptDestinationFolder ".\ScriptFolder" -ServiceAccountName "ContosoDomain\PattiFuller"
+PS C:\> Export-AdfsDeploymentSQLScript -DestinationFolder ".\ScriptFolder" -ServiceAccountName "ContosoDomain\PattiFuller"
 ```
 
 This command exports SQL deployment scripts for AD FS installation on behalf of the specified AD FS service account.

--- a/docset/winserver2012-ps/adfs/Export-AdfsDeploymentSQLScript.md
+++ b/docset/winserver2012-ps/adfs/Export-AdfsDeploymentSQLScript.md
@@ -23,7 +23,7 @@ The Export-AdfsDeploymentSQLScript cmdlet generates the SQL scripts that can be 
 
 ### -------------------------- EXAMPLE 1 --------------------------
 ```
-C:\PS>Export-AdfsDeploymentSQLScript -ScriptDestinationFolder ".\scriptfolder" -ServiceAccountName DOMAIN\adfsUser
+C:\PS>Export-AdfsDeploymentSQLScript -DestinationFolder ".\scriptfolder" -ServiceAccountName DOMAIN\adfsUser
 ```
 
 Description

--- a/docset/winserver2012r2-ps/adfs/Export-AdfsDeploymentSQLScript.md
+++ b/docset/winserver2012r2-ps/adfs/Export-AdfsDeploymentSQLScript.md
@@ -34,7 +34,7 @@ The **Export-AdfsDeploymentSQLScript** cmdlet generates the SQL scripts that you
 
 ### Example 1: Export SQL deployment scripts
 ```
-PS C:\> Export-AdfsDeploymentSQLScript -ScriptDestinationFolder ".\ScriptFolder" -ServiceAccountName "ContosoDomain\AdfsUser"
+PS C:\> Export-AdfsDeploymentSQLScript -DestinationFolder ".\ScriptFolder" -ServiceAccountName "ContosoDomain\AdfsUser"
 ```
 
 This command exports SQL deployment scripts for AD FS installation on behalf of the specified AD FS service account.


### PR DESCRIPTION
Rename of parameter `-ScriptDestinationFolder` to `-DestinationFolder` in example to support copying.

Fix for #176