### PR TITLE
Update new-scheduledtasksettingsset.md

### DIFF
--- a/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
+++ b/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
@@ -121,6 +121,19 @@ This example registers a scheduled task that runs only when a network is availab
 
 The first command creates a scheduled task action named Cmd and assigns the **ScheduledTaskAction** object to the $Sta variable.
 
+### Example 6: Register a scheduled task that has a time limit to complete the task
+```
+PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
+
+The second command creates scheduled task settings that specify if the task is not finished after 1 hour, it is considered as failed. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+$Stset = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 1)
+
+The third command registers the scheduled task Task01 to run the task action named Cmd only then finish the task after 1 hour.
+PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
+```
+Without the ExecutionTimeLimit setting defined the time limit set to it's default of 3 days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan?view=powershell-6).
+
+
 ## PARAMETERS
 
 ### -AllowStartIfOnBatteries

--- a/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
+++ b/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
@@ -55,6 +55,8 @@ PS C:\>$STSet = New-ScheduledTaskSettingsSet
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $STSet
 
 ```
+The first command creates a scheduled task action named Cmd and assigns the ScheduledTaskAction object to the $Sta variable.
+ 
 The second command creates scheduled task settings that use the default settings and assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
 The third command registers the scheduled task Task01 to run the task action named Cmd and to use the default task settings.
@@ -72,6 +74,8 @@ PS C:\>$STSet = New-ScheduledTaskSettingsSet -Priority 5
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 
 ```
+The first command creates a scheduled task action named Cmd and assigns the ScheduledTaskAction object to the $Sta variable.
+ 
 The second command creates scheduled task settings that sets a higher priority for the scheduled task, and assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
 The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that have a priority setting of 9.
@@ -89,6 +93,8 @@ PS C:\>$Stset = New-ScheduledTaskSettingsSet -RestartCount 3 -RestartInterval 60
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 
 ```
+The first command creates a scheduled task action named Cmd and assigns the ScheduledTaskAction object to the $Sta variable.
+ 
 The second command creates scheduled task settings that specify that Task Scheduler attempts three restarts of the task at sixty minute intervals. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
 The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
@@ -106,6 +112,8 @@ PS C:\>$Stset = New-ScheduledTaskSettingsSet -RunOnlyIfIdle -IdleDuration 00:02:
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 
 ```
+The first command creates a scheduled task action named Cmd and assigns the ScheduledTaskAction object to the $Sta variable.
+ 
 The second command creates scheduled task settings that specify that Task Scheduler runs the task only when the computer is idle for 2 minutes and waits for 2 hours and 30 minutes for an idle condition. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
 The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
@@ -123,6 +131,8 @@ PS C:\>$Stset = New-ScheduledTaskSettingsSet -RunOnlyIfNetworkAvailable
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 
 ```
+The first command creates a scheduled task action named Cmd and assigns the ScheduledTaskAction object to the $Sta variable.
+ 
 The second command creates scheduled task settings that specify that Task Scheduler runs the task only when a network is available. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
 The third command registers the scheduled task Task01 to run the task action named Cmd only when a network is available.
@@ -140,6 +150,8 @@ $Stset = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 1
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 
 ```
+The first command creates a scheduled task action named Cmd and assigns the ScheduledTaskAction object to the $Sta variable.
+ 
 The second command creates scheduled task settings that specify if the task is not finished after one hour, it is considered as failed. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
 The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.

--- a/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
+++ b/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
@@ -50,11 +50,11 @@ You can use the scheduled task settings to register a new scheduled task or upda
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-#The second command creates scheduled task settings that use the default settings and assigns the **ScheduledTaskSettings** object to the $Stset variable.
 PS C:\>$STSet = New-ScheduledTaskSettingsSet
+#The second command creates scheduled task settings that use the default settings and assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
-#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the default task settings.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $STSet
+#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the default task settings.
 ```
 
 This example registers a scheduled task that uses default task settings.
@@ -65,11 +65,11 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-#The second command creates scheduled task settings that sets a higher priority for the scheduled task, and assigns the **ScheduledTaskSettings** object to the $Stset variable.
 PS C:\>$STSet = New-ScheduledTaskSettingsSet -Priority 5
+#The second command creates scheduled task settings that sets a higher priority for the scheduled task, and assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
-#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that have a priority setting of 9.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
+#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that have a priority setting of 9.
 ```
 
 This example sets the priority of a scheduled task.
@@ -80,11 +80,11 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-#The second command creates scheduled task settings that specify that Task Scheduler attempts three restarts of the task at sixty minute intervals. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 PS C:\>$Stset = New-ScheduledTaskSettingsSet -RestartCount 3 -RestartInterval 60
+#The second command creates scheduled task settings that specify that Task Scheduler attempts three restarts of the task at sixty minute intervals. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
-#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
+#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
 ```
 
 This example sets restart settings for a scheduled task.
@@ -95,11 +95,11 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-#The second command creates scheduled task settings that specify that Task Scheduler runs the task only when the computer is idle for 2 minutes and waits for 2 hours and 30 minutes for an idle condition. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 PS C:\>$Stset = New-ScheduledTaskSettingsSet -RunOnlyIfIdle -IdleDuration 00:02:00 -IdleWaitTimeout 02:30:00
+#The second command creates scheduled task settings that specify that Task Scheduler runs the task only when the computer is idle for 2 minutes and waits for 2 hours and 30 minutes for an idle condition. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
-#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
+#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
 ```
 
 This example sets idle settings for a scheduled task.
@@ -110,11 +110,11 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-#The second command creates scheduled task settings that specify that Task Scheduler runs the task only when a network is available. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 PS C:\>$Stset = New-ScheduledTaskSettingsSet -RunOnlyIfNetworkAvailable
+#The second command creates scheduled task settings that specify that Task Scheduler runs the task only when a network is available. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
-#The third command registers the scheduled task Task01 to run the task action named Cmd only when a network is available.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
+#The third command registers the scheduled task Task01 to run the task action named Cmd only when a network is available.
 ```
 
 This example registers a scheduled task that runs only when a network is available.
@@ -125,11 +125,11 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-#The second command creates scheduled task settings that specify if the task is not finished after one hour, it is considered as failed. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 $Stset = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 1)
+#The second command creates scheduled task settings that specify if the task is not finished after one hour, it is considered as failed. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
-#The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
+#The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.
 ```
 Without the ExecutionTimeLimit setting defined, the time limit set to it's default of three days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan).
 

--- a/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
+++ b/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
@@ -125,13 +125,13 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-The second command creates scheduled task settings that specify if the task is not finished after 1 hour, it is considered as failed. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+The second command creates scheduled task settings that specify if the task is not finished after one hour, it is considered as failed. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 $Stset = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 1)
 
-The third command registers the scheduled task Task01 to run the task action named Cmd only then finish the task after 1 hour.
+The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 ```
-Without the ExecutionTimeLimit setting defined the time limit set to it's default of 3 days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan?view=powershell-6).
+Without the ExecutionTimeLimit setting defined, the time limit set to it's default of three days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan?view=powershell-6).
 
 
 ## PARAMETERS

--- a/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
+++ b/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
@@ -55,9 +55,9 @@ PS C:\>$STSet = New-ScheduledTaskSettingsSet
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $STSet
 
 ```
-#The second command creates scheduled task settings that use the default settings and assigns the **ScheduledTaskSettings** object to the $Stset variable.
+The second command creates scheduled task settings that use the default settings and assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
-#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the default task settings.
+The third command registers the scheduled task Task01 to run the task action named Cmd and to use the default task settings.
 
 This example registers a scheduled task that uses default task settings.
 
@@ -72,9 +72,9 @@ PS C:\>$STSet = New-ScheduledTaskSettingsSet -Priority 5
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 
 ```
-#The second command creates scheduled task settings that sets a higher priority for the scheduled task, and assigns the **ScheduledTaskSettings** object to the $Stset variable.
+The second command creates scheduled task settings that sets a higher priority for the scheduled task, and assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
-#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that have a priority setting of 9.
+The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that have a priority setting of 9.
 
 This example sets the priority of a scheduled task.
 
@@ -89,9 +89,9 @@ PS C:\>$Stset = New-ScheduledTaskSettingsSet -RestartCount 3 -RestartInterval 60
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 
 ```
-#The second command creates scheduled task settings that specify that Task Scheduler attempts three restarts of the task at sixty minute intervals. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+The second command creates scheduled task settings that specify that Task Scheduler attempts three restarts of the task at sixty minute intervals. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
-#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
+The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
 
 This example sets restart settings for a scheduled task.
 
@@ -106,9 +106,9 @@ PS C:\>$Stset = New-ScheduledTaskSettingsSet -RunOnlyIfIdle -IdleDuration 00:02:
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 
 ```
-#The second command creates scheduled task settings that specify that Task Scheduler runs the task only when the computer is idle for 2 minutes and waits for 2 hours and 30 minutes for an idle condition. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+The second command creates scheduled task settings that specify that Task Scheduler runs the task only when the computer is idle for 2 minutes and waits for 2 hours and 30 minutes for an idle condition. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
-#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
+The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
 
 This example sets idle settings for a scheduled task.
 
@@ -123,9 +123,9 @@ PS C:\>$Stset = New-ScheduledTaskSettingsSet -RunOnlyIfNetworkAvailable
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 
 ```
-#The second command creates scheduled task settings that specify that Task Scheduler runs the task only when a network is available. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+The second command creates scheduled task settings that specify that Task Scheduler runs the task only when a network is available. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
-#The third command registers the scheduled task Task01 to run the task action named Cmd only when a network is available.
+The third command registers the scheduled task Task01 to run the task action named Cmd only when a network is available.
 
 This example registers a scheduled task that runs only when a network is available.
 
@@ -140,9 +140,9 @@ $Stset = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 1
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 
 ```
-#The second command creates scheduled task settings that specify if the task is not finished after one hour, it is considered as failed. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+The second command creates scheduled task settings that specify if the task is not finished after one hour, it is considered as failed. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
-#The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.
+The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.
 
 Without the ExecutionTimeLimit setting defined, the time limit set to it's default of three days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan).
 

--- a/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
+++ b/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
@@ -131,7 +131,7 @@ $Stset = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 1
 The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 ```
-Without the ExecutionTimeLimit setting defined, the time limit set to it's default of three days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan?view=powershell-6).
+Without the ExecutionTimeLimit setting defined, the time limit set to it's default of three days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan).
 
 
 ## PARAMETERS

--- a/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
+++ b/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
@@ -50,10 +50,10 @@ You can use the scheduled task settings to register a new scheduled task or upda
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-The second command creates scheduled task settings that use the default settings and assigns the **ScheduledTaskSettings** object to the $Stset variable.
+#The second command creates scheduled task settings that use the default settings and assigns the **ScheduledTaskSettings** object to the $Stset variable.
 PS C:\>$STSet = New-ScheduledTaskSettingsSet
 
-The third command registers the scheduled task Task01 to run the task action named Cmd and to use the default task settings.
+#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the default task settings.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $STSet
 ```
 
@@ -65,10 +65,10 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-The second command creates scheduled task settings that sets a higher priority for the scheduled task, and assigns the **ScheduledTaskSettings** object to the $Stset variable.
+#The second command creates scheduled task settings that sets a higher priority for the scheduled task, and assigns the **ScheduledTaskSettings** object to the $Stset variable.
 PS C:\>$STSet = New-ScheduledTaskSettingsSet -Priority 5
 
-The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that have a priority setting of 9.
+#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that have a priority setting of 9.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 ```
 
@@ -80,10 +80,10 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-The second command creates scheduled task settings that specify that Task Scheduler attempts three restarts of the task at sixty minute intervals. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+#The second command creates scheduled task settings that specify that Task Scheduler attempts three restarts of the task at sixty minute intervals. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 PS C:\>$Stset = New-ScheduledTaskSettingsSet -RestartCount 3 -RestartInterval 60
 
-The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
+#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 ```
 
@@ -95,10 +95,10 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-The second command creates scheduled task settings that specify that Task Scheduler runs the task only when the computer is idle for 2 minutes and waits for 2 hours and 30 minutes for an idle condition. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+#The second command creates scheduled task settings that specify that Task Scheduler runs the task only when the computer is idle for 2 minutes and waits for 2 hours and 30 minutes for an idle condition. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 PS C:\>$Stset = New-ScheduledTaskSettingsSet -RunOnlyIfIdle -IdleDuration 00:02:00 -IdleWaitTimeout 02:30:00
 
-The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
+#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 ```
 
@@ -110,10 +110,10 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-The second command creates scheduled task settings that specify that Task Scheduler runs the task only when a network is available. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+#The second command creates scheduled task settings that specify that Task Scheduler runs the task only when a network is available. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 PS C:\>$Stset = New-ScheduledTaskSettingsSet -RunOnlyIfNetworkAvailable
 
-The third command registers the scheduled task Task01 to run the task action named Cmd only when a network is available.
+#The third command registers the scheduled task Task01 to run the task action named Cmd only when a network is available.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 ```
 
@@ -125,10 +125,10 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
-The second command creates scheduled task settings that specify if the task is not finished after one hour, it is considered as failed. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+#The second command creates scheduled task settings that specify if the task is not finished after one hour, it is considered as failed. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 $Stset = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 1)
 
-The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.
+#The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
 ```
 Without the ExecutionTimeLimit setting defined, the time limit set to it's default of three days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan).

--- a/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
+++ b/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
@@ -51,11 +51,13 @@ You can use the scheduled task settings to register a new scheduled task or upda
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
 PS C:\>$STSet = New-ScheduledTaskSettingsSet
-#The second command creates scheduled task settings that use the default settings and assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $STSet
-#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the default task settings.
+
 ```
+#The second command creates scheduled task settings that use the default settings and assigns the **ScheduledTaskSettings** object to the $Stset variable.
+
+#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the default task settings.
 
 This example registers a scheduled task that uses default task settings.
 
@@ -66,11 +68,13 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
 PS C:\>$STSet = New-ScheduledTaskSettingsSet -Priority 5
-#The second command creates scheduled task settings that sets a higher priority for the scheduled task, and assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
-#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that have a priority setting of 9.
+
 ```
+#The second command creates scheduled task settings that sets a higher priority for the scheduled task, and assigns the **ScheduledTaskSettings** object to the $Stset variable.
+
+#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that have a priority setting of 9.
 
 This example sets the priority of a scheduled task.
 
@@ -81,11 +85,13 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
 PS C:\>$Stset = New-ScheduledTaskSettingsSet -RestartCount 3 -RestartInterval 60
-#The second command creates scheduled task settings that specify that Task Scheduler attempts three restarts of the task at sixty minute intervals. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
-#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
+
 ```
+#The second command creates scheduled task settings that specify that Task Scheduler attempts three restarts of the task at sixty minute intervals. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+
+#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
 
 This example sets restart settings for a scheduled task.
 
@@ -96,11 +102,13 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
 PS C:\>$Stset = New-ScheduledTaskSettingsSet -RunOnlyIfIdle -IdleDuration 00:02:00 -IdleWaitTimeout 02:30:00
-#The second command creates scheduled task settings that specify that Task Scheduler runs the task only when the computer is idle for 2 minutes and waits for 2 hours and 30 minutes for an idle condition. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
-#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
+
 ```
+#The second command creates scheduled task settings that specify that Task Scheduler runs the task only when the computer is idle for 2 minutes and waits for 2 hours and 30 minutes for an idle condition. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+
+#The third command registers the scheduled task Task01 to run the task action named Cmd and to use the task settings that the **ScheduledTaskSettings** object defines.
 
 This example sets idle settings for a scheduled task.
 
@@ -111,11 +119,13 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
 PS C:\>$Stset = New-ScheduledTaskSettingsSet -RunOnlyIfNetworkAvailable
-#The second command creates scheduled task settings that specify that Task Scheduler runs the task only when a network is available. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
-#The third command registers the scheduled task Task01 to run the task action named Cmd only when a network is available.
+
 ```
+#The second command creates scheduled task settings that specify that Task Scheduler runs the task only when a network is available. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+
+#The third command registers the scheduled task Task01 to run the task action named Cmd only when a network is available.
 
 This example registers a scheduled task that runs only when a network is available.
 
@@ -126,11 +136,14 @@ The first command creates a scheduled task action named Cmd and assigns the **Sc
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"
 
 $Stset = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 1)
-#The second command creates scheduled task settings that specify if the task is not finished after one hour, it is considered as failed. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
 
 PS C:\>Register-ScheduledTask Task01 -Action $Sta -Settings $Stset
-#The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.
+
 ```
+#The second command creates scheduled task settings that specify if the task is not finished after one hour, it is considered as failed. This command assigns the **ScheduledTaskSettings** object to the $Stset variable.
+
+#The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.
+
 Without the ExecutionTimeLimit setting defined, the time limit set to it's default of three days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan).
 
 

--- a/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
+++ b/docset/windows/scheduledtasks/new-scheduledtasksettingsset.md
@@ -139,8 +139,6 @@ The third command registers the scheduled task Task01 to run the task action nam
 
 This example registers a scheduled task that runs only when a network is available.
 
-The first command creates a scheduled task action named Cmd and assigns the **ScheduledTaskAction** object to the $Sta variable.
-
 ### Example 6: Register a scheduled task that has a time limit to complete the task
 ```
 PS C:\>$Sta = New-ScheduledTaskAction -Execute "Cmd"


### PR DESCRIPTION
#548 
Step Taken: 
- Added #6 example to -ExecutionTimeLimit 
-ExecutionTimeLimit (New-TimeSpan -Hours 1) same as ExecutionTimeLimit =  'PT1H'
it specify that if the task is not finished after 1 hour, it is considered as failed, it need to finish the task after 1 hour.

-Also added that "Without the ExecutionTimeLimit setting defined the time limit set to it's default of 3 days for the Task Scheduler is allowed to complete the task."
-added article for time limit parameter https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan?view=powershell-6

References;
https://social.technet.microsoft.com/Forums/en-US/26be656a-ce4f-4566-a994-0e0c2edabac8/windows-task-scheduler-time-limit-set-to-unlimited?forum=winserver8gen

The -ExecutionTimeLimit parameter is for New-ScheduledTaskSettingsSet command.
https://social.technet.microsoft.com/Forums/en-US/26be656a-ce4f-4566-a994-0e0c2edabac8/windows-task-scheduler-time-limit-set-to-unlimited?forum=winserver8gen

https://social.technet.microsoft.com/Forums/en-US/26be656a-ce4f-4566-a994-0e0c2edabac8/windows-task-scheduler-time-limit-set-to-unlimited?forum=winserver8gen

Trigger task scheduler Job from powershell
https://stackoverflow.com/questions/44491658/trigger-task-scheduler-job-from-powershell?rq=1