### PR TITLE
Update set-clusterlog.md

### DIFF
--- a/docset/windows/failoverclusters/set-clusterlog.md
+++ b/docset/windows/failoverclusters/set-clusterlog.md
@@ -93,6 +93,15 @@ Accept wildcard characters: False
 Specifies the log level to set for the cluster.
 The acceptable values for this parameter are:`0` to `5`.
 
+| Level  | Error  | Warning  | Info  | Verbose | Debug |
+|:-----|:-----|:-----|:-----|:-----|:-----|
+|0 (Disabled)  <br/> ||||||
+|1  <br/> |&#x2714;||||
+|2 <br/> |&#x2714;|&#x2714;|||
+|3 (Default) <br/> |&#x2714;|&#x2714;|&#x2714;||
+|4 <br/> |&#x2714;|&#x2714;|&#x2714;|&#x2714;|
+|5  <br/> |&#x2714;|&#x2714;|&#x2714;|&#x2714;|&#x2714;|
+
 ```yaml
 Type: Int32
 Parameter Sets: (All)
@@ -104,14 +113,7 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-| Level  | Error  | Warning  | Info  | Verbose | Debug |
-|:-----|:-----|:-----|:-----|:-----|:-----|
-|0 (Disabled)  <br/> ||||||
-|1  <br/> |&#x2714;||||
-|2 <br/> |&#x2714;|&#x2714;|||
-|3 (Default) <br/> |&#x2714;|&#x2714;|&#x2714;||
-|4 <br/> |&#x2714;|&#x2714;|&#x2714;|&#x2714;|
-|5  <br/> |&#x2714;|&#x2714;|&#x2714;|&#x2714;|&#x2714;|
+
 
 ### -Size
 Specifies the log size to set for the cluster.

--- a/docset/windows/failoverclusters/set-clusterlog.md
+++ b/docset/windows/failoverclusters/set-clusterlog.md
@@ -104,6 +104,14 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+| Level  | Error  | Warning  | Info  | Verbose | Debug |
+|:-----|:-----|:-----|:-----|:-----|:-----|
+|0 (Disabled)  <br/> ||||||
+|1  <br/> |&#x2714;||||
+|2 <br/> |&#x2714;|&#x2714;|||
+|3 (Default) <br/> |&#x2714;|&#x2714;|&#x2714;||
+|4 <br/> |&#x2714;|&#x2714;|&#x2714;|&#x2714;|
+|5  <br/> |&#x2714;|&#x2714;|&#x2714;|&#x2714;|&#x2714;|
 
 ### -Size
 Specifies the log size to set for the cluster.


### PR DESCRIPTION
#533 
Action taken: 
-Created Cluster log Level graph

Reference: 
-graph ref:
https://mssqlfun.com/2015/04/24/window-server-2008-failover-clustering-logs/

-indicated that 'The default level is 3 (Errors, Warning, Info)'
https://social.technet.microsoft.com/Forums/windowsserver/en-US/13808c09-39f7-4a47-b2a9-6d1b4e117092/cluster-log-level?forum=winserverClustering

-indicated that " default level of 3"
https://techcommunity.microsoft.com/t5/Failover-Clustering/How-to-create-the-cluster-log-in-Windows-Server-2008-Failover/ba-p/371283