### PR TITLE
Fixed KeyProtectorId parameter specs and example

### DIFF
--- a/docset/windows/bitlocker/remove-bitlockerkeyprotector.md
+++ b/docset/windows/bitlocker/remove-bitlockerkeyprotector.md
@@ -48,7 +48,7 @@ For an overview of BitLocker, see [BitLocker Drive Encryption Overview](http://t
 ### Example 1: Remove a key protector for a volume
 ```
 PS C:\> $BLV = Get-BitLockerVolume -MountPoint "C:"
-PS C:\> Remove-BitlockerKeyProtector -MountPoint "C:" -KeyProtectorId $BLV.KeyProtector[1]
+PS C:\> Remove-BitlockerKeyProtector -MountPoint "C:" -KeyProtectorId $BLV.KeyProtector[1].KeyProtectorId
 ```
 
 This example removes a key protector for a specified BitLocker volume.
@@ -76,9 +76,9 @@ Accept wildcard characters: False
 ```
 
 ### -KeyProtectorId
-Specifies the ID for a key protector or a **KeyProtector** object.
+Specifies the ID for a key protector.
 A BitLocker volume object includes a **KeyProtector** object.
-You can specify the key protector object itself, or you can specify the ID.
+You have to specify the key protector ID.
 See the Examples section.
 To obtain a BitLocker volume object, use the **Get-BitLockerVolume** cmdlet.
 


### PR DESCRIPTION
It seems that only the ID can be passed as *KeyProtectorId* parameter - and not the key protector object itself.
I've just tested this on Windows 10 Pro 1809 and was unable to pass a *KeyProtector* object as parameter.