### PR TITLE
fix: winserver2012r2-ps\hpc\New-HpcSoftCard.md

### DIFF
--- a/docset/winserver2012r2-ps/hpc/New-HpcSoftCard.md
+++ b/docset/winserver2012r2-ps/hpc/New-HpcSoftCard.md
@@ -1,3 +1,4 @@
+---
 author: kenwith
 ms.author: kenwith
 description:


### PR DESCRIPTION

Start of frontmatter is missing