### PR TITLE
typo: install-adcscertificationauthority -> Install-AdcsCertificationAuthority

### DIFF
--- a/docset/winserver2012-ps/adcsdeployment/install-adcscertificationauthority.md
+++ b/docset/winserver2012-ps/adcsdeployment/install-adcscertificationauthority.md
@@ -508,7 +508,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 * Ensure you run Windows PowerShell as an administrator. You can use the -f switch to bypass the prompt for confirmation.
-To see parameters, run the following command: install-adcscertificationauthority -?
+To see parameters, run the following command: Install-AdcsCertificationAuthority -?
 If you have installation issues, try using the -verbose switch to get verbose output and review the information in the %windir%\cerocm.log.
 
 ## RELATED LINKS

--- a/docset/winserver2012r2-ps/adcsdeployment/install-adcscertificationauthority.md
+++ b/docset/winserver2012r2-ps/adcsdeployment/install-adcscertificationauthority.md
@@ -520,7 +520,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 * Ensure you run Windows PowerShell as an administrator. You can use the -f switch to bypass the prompt for confirmation.
-To see parameters, run the following command: install-adcscertificationauthority -?
+To see parameters, run the following command: Install-AdcsCertificationAuthority -?
 If you have installation issues, try using the -verbose switch to get verbose output and review the information in the %windir%\cerocm.log.
 
 ## RELATED LINKS


### PR DESCRIPTION
This lines might just be removed since they point to using the built-in help. You can see the other cmdlets using this pattern by searching "To see parameters, run the following command"