### PR TITLE
Added missing desc; repaired links

### DIFF
--- a/docset/winserver2012r2-ps/storage/Repair-Volume.md
+++ b/docset/winserver2012r2-ps/storage/Repair-Volume.md
@@ -4,7 +4,7 @@ Module Name: Storage
 online version: 
 schema: 2.0.0
 title: Repair-Volume
-description: 
+description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 keywords: powershell, cmdlet
 author: brianlic
 manager: jasgro
@@ -12,6 +12,7 @@ ms.date: 2017-10-29
 ms.topic: reference
 ms.prod: powershell
 ms.technology: powershell
+ms.sitesec: library
 ms.assetid: 41547EC6-C1F1-487F-9BB3-0A08FA80BA70
 ---
 
@@ -101,7 +102,7 @@ This example takes the System Reserved volume offline, and fixes all issues. Thi
 ## PARAMETERS
 
 ### -AsJob
-ps_cimcommon_asjob
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
 
 ```yaml
 Type: SwitchParameter
@@ -117,7 +118,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a New-CimSessionhttp://go.microsoft.com/fwlink/p/?LinkId=227967 or Get-CimSessionhttp://go.microsoft.com/fwlink/p/?LinkId=227966 cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](http://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](http://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -303,7 +304,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -326,4 +327,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Optimize-Volume](./Optimize-Volume.md)
 
 [Set-Volume](./Set-Volume.md)
-


### PR DESCRIPTION
Imported from "windows/storage/repair-volume.md":
- Added the missing description for `-AsJob`
- Added the missing cmdlet description
- Repaired three damaged links