### PR TITLE
fix: None or object return headers

### DIFF
--- a/docset/windows/hyper-v/add-vmfibrechannelhba.md
+++ b/docset/windows/hyper-v/add-vmfibrechannelhba.md
@@ -294,8 +294,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/add-vmharddiskdrive.md
+++ b/docset/windows/hyper-v/add-vmharddiskdrive.md
@@ -446,8 +446,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.HardDiskDrive** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.HardDiskDrive
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/add-vmmigrationnetwork.md
+++ b/docset/windows/hyper-v/add-vmmigrationnetwork.md
@@ -200,8 +200,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.MigrationNetwork** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.MigrationNetwork
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/add-vmnetworkadapteracl.md
+++ b/docset/windows/hyper-v/add-vmnetworkadapteracl.md
@@ -389,8 +389,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMNetworkAdapterAclSetting** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMNetworkAdapterAclSetting
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/add-vmremotefx3dvideoadapter.md
+++ b/docset/windows/hyper-v/add-vmremotefx3dvideoadapter.md
@@ -191,8 +191,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.RemoteFxVideoAdapter** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.RemoteFxVideoAdapter
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/add-vmscsicontroller.md
+++ b/docset/windows/hyper-v/add-vmscsicontroller.md
@@ -184,8 +184,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.ScsiController** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.ScsiController
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/add-vmstoragepath.md
+++ b/docset/windows/hyper-v/add-vmstoragepath.md
@@ -196,8 +196,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **System.String** if *PassThru* is specified.
+### None
+Default
+
+### System.String
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/add-vmswitchextensionportfeature.md
+++ b/docset/windows/hyper-v/add-vmswitchextensionportfeature.md
@@ -308,8 +308,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMSwitchExtensionPortFeature** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSwitchExtensionPortFeature
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/add-vmswitchextensionswitchfeature.md
+++ b/docset/windows/hyper-v/add-vmswitchextensionswitchfeature.md
@@ -203,8 +203,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMSwitchExtensionSwitchFeature** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSwitchExtensionSwitchFeature
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/complete-vmfailover.md
+++ b/docset/windows/hyper-v/complete-vmfailover.md
@@ -195,8 +195,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/connect-vmnetworkadapter.md
+++ b/docset/windows/hyper-v/connect-vmnetworkadapter.md
@@ -285,8 +285,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMNetworkAdapter** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMNetworkAdapter
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/connect-vmsan.md
+++ b/docset/windows/hyper-v/connect-vmsan.md
@@ -216,8 +216,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.Powershell.VMSan** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.Powershell.VMSan
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/disable-vmintegrationservice.md
+++ b/docset/windows/hyper-v/disable-vmintegrationservice.md
@@ -221,8 +221,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.IntegrationService** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.IntegrationService
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/disable-vmremotefxphysicalvideoadapter.md
+++ b/docset/windows/hyper-v/disable-vmremotefxphysicalvideoadapter.md
@@ -197,8 +197,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMRemoteFXPhysicalVideoAdapter** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMRemoteFXPhysicalVideoAdapter
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/disconnect-vmnetworkadapter.md
+++ b/docset/windows/hyper-v/disconnect-vmnetworkadapter.md
@@ -208,8 +208,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMNetworkAdapter** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMNetworkAdapter
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/disconnect-vmsan.md
+++ b/docset/windows/hyper-v/disconnect-vmsan.md
@@ -216,8 +216,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMSan** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSan
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/enable-vmintegrationservice.md
+++ b/docset/windows/hyper-v/enable-vmintegrationservice.md
@@ -236,8 +236,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.IntegrationService** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.IntegrationService
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/enable-vmmigration.md
+++ b/docset/windows/hyper-v/enable-vmmigration.md
@@ -154,8 +154,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.Host** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.Host
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/export-vm.md
+++ b/docset/windows/hyper-v/export-vm.md
@@ -251,8 +251,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/export-vmsnapshot.md
+++ b/docset/windows/hyper-v/export-vmsnapshot.md
@@ -267,8 +267,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.Snapshot** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.Snapshot
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/grant-vmconnectaccess.md
+++ b/docset/windows/hyper-v/grant-vmconnectaccess.md
@@ -203,8 +203,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMConnectAce** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMConnectAce
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/import-vminitialreplication.md
+++ b/docset/windows/hyper-v/import-vminitialreplication.md
@@ -246,8 +246,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vm.md
+++ b/docset/windows/hyper-v/remove-vm.md
@@ -232,8 +232,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmdvddrive.md
+++ b/docset/windows/hyper-v/remove-vmdvddrive.md
@@ -224,8 +224,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.DriveController** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.DriveController
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmfibrechannelhba.md
+++ b/docset/windows/hyper-v/remove-vmfibrechannelhba.md
@@ -246,8 +246,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMFibreChannelHba** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMFibreChannelHba
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmharddiskdrive.md
+++ b/docset/windows/hyper-v/remove-vmharddiskdrive.md
@@ -242,8 +242,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.DriveController** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.DriveController
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmmigrationnetwork.md
+++ b/docset/windows/hyper-v/remove-vmmigrationnetwork.md
@@ -170,8 +170,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.MigrationNetwork** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.MigrationNetwork
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmremotefx3dvideoadapter.md
+++ b/docset/windows/hyper-v/remove-vmremotefx3dvideoadapter.md
@@ -205,8 +205,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMRemoteFxVideoAdapter** if *PassThru* is specified.
+### None
+Default
+
+### VMRemoteFxVideoAdapter
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmreplication.md
+++ b/docset/windows/hyper-v/remove-vmreplication.md
@@ -232,8 +232,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMReplication** if *PassThru* is specified.
+### None
+Default
+
+### VMReplication
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmreplicationauthorizationentry.md
+++ b/docset/windows/hyper-v/remove-vmreplicationauthorizationentry.md
@@ -215,8 +215,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMReplicationAuthorizationEntry** if *PassThru* is specified.
+### None
+Default
+
+### VMReplicationAuthorizationEntry
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmresourcepool.md
+++ b/docset/windows/hyper-v/remove-vmresourcepool.md
@@ -186,8 +186,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMResourcePool** if *PassThru* is specified.
+### None
+Default
+
+### VMResourcePool
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmsan.md
+++ b/docset/windows/hyper-v/remove-vmsan.md
@@ -163,8 +163,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.Powershell.VMSan** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.Powershell.VMSan
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmsnapshot.md
+++ b/docset/windows/hyper-v/remove-vmsnapshot.md
@@ -274,8 +274,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmstoragepath.md
+++ b/docset/windows/hyper-v/remove-vmstoragepath.md
@@ -165,8 +165,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **System.String** if *PassThru* is specified.
+### None
+Default
+
+### System.String
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmswitchextensionportfeature.md
+++ b/docset/windows/hyper-v/remove-vmswitchextensionportfeature.md
@@ -273,8 +273,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMSwitchExtensionPortFeature** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSwitchExtensionPortFeature
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/remove-vmswitchextensionswitchfeature.md
+++ b/docset/windows/hyper-v/remove-vmswitchextensionswitchfeature.md
@@ -196,8 +196,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMSwitchExtensionSwitchFeature** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSwitchExtensionSwitchFeature
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/rename-vm.md
+++ b/docset/windows/hyper-v/rename-vm.md
@@ -206,8 +206,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/rename-vmresourcepool.md
+++ b/docset/windows/hyper-v/rename-vmresourcepool.md
@@ -195,8 +195,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMResourcePool** if *PassThru* is specified.
+### None
+Default
+
+### VMResourcePool
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/rename-vmsan.md
+++ b/docset/windows/hyper-v/rename-vmsan.md
@@ -178,8 +178,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMSan** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSan
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/rename-vmsnapshot.md
+++ b/docset/windows/hyper-v/rename-vmsnapshot.md
@@ -239,8 +239,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMSnapshot** if *PassThru* is specified.
+### None
+Default
+
+### VMSnapshot
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/rename-vmswitch.md
+++ b/docset/windows/hyper-v/rename-vmswitch.md
@@ -200,8 +200,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.EthernetSwitch** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.EthernetSwitch
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/repair-vm.md
+++ b/docset/windows/hyper-v/repair-vm.md
@@ -153,8 +153,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.CompatibilityReport** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.CompatibilityReport
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/reset-vmreplicationstatistics.md
+++ b/docset/windows/hyper-v/reset-vmreplicationstatistics.md
@@ -234,8 +234,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMReplication** if *PassThru* is specified.
+### None
+Default
+
+### VMReplication
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/restore-vmsnapshot.md
+++ b/docset/windows/hyper-v/restore-vmsnapshot.md
@@ -252,8 +252,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMSnapshot** if *PassThru* is specified.
+### None
+Default
+
+### VMSnapshot
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/resume-vm.md
+++ b/docset/windows/hyper-v/resume-vm.md
@@ -201,8 +201,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.Powershell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/resume-vmreplication.md
+++ b/docset/windows/hyper-v/resume-vmreplication.md
@@ -314,8 +314,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMReplication** if *PassThru* is specified.
+### None
+Default
+
+### VMReplication
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/revoke-vmconnectaccess.md
+++ b/docset/windows/hyper-v/revoke-vmconnectaccess.md
@@ -202,8 +202,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMConnectAce** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMConnectAce
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vm.md
+++ b/docset/windows/hyper-v/set-vm.md
@@ -562,8 +562,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmbios.md
+++ b/docset/windows/hyper-v/set-vmbios.md
@@ -267,8 +267,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.Bios** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.Bios
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmcomport.md
+++ b/docset/windows/hyper-v/set-vmcomport.md
@@ -255,8 +255,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.ComPort** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.ComPort
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmdvddrive.md
+++ b/docset/windows/hyper-v/set-vmdvddrive.md
@@ -311,8 +311,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.DvdDrive** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.DvdDrive
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmhost.md
+++ b/docset/windows/hyper-v/set-vmhost.md
@@ -462,8 +462,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMHost** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMHost
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmmemory.md
+++ b/docset/windows/hyper-v/set-vmmemory.md
@@ -334,8 +334,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.Memory** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.Memory
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmmigrationnetwork.md
+++ b/docset/windows/hyper-v/set-vmmigrationnetwork.md
@@ -216,8 +216,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.MigrationNetwork** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.MigrationNetwork
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmnetworkadapterfailoverconfiguration.md
+++ b/docset/windows/hyper-v/set-vmnetworkadapterfailoverconfiguration.md
@@ -441,8 +441,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMNetworkAdapterFailoverConfiguration** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMNetworkAdapterFailoverConfiguration
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmnetworkadaptervlan.md
+++ b/docset/windows/hyper-v/set-vmnetworkadaptervlan.md
@@ -479,8 +479,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMNetworkAdapterVlanSetting** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMNetworkAdapterVlanSetting
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmprocessor.md
+++ b/docset/windows/hyper-v/set-vmprocessor.md
@@ -425,8 +425,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMProcessor** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMProcessor
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmreplication.md
+++ b/docset/windows/hyper-v/set-vmreplication.md
@@ -653,8 +653,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMReplication** if *PassThru* is specified.
+### None
+Default
+
+### VMReplication
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmreplicationauthorizationentry.md
+++ b/docset/windows/hyper-v/set-vmreplicationauthorizationentry.md
@@ -229,8 +229,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMReplicationAuthorizationEntry** if *PassThru* is specified.
+### None
+Default
+
+### VMReplicationAuthorizationEntry
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmreplicationserver.md
+++ b/docset/windows/hyper-v/set-vmreplicationserver.md
@@ -401,8 +401,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMRecoveryServer** if *PassThru* is specified.
+### None
+Default
+
+### VMRecoveryServer
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmresourcepool.md
+++ b/docset/windows/hyper-v/set-vmresourcepool.md
@@ -203,8 +203,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMResourcePool** if *PassThru* is specified.
+### None
+Default
+
+### VMResourcePool
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmsan.md
+++ b/docset/windows/hyper-v/set-vmsan.md
@@ -232,8 +232,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.SAN** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.SAN
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmswitch.md
+++ b/docset/windows/hyper-v/set-vmswitch.md
@@ -441,8 +441,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.EthernetSwitch** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.EthernetSwitch
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmswitchextensionportfeature.md
+++ b/docset/windows/hyper-v/set-vmswitchextensionportfeature.md
@@ -274,8 +274,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMSwitchExtensionPortFeature** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSwitchExtensionPortFeature
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/set-vmswitchextensionswitchfeature.md
+++ b/docset/windows/hyper-v/set-vmswitchextensionswitchfeature.md
@@ -197,8 +197,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VMSwitchExtensionSwitchFeature** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSwitchExtensionSwitchFeature
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/start-vm.md
+++ b/docset/windows/hyper-v/start-vm.md
@@ -206,8 +206,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/start-vmfailover.md
+++ b/docset/windows/hyper-v/start-vmfailover.md
@@ -310,8 +310,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/start-vminitialreplication.md
+++ b/docset/windows/hyper-v/start-vminitialreplication.md
@@ -313,8 +313,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/stop-vm.md
+++ b/docset/windows/hyper-v/stop-vm.md
@@ -264,8 +264,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/stop-vmfailover.md
+++ b/docset/windows/hyper-v/stop-vmfailover.md
@@ -209,8 +209,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/stop-vminitialreplication.md
+++ b/docset/windows/hyper-v/stop-vminitialreplication.md
@@ -216,8 +216,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/stop-vmreplication.md
+++ b/docset/windows/hyper-v/stop-vmreplication.md
@@ -226,8 +226,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/suspend-vm.md
+++ b/docset/windows/hyper-v/suspend-vm.md
@@ -207,8 +207,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **Microsoft.HyperV.PowerShell.VirtualMachine** if *PassThru* is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/windows/hyper-v/suspend-vmreplication.md
+++ b/docset/windows/hyper-v/suspend-vmreplication.md
@@ -232,8 +232,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-###  
-None by default; **VMReplication** if *PassThru* is specified.
+### None
+Default
+
+### VMReplication
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Add-VMFibreChannelHba.md
+++ b/docset/winserver2012-ps/hyper-v/Add-VMFibreChannelHba.md
@@ -245,8 +245,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Add-VMHardDiskDrive.md
+++ b/docset/winserver2012-ps/hyper-v/Add-VMHardDiskDrive.md
@@ -304,8 +304,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.HardDiskDrive** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.HardDiskDrive
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Add-VMMigrationNetwork.md
+++ b/docset/winserver2012-ps/hyper-v/Add-VMMigrationNetwork.md
@@ -152,8 +152,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.MigrationNetwork** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.MigrationNetwork
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Add-VMNetworkAdapterAcl.md
+++ b/docset/winserver2012-ps/hyper-v/Add-VMNetworkAdapterAcl.md
@@ -335,8 +335,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VMNetworkAdapterAclSetting** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VMNetworkAdapterAclSetting
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Add-VMRemoteFx3dVideoAdapter.md
+++ b/docset/winserver2012-ps/hyper-v/Add-VMRemoteFx3dVideoAdapter.md
@@ -111,8 +111,11 @@ Accept wildcard characters: True
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.RemoteFxVideoAdapter** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.RemoteFxVideoAdapter
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Add-VMScsiController.md
+++ b/docset/winserver2012-ps/hyper-v/Add-VMScsiController.md
@@ -104,8 +104,11 @@ Accept wildcard characters: True
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.ScsiController** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.ScsiController
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Add-VMStoragePath.md
+++ b/docset/winserver2012-ps/hyper-v/Add-VMStoragePath.md
@@ -115,8 +115,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **System.String** if **-PassThru** is specified.
+### None
+Default
+
+### System.String
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Add-VMSwitchExtensionPortFeature.md
+++ b/docset/winserver2012-ps/hyper-v/Add-VMSwitchExtensionPortFeature.md
@@ -253,8 +253,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.HyperV.PowerShell.VMSwitchExtensionPortFeature** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSwitchExtensionPortFeature
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Add-VMSwitchExtensionSwitchFeature.md
+++ b/docset/winserver2012-ps/hyper-v/Add-VMSwitchExtensionSwitchFeature.md
@@ -123,8 +123,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.HyperV.PowerShell.VMSwitchExtensionSwitchFeature** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSwitchExtensionSwitchFeature
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Complete-VMFailover.md
+++ b/docset/winserver2012-ps/hyper-v/Complete-VMFailover.md
@@ -145,8 +145,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Connect-VMNetworkAdapter.md
+++ b/docset/winserver2012-ps/hyper-v/Connect-VMNetworkAdapter.md
@@ -235,8 +235,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VMNetworkAdapter** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VMNetworkAdapter
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Connect-VMSan.md
+++ b/docset/winserver2012-ps/hyper-v/Connect-VMSan.md
@@ -166,8 +166,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.SAN** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.SAN
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Disable-VMIntegrationService.md
+++ b/docset/winserver2012-ps/hyper-v/Disable-VMIntegrationService.md
@@ -172,8 +172,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.PowerShell.IntegrationService** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.PowerShell.IntegrationService
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Disable-VMRemoteFXPhysicalVideoAdapter.md
+++ b/docset/winserver2012-ps/hyper-v/Disable-VMRemoteFXPhysicalVideoAdapter.md
@@ -115,8 +115,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.HyperV.PowerShell.VMRemoteFXPhysicalVideoAdapter** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMRemoteFXPhysicalVideoAdapter
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Disconnect-VMNetworkAdapter.md
+++ b/docset/winserver2012-ps/hyper-v/Disconnect-VMNetworkAdapter.md
@@ -126,8 +126,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VMNetworkAdapter** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VMNetworkAdapter
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Disconnect-VMSan.md
+++ b/docset/winserver2012-ps/hyper-v/Disconnect-VMSan.md
@@ -135,8 +135,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMSan** if **-PassThru** is specified.
+### None
+Default
+
+### VMSan
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Enable-VMIntegrationService.md
+++ b/docset/winserver2012-ps/hyper-v/Enable-VMIntegrationService.md
@@ -185,8 +185,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.PowerShell.IntegrationService** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.PowerShell.IntegrationService
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Enable-VMMigration.md
+++ b/docset/winserver2012-ps/hyper-v/Enable-VMMigration.md
@@ -66,8 +66,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.Host** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.Host
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Export-VM.md
+++ b/docset/winserver2012-ps/hyper-v/Export-VM.md
@@ -145,8 +145,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Export-VMSnapshot.md
+++ b/docset/winserver2012-ps/hyper-v/Export-VMSnapshot.md
@@ -214,8 +214,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.Snapshot** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.Snapshot
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Grant-VMConnectAccess.md
+++ b/docset/winserver2012-ps/hyper-v/Grant-VMConnectAccess.md
@@ -138,8 +138,11 @@ Accept wildcard characters: True
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VMConnectAce** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VMConnectAce
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Import-VMInitialReplication.md
+++ b/docset/winserver2012-ps/hyper-v/Import-VMInitialReplication.md
@@ -163,8 +163,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VM.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VM.md
@@ -183,8 +183,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMDvdDrive.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMDvdDrive.md
@@ -144,8 +144,11 @@ Accept wildcard characters: True
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.DriveController** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.DriveController
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMFibreChannelHba.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMFibreChannelHba.md
@@ -198,8 +198,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VMFibreChannelHba** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VMFibreChannelHba
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMHardDiskDrive.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMHardDiskDrive.md
@@ -191,8 +191,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.DriveController** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.DriveController
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMMigrationNetwork.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMMigrationNetwork.md
@@ -121,8 +121,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.MigrationNetwork** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.MigrationNetwork
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMRemoteFx3dVideoAdapter.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMRemoteFx3dVideoAdapter.md
@@ -124,8 +124,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMRemoteFxVideoAdapter** if **-PassThru** is specified.
+### None
+Default
+
+### VMRemoteFxVideoAdapter
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMReplication.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMReplication.md
@@ -133,8 +133,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMReplication** if **-PassThru** is specified.
+### None
+Default
+
+### VMReplication
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMReplicationAuthorizationEntry.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMReplicationAuthorizationEntry.md
@@ -166,8 +166,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMReplicationAuthorizationEntry** if **-PassThru** is specified.
+### None
+Default
+
+### VMReplicationAuthorizationEntry
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMResourcePool.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMResourcePool.md
@@ -130,8 +130,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMResourcePool** if **-PassThru** is specified.
+### None
+Default
+
+### VMResourcePool
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMSan.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMSan.md
@@ -83,8 +83,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.SAN** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.SAN
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMScsiController.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMScsiController.md
@@ -151,8 +151,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMScsiController** if **-PassThru** is specified.
+### None
+Default
+
+### VMScsiController
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMSnapshot.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMSnapshot.md
@@ -190,8 +190,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMStoragePath.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMStoragePath.md
@@ -115,8 +115,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **System.String** if **-PassThru** is specified.
+### None
+Default
+
+### System.String
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMSwitchExtensionPortFeature.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMSwitchExtensionPortFeature.md
@@ -249,8 +249,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.HyperV.PowerShell.VMSwitchExtensionPortFeature** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSwitchExtensionPortFeature
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Remove-VMSwitchExtensionSwitchFeature.md
+++ b/docset/winserver2012-ps/hyper-v/Remove-VMSwitchExtensionSwitchFeature.md
@@ -154,8 +154,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.HyperV.PowerShell.VMSwitchExtensionSwitchFeature** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSwitchExtensionSwitchFeature
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Rename-VM.md
+++ b/docset/winserver2012-ps/hyper-v/Rename-VM.md
@@ -126,8 +126,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Rename-VMResourcePool.md
+++ b/docset/winserver2012-ps/hyper-v/Rename-VMResourcePool.md
@@ -145,8 +145,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMResourcePool** if **-PassThru** is specified.
+### None
+Default
+
+### VMResourcePool
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Rename-VMSan.md
+++ b/docset/winserver2012-ps/hyper-v/Rename-VMSan.md
@@ -98,8 +98,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.PowerShell.SAN** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.PowerShell.SAN
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Rename-VMSnapshot.md
+++ b/docset/winserver2012-ps/hyper-v/Rename-VMSnapshot.md
@@ -155,8 +155,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMSnapshot** if **-PassThru** is specified.
+### None
+Default
+
+### VMSnapshot
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Rename-VMSwitch.md
+++ b/docset/winserver2012-ps/hyper-v/Rename-VMSwitch.md
@@ -119,8 +119,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.EthernetSwitch** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.EthernetSwitch
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Repair-VM.md
+++ b/docset/winserver2012-ps/hyper-v/Repair-VM.md
@@ -150,8 +150,11 @@ Accept wildcard characters: False
 
 ## INPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.CompatibilityReport** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.CompatibilityReport
+If **-PassThru** is specified.
 
 ## OUTPUTS
 

--- a/docset/winserver2012-ps/hyper-v/Reset-VMReplicationStatistics.md
+++ b/docset/winserver2012-ps/hyper-v/Reset-VMReplicationStatistics.md
@@ -133,8 +133,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMReplication** if **-PassThru** is specified.
+### None
+Default
+
+### VMReplication
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Restore-VMSnapshot.md
+++ b/docset/winserver2012-ps/hyper-v/Restore-VMSnapshot.md
@@ -164,8 +164,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMSnapshot** if **-PassThru** is specified.
+### None
+Default
+
+### VMSnapshot
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Resume-VM.md
+++ b/docset/winserver2012-ps/hyper-v/Resume-VM.md
@@ -117,8 +117,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.HyperV.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.HyperV.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Resume-VMReplication.md
+++ b/docset/winserver2012-ps/hyper-v/Resume-VMReplication.md
@@ -198,8 +198,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMReplication** if **-PassThru** is specified.
+### None
+Default
+
+### VMReplication
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Revoke-VMConnectAccess.md
+++ b/docset/winserver2012-ps/hyper-v/Revoke-VMConnectAccess.md
@@ -135,8 +135,11 @@ Accept wildcard characters: True
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VMConnectAce** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VMConnectAce
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VM.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VM.md
@@ -366,8 +366,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMBios.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMBios.md
@@ -209,8 +209,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.Bios** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.Bios
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMComPort.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMComPort.md
@@ -187,8 +187,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.ComPort** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.ComPort
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMDvdDrive.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMDvdDrive.md
@@ -230,8 +230,11 @@ Accept wildcard characters: True
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.DvdDrive** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.DvdDrive
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMHost.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMHost.md
@@ -360,8 +360,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.Host** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.Host
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMMemory.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMMemory.md
@@ -252,8 +252,11 @@ Accept wildcard characters: True
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.Memory** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.Memory
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMMigrationNetwork.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMMigrationNetwork.md
@@ -161,8 +161,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.MigrationNetwork** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.MigrationNetwork
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMNetworkAdapterFailoverConfiguration.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMNetworkAdapterFailoverConfiguration.md
@@ -392,8 +392,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VMNetworkAdapterFailoverConfiguration** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VMNetworkAdapterFailoverConfiguration
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMNetworkAdapterVlan.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMNetworkAdapterVlan.md
@@ -429,8 +429,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VMNetworkAdapterVlanSetting** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VMNetworkAdapterVlanSetting
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMProcessor.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMProcessor.md
@@ -285,8 +285,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VMNetworkAdapterVlanSetting** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VMNetworkAdapterVlanSetting
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMReplication.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMReplication.md
@@ -546,8 +546,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMReplication** if **-PassThru** is specified.
+### None
+Default
+
+### VMReplication
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMReplicationAuthorizationEntry.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMReplicationAuthorizationEntry.md
@@ -148,8 +148,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMReplicationAuthorizationEntry** if **-PassThru** is specified.
+### None
+Default
+
+### VMReplicationAuthorizationEntry
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMReplicationServer.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMReplicationServer.md
@@ -351,8 +351,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMRecoveryServer** if **-PassThru** is specified.
+### None
+Default
+
+### VMRecoveryServer
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMResourcePool.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMResourcePool.md
@@ -153,8 +153,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMResourcePool** if **-PassThru** is specified.
+### None
+Default
+
+### VMResourcePool
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMSan.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMSan.md
@@ -150,8 +150,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.PowerShell.SAN** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.PowerShell.SAN
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMSwitch.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMSwitch.md
@@ -316,8 +316,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.EthernetSwitch** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.EthernetSwitch
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMSwitchExtensionPortFeature.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMSwitchExtensionPortFeature.md
@@ -250,8 +250,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.HyperV.PowerShell.VMSwitchExtensionPortFeature** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSwitchExtensionPortFeature
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Set-VMSwitchExtensionSwitchFeature.md
+++ b/docset/winserver2012-ps/hyper-v/Set-VMSwitchExtensionSwitchFeature.md
@@ -124,8 +124,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.HyperV.PowerShell.VMSwitchExtensionSwitchFeature** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.HyperV.PowerShell.VMSwitchExtensionSwitchFeature
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Start-VM.md
+++ b/docset/winserver2012-ps/hyper-v/Start-VM.md
@@ -126,8 +126,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Start-VMFailover.md
+++ b/docset/winserver2012-ps/hyper-v/Start-VMFailover.md
@@ -258,8 +258,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Start-VMInitialReplication.md
+++ b/docset/winserver2012-ps/hyper-v/Start-VMInitialReplication.md
@@ -249,8 +249,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Stop-VM.md
+++ b/docset/winserver2012-ps/hyper-v/Stop-VM.md
@@ -215,8 +215,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Stop-VMFailover.md
+++ b/docset/winserver2012-ps/hyper-v/Stop-VMFailover.md
@@ -129,8 +129,11 @@ Accept wildcard characters: True
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Stop-VMInitialReplication.md
+++ b/docset/winserver2012-ps/hyper-v/Stop-VMInitialReplication.md
@@ -165,8 +165,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Stop-VMReplication.md
+++ b/docset/winserver2012-ps/hyper-v/Stop-VMReplication.md
@@ -155,8 +155,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Suspend-VM.md
+++ b/docset/winserver2012-ps/hyper-v/Suspend-VM.md
@@ -158,8 +158,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **Microsoft.Virtualization.Powershell.VirtualMachine** if **-PassThru** is specified.
+### None
+Default
+
+### Microsoft.Virtualization.Powershell.VirtualMachine
+If **-PassThru** is specified.
 
 ## NOTES
 

--- a/docset/winserver2012-ps/hyper-v/Suspend-VMReplication.md
+++ b/docset/winserver2012-ps/hyper-v/Suspend-VMReplication.md
@@ -164,8 +164,11 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### 
-None by default; **VMReplication** if **-PassThru** is specified.
+### None
+Default
+
+### VMReplication
+If **-PassThru** is specified.
 
 ## NOTES
 


### PR DESCRIPTION

Find: \#\#\#
None by default; \*\*(\w*)\*\* if \*\*\-PassThru\*\* is specified\.
Replace: ### None\nDefault\n\n### $1\nIf **-PassThru** is specified.