### PR TITLE
Fixed typo obj3ct -> object

### DIFF
--- a/docset/windows/storage/get-physicalextent.md
+++ b/docset/windows/storage/get-physicalextent.md
@@ -73,7 +73,7 @@ Accept wildcard characters: False
 
 ### -PhysicalDisk
 Specifies physical disk.
-To obtain a **PhysicalDisk** obje3t, use the Get-PhysicalDisk cmdlet.
+To obtain a **PhysicalDisk** object, use the Get-PhysicalDisk cmdlet.
 
 ```yaml
 Type: CimInstance


### PR DESCRIPTION
This page is full of bad examples, FYI. Please pay some attention to this page, c.f. #514 