### PR TITLE
typo: â€™ -> '

### DIFF
--- a/docset/winserver2012-ps/internationalcmdlets/Get-WinAcceptLanguageFromLanguageListOptOut.md
+++ b/docset/winserver2012-ps/internationalcmdlets/Get-WinAcceptLanguageFromLanguageListOptOut.md
@@ -18,7 +18,7 @@ Get-WinAcceptLanguageFromLanguageListOptOut [<CommonParameters>]
 
 ## DESCRIPTION
 The **Get-WinAcceptLanguageFromLanguageListOptOut** cmdlet gets the **HTTP Accept Language from Language List opt-out** setting for the current user account.
-By default, the **HTTP Accept Language List** is automatically generated from the current user accountâ€™s language list.
+By default, the **HTTP Accept Language List** is automatically generated from the current user account's language list.
 
 When set to $True, this setting deletes the current content of the HTTP Accept Language registry key and prevents changes to the language list from reestablishing the key.
 When set to $False, this setting reestablishes the **HTTP Accept Language List** that is based on the language list for the current user account.

--- a/docset/winserver2012-ps/internationalcmdlets/Get-WinHomeLocation.md
+++ b/docset/winserver2012-ps/internationalcmdlets/Get-WinHomeLocation.md
@@ -19,7 +19,7 @@ Get-WinHomeLocation [<CommonParameters>]
 ## DESCRIPTION
 The **Get-WinHomeLocation** cmdlet gets the value of the user GeoID setting and returns a .NET GeoID object.
 The Windows GeoID setting is a user setting that describes the home location (that is, the country or region) of the current user account.
-Applications that require the current user accountâ€™s home location, such as a driver for a television tuner application, can use this setting.
+Applications that require the current user account's home location, such as a driver for a television tuner application, can use this setting.
 
 A table of GeoIDs is available at Table of Geographical Locationshttp://go.microsoft.com/fwlink/?LinkID=242308 (http://go.microsoft.com/fwlink/?LinkID=242308).
 

--- a/docset/winserver2012-ps/internationalcmdlets/Get-WinUserLanguageList.md
+++ b/docset/winserver2012-ps/internationalcmdlets/Get-WinUserLanguageList.md
@@ -85,7 +85,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### List<WinUserLanguage>
-A list of WinUserLanguage objects that contain one or more languages and associated properties from the current user accountâ€™s language list.
+A list of WinUserLanguage objects that contain one or more languages and associated properties from the current user account's language list.
 For information about the Generic.List object, see List\<T\> Classhttp://go.microsoft.com/fwlink/?LinkID=243342.
 
 The generic list object supports the following methods:

--- a/docset/winserver2012-ps/internationalcmdlets/New-WinUserLanguageList.md
+++ b/docset/winserver2012-ps/internationalcmdlets/New-WinUserLanguageList.md
@@ -57,7 +57,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### List<WinUserLanguage>
-A list of **WinUserLanguage** objects that contain one or more languages and associated properties from the current user accountâ€™s language list.
+A list of **WinUserLanguage** objects that contain one or more languages and associated properties from the current user account's language list.
 For more information about the *Generic.List* object, see List\<T\> Classhttp://go.microsoft.com/fwlink/?LinkID=243342.
 
 The generic list object supports the following methods:

--- a/docset/winserver2012-ps/internationalcmdlets/Set-WinHomeLocation.md
+++ b/docset/winserver2012-ps/internationalcmdlets/Set-WinHomeLocation.md
@@ -19,7 +19,7 @@ Set-WinHomeLocation [-GeoId] <Int32> [<CommonParameters>]
 ## DESCRIPTION
 The **Set-WinHomeLocation** cmdlet sets the value of the user GeoID object.
 The Windows GeoID setting is a user setting that describes the home location (that is, the country or region) of the current user account.
-Applications that require the current user accountâ€™s home location, such as a driver for a television tuner application, can use this setting.
+Applications that require the current user account's home location, such as a driver for a television tuner application, can use this setting.
 
 A table of GeoIDs is available at Table of Geographical Locationshttp://go.microsoft.com/fwlink/?LinkID=242308.
 

--- a/docset/winserver2012-ps/internationalcmdlets/Set-WinUserLanguageList.md
+++ b/docset/winserver2012-ps/internationalcmdlets/Set-WinUserLanguageList.md
@@ -112,7 +112,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### List<WinUserLanguage>
-*List\<WinUserLanguage\>* is a list of **WinUserLanguage** objects that contain one or more languages and associated properties from the current user accountâ€™s language list. 
+*List\<WinUserLanguage\>* is a list of **WinUserLanguage** objects that contain one or more languages and associated properties from the current user account's language list. 
 The language object contains the following properties:
 
 - BCP-47 (READ). A standard language tag that is used to identify languages. For more information, see the Internet Engineering Task Force (IETF) BCP 47 RFChttp://go.microsoft.com/fwlink/?LinkID=242207. 

--- a/docset/winserver2012-ps/msmq/Set-MsmqQueueACL.md
+++ b/docset/winserver2012-ps/msmq/Set-MsmqQueueACL.md
@@ -119,7 +119,7 @@ The acceptable values for this parameter are:
 - FullControl: Full control of the specified queue. 
 - GetPermissions: Get the permissions of the specified queue. 
 - GetProperties: Get the properties of the specified queue. 
-- JournalReceive: Receive a message from the specified queueâ€™s journal queue. 
+- JournalReceive: Receive a message from the specified queue's journal queue. 
 - Peek: Peek a message from the specified queue. 
 - Receive: Receive a message from the specified queue. 
 - Send: Send a message to the specified queue. 

--- a/docset/winserver2012-ps/msmq/Set-MsmqQueueManagerACL.md
+++ b/docset/winserver2012-ps/msmq/Set-MsmqQueueManagerACL.md
@@ -47,10 +47,10 @@ The acceptable values for this parameter are:
 - GetPermissions: Get the permissions of the specified queue manager. 
 - GetProperties: Get the properties of the specified queue manager. 
 ListContent: List content stored in the queues of the specified queue manager. 
-- PeekDeadLetter: Peek a message from the specified queue managerâ€™s system dead letter queue and transactional dead letter queue. 
-- PeekJournal: Peek a message from the specified queue managerâ€™s system journal queue. 
+- PeekDeadLetter: Peek a message from the specified queue manager's system dead letter queue and transactional dead letter queue. 
+- PeekJournal: Peek a message from the specified queue manager's system journal queue. 
 - ReceiveDeadLetter: Receive a message from the specified queue manager's system dead letter queue and transactional dead letter queue. 
-- ReceiveJournal: Receive a message from the specified queue managerâ€™s system journal queue. 
+- ReceiveJournal: Receive a message from the specified queue manager's system journal queue. 
 - SetPermissions: Set the permissions of the specified queue manager. 
 - SetProperties: Set the properties of the specified queue manager. 
 - TakeOwnership: Assign a queue of the specified queue manager to the specified user.
@@ -81,9 +81,9 @@ The acceptable values for this parameter are:
 - GetPermissions: Get the permissions of the specified queue manager. 
 - GetProperties: Get the properties of the specified queue manager. 
 - ListContent: List content stored in the queues of the specified queue manager. 
-- PeekDeadLetter: Peek a message from the specified queue managerâ€™s system dead letter queue and transactional dead letter queue. 
-- PeekJournal: Peek a message from the specified queue managerâ€™s system journal queue. 
-- ReceiveDeadLetter: Receive a message from the specified queue managerâ€™s system dead letter queue and transactional dead letter queue. 
+- PeekDeadLetter: Peek a message from the specified queue manager's system dead letter queue and transactional dead letter queue. 
+- PeekJournal: Peek a message from the specified queue manager's system journal queue. 
+- ReceiveDeadLetter: Receive a message from the specified queue manager's system dead letter queue and transactional dead letter queue. 
 - ReceiveJournal: Receive a message from the specified queue manager's system journal queue. 
 - SetPermissions: Set the permissions of the specified queue manager. 
 - SetProperties: Set the properties of the specified queue manager. 


### PR DESCRIPTION

Likely an old smartquote encoding issue from UTF 8 conversion