### PR TITLE
Update get-troubleshootingpack.md

### DIFF
--- a/docset/windows/troubleshootingpack/get-troubleshootingpack.md
+++ b/docset/windows/troubleshootingpack/get-troubleshootingpack.md
@@ -85,7 +85,7 @@ PS C:\> Get-TroubleshootingPack -Path "C:\Windows\Diagnostics\System\Audio" -Ans
 ```
 
 This command uses the **Get-TroubleshootingPack** cmdlet to generate an answer file.
-The Areo troubleshooting pack provides a series of questions for the user to describe the troubleshooting situation and saves that information in the specified XML file.
+The Audio troubleshooting pack provides a series of questions for the user to describe the troubleshooting situation and saves that information in the specified XML file.
 
 ## PARAMETERS
 


### PR DESCRIPTION
5th example uses Audio troubleshooter, but text referred to Aero - fixed.