### PR TITLE
Added missing state value to Get-NetTCPConnection

### DIFF
--- a/docset/windows/nettcpip/get-nettcpconnection.md
+++ b/docset/windows/nettcpip/get-nettcpconnection.md
@@ -231,6 +231,7 @@ Specifies an array of TCP states.
 The cmdlet gets connections that match the states that you specify.
 The acceptable values for this parameter are:
 
+- Bound
 - Closed
 - CloseWait
 - Closing


### PR DESCRIPTION
Currently when using `get-help Get-NetTCPConnection -Detailed` this is the output for the State parameter
```-State [<State[]>]
        Specifies an array of TCP states. The cmdlet gets connections that match the states that you specify. The acceptable values for this
        parameter are:

        -- Closed
        -- CloseWait
        -- Closing
        -- DeleteTCB
        -- Established
        -- FinWait1
        -- FinWait2
        -- LastAck
        -- Listen
        -- SynReceived
        -- SynSent
        -- TimeWait
```

The list is missing the acceptable value `-- Bound`. This pull request fixes that.
