### PR TITLE
Update remove-appxpackage.md

### DIFF
--- a/docset/windows/appx/remove-appxpackage.md
+++ b/docset/windows/appx/remove-appxpackage.md
@@ -124,6 +124,15 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+> [!NOTE] -user parameter requires sid information
+See [whoami syntax](./windows-commands/whoami.md)
+
+```
+whoami /user
+whoami /groups
+```
+
+
 ### -Confirm
 Prompts you for confirmation before running the cmdlet.
 

--- a/docset/windows/appx/remove-appxpackage.md
+++ b/docset/windows/appx/remove-appxpackage.md
@@ -112,6 +112,14 @@ If you specify this parameter, the cmdlet removes the app package for only the u
 - user_name
 - SID-string
 
+> [!NOTE] -user parameter requires sid information
+See [whoami syntax](https://docs.microsoft.com/windows-server/administration/windows-commands/whoami)
+
+```
+whoami /user
+whoami /groups
+```
+
 ```yaml
 Type: String
 Parameter Sets: UserSet
@@ -123,15 +131,6 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-
-> [!NOTE] -user parameter requires sid information
-See [whoami syntax](./windows-commands/whoami.md)
-
-```
-whoami /user
-whoami /groups
-```
-
 
 ### -Confirm
 Prompts you for confirmation before running the cmdlet.

--- a/docset/windows/appx/remove-appxpackage.md
+++ b/docset/windows/appx/remove-appxpackage.md
@@ -106,14 +106,12 @@ Accept wildcard characters: False
 ```
 
 ### -User
-If you specify this parameter, the cmdlet removes the app package for only the user that this cmdlet specifies. To remove a package for a user profile other than the profile of the current user, you must run this command by using administrator permissions. The user name can be in one of these formats:
-- domain\user_name
-- user_name@fqn.domain.tld
-- user_name
+If you specify this parameter, the cmdlet removes the app package for only the user that this cmdlet specifies. To remove a package for a user profile other than the profile of the current user, you must run this command by using administrator permissions. 
 - SID-string
 
-> [!NOTE] -user parameter requires sid information
-See [whoami syntax](https://docs.microsoft.com/windows-server/administration/windows-commands/whoami)
+> [!NOTE]
+- User "parameter of the "Remove-AppxPackage" command only accepts SID 
+- Use **whoami** command to display the current SID of a user, see [whoami syntax](https://docs.microsoft.com/windows-server/administration/windows-commands/whoami)
 
 ```
 whoami /user


### PR DESCRIPTION
#374 
**Action Taken** 
-added Noted
To find SID of a user, run
whoami /user
whoami / groups

URL: https://github.com/MicrosoftDocs/windowsserverdocs/blob/master/WindowsServerDocs/administration/windows-commands/whoami.md

**TS:**
Run the command: Remove-AppxPackage -Package pakage -user user 
same error, see screenshot: https://snag.gy/d6rZCF.jpg

Look for SID String for my own machine whoami / user
Shows up SID string, see screenshot: https://snag.gy/9JsAve.jpg

Remove-AppxPackage -Package package -user Sid - successfully worked