### PR TITLE
Update get-scheduledtask.md

### DIFF
--- a/docset/windows/scheduledtasks/get-scheduledtask.md
+++ b/docset/windows/scheduledtasks/get-scheduledtask.md
@@ -94,7 +94,7 @@ Accept wildcard characters: False
 ```
 
 ### -TaskName
-Specifies an array of one or more names of a scheduled task.
+Specifies an array of one or more names of a scheduled task. You can use **"*"** for a wildcard character query.
 
 ```yaml
 Type: String[]
@@ -109,7 +109,7 @@ Accept wildcard characters: True
 ```
 
 ### -TaskPath
-Specifies an array of one or more paths for scheduled tasks in Task Scheduler namespace.
+Specifies an array of one or more paths for scheduled tasks in Task Scheduler namespace. You can use **"*"** for a wildcard character query.
 You can use ***\\\*** for the root folder.
 If you do not specify a path, the cmdlet uses the root folder.
 

--- a/docset/windows/scheduledtasks/get-scheduledtask.md
+++ b/docset/windows/scheduledtasks/get-scheduledtask.md
@@ -94,7 +94,7 @@ Accept wildcard characters: False
 ```
 
 ### -TaskName
-Specifies an array of one or more names of a scheduled task.
+Specifies an array of one or more names of a scheduled task. You can use "*" for a wildcard character query.
 
 ```yaml
 Type: String[]
@@ -109,9 +109,7 @@ Accept wildcard characters: False
 ```
 
 ### -TaskPath
-Specifies an array of one or more paths for scheduled tasks in Task Scheduler namespace. 
-You can use "*" for a wildcard character query.
-You can use **\** for the root folder. 
+Specifies an array of one or more paths for scheduled tasks in Task Scheduler namespace. You can use "*" for a wildcard character query.
 If you do not specify a path, the cmdlet uses the root folder.
 
 ```yaml

--- a/docset/windows/scheduledtasks/get-scheduledtask.md
+++ b/docset/windows/scheduledtasks/get-scheduledtask.md
@@ -94,7 +94,7 @@ Accept wildcard characters: False
 ```
 
 ### -TaskName
-Specifies an array of one or more names of a scheduled task. You can use "*" for a wildcard character query.
+Specifies an array of one or more names of a scheduled task. You can use **"*"** for a wildcard character query.
 
 ```yaml
 Type: String[]
@@ -109,7 +109,8 @@ Accept wildcard characters: False
 ```
 
 ### -TaskPath
-Specifies an array of one or more paths for scheduled tasks in Task Scheduler namespace. You can use "*" for a wildcard character query.
+Specifies an array of one or more paths for scheduled tasks in Task Scheduler namespace. You can use **"*"** for a wildcard character query.
+You can use ***\\\*** for the root folder.
 If you do not specify a path, the cmdlet uses the root folder.
 
 ```yaml

--- a/docset/windows/scheduledtasks/get-scheduledtask.md
+++ b/docset/windows/scheduledtasks/get-scheduledtask.md
@@ -37,7 +37,7 @@ The **Get-ScheduledTask** cmdlet gets the task definition object of a scheduled 
 
 ### Example 1: Get a scheduled task definition object
 ```
-PS C:\> Get-ScheduledTask -TaskName "SystemScan"
+PS C:\> Get-ScheduledTask -TaskName "SystemScan*"
 TaskPath                          TaskName                        State
 --------                          --------                        --------
 \                                 SystemScan                      Ready
@@ -94,7 +94,7 @@ Accept wildcard characters: False
 ```
 
 ### -TaskName
-Specifies an array of one or more names of a scheduled task.
+Specifies an array of one or more names of a scheduled task. You can use "*" for a wildcard character query.
 
 ```yaml
 Type: String[]

--- a/docset/windows/scheduledtasks/get-scheduledtask.md
+++ b/docset/windows/scheduledtasks/get-scheduledtask.md
@@ -94,7 +94,7 @@ Accept wildcard characters: False
 ```
 
 ### -TaskName
-Specifies an array of one or more names of a scheduled task. You can use **"*"** for a wildcard character query.
+Specifies an array of one or more names of a scheduled task.
 
 ```yaml
 Type: String[]
@@ -105,11 +105,11 @@ Required: False
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -TaskPath
-Specifies an array of one or more paths for scheduled tasks in Task Scheduler namespace. You can use **"*"** for a wildcard character query.
+Specifies an array of one or more paths for scheduled tasks in Task Scheduler namespace.
 You can use ***\\\*** for the root folder.
 If you do not specify a path, the cmdlet uses the root folder.
 

--- a/docset/windows/scheduledtasks/get-scheduledtask.md
+++ b/docset/windows/scheduledtasks/get-scheduledtask.md
@@ -109,7 +109,8 @@ Accept wildcard characters: False
 ```
 
 ### -TaskPath
-Specifies an array of one or more paths for scheduled tasks in Task Scheduler namespace. You can use " * " for a wildcard character query.
+Specifies an array of one or more paths for scheduled tasks in Task Scheduler namespace. 
+You can use "*" for a wildcard character query.
 You can use **\** for the root folder. 
 If you do not specify a path, the cmdlet uses the root folder.
 

--- a/docset/windows/scheduledtasks/get-scheduledtask.md
+++ b/docset/windows/scheduledtasks/get-scheduledtask.md
@@ -37,7 +37,7 @@ The **Get-ScheduledTask** cmdlet gets the task definition object of a scheduled 
 
 ### Example 1: Get a scheduled task definition object
 ```
-PS C:\> Get-ScheduledTask -TaskName "SystemScan*"
+PS C:\> Get-ScheduledTask -TaskName "SystemScan"
 TaskPath                          TaskName                        State
 --------                          --------                        --------
 \                                 SystemScan                      Ready
@@ -47,7 +47,7 @@ This command gets the definition object of the SystemScan scheduled task in the 
 
 ### Example 2: Get an array of scheduled task definition objects
 ```
-PS C:\> Get-ScheduledTask -TaskPath "\UpdateTasks\"
+PS C:\> Get-ScheduledTask -TaskPath "\UpdateTasks\*"
 TaskPath                          TaskName                        State
 --------                          --------                        --------
 \UpdateTasks                      UpdateApps                      Ready 
@@ -94,7 +94,7 @@ Accept wildcard characters: False
 ```
 
 ### -TaskName
-Specifies an array of one or more names of a scheduled task. You can use "*" for a wildcard character query.
+Specifies an array of one or more names of a scheduled task.
 
 ```yaml
 Type: String[]
@@ -109,8 +109,8 @@ Accept wildcard characters: False
 ```
 
 ### -TaskPath
-Specifies an array of one or more paths for scheduled tasks in Task Scheduler namespace.
-You can use **\** for the root folder.
+Specifies an array of one or more paths for scheduled tasks in Task Scheduler namespace. You can use " * " for a wildcard character query.
+You can use **\** for the root folder. 
 If you do not specify a path, the cmdlet uses the root folder.
 
 ```yaml
@@ -122,12 +122,12 @@ Required: False
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -ThrottleLimit
 Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-If this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
+If this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer. 
 The throttle limit applies only to the current cmdlet, not to the session or to the computer.
 
 ```yaml


### PR DESCRIPTION
#505 
Action Taken:
-Added * to systemscan example
-In TaskName ,added "You can use "*" for a wildcard character query."

Did the following test:
Tried to look for wildcard taskname "d" or "D" , no result found
but  "d*" or "D*" shows result, see screenshot.
https://snag.gy/fzq6uJ.jpg

Tried several wildcard but only "string*" works, see screenshot
https://snag.gy/yG8Ump.jpg

Tried for "SystemScan" do not show result but tried "SystemScan*" or "System*" shows result, see screenshot
https://snag.gy/iOtJqN.jpg