### PR TITLE
Update uninstall-addsdomaincontroller.md

### DIFF
--- a/docset/windows/addsdeployment/uninstall-addsdomaincontroller.md
+++ b/docset/windows/addsdeployment/uninstall-addsdomaincontroller.md
@@ -258,7 +258,7 @@ Accept wildcard characters: False
 ### -RemoveDnsDelegation
 Specifies whether to preserve DNS delegations that point to this DNS server from the parent DNS zone.
 
-By default, this parameter is set to False, which means DNS delegations that point to this server from the parent DNS zone will be retained after uninstallation of the domain controller.
+Specifies whether to preserve DNS delegation that point to this DNS server from the parent DNS Zone. If you use this parameter, DNS delegations that point to this server from the parent DNS zone will not be retained after uninstallation of the domain controller.
 This setting corresponds to the earlier Dcpromo.exe parameter default of /RemoveDNSDelegation:Yes.
 
 ```yaml

--- a/docset/windows/addsdeployment/uninstall-addsdomaincontroller.md
+++ b/docset/windows/addsdeployment/uninstall-addsdomaincontroller.md
@@ -256,7 +256,6 @@ Accept wildcard characters: False
 ```
 
 ### -RemoveDnsDelegation
-Specifies whether to preserve DNS delegations that point to this DNS server from the parent DNS zone.
 
 Specifies whether to preserve DNS delegation that point to this DNS server from the parent DNS Zone. If you use this parameter, DNS delegations that point to this server from the parent DNS zone will not be retained after uninstallation of the domain controller.
 This setting corresponds to the earlier Dcpromo.exe parameter default of /RemoveDNSDelegation:Yes.

--- a/docset/windows/addsdeployment/uninstall-addsdomaincontroller.md
+++ b/docset/windows/addsdeployment/uninstall-addsdomaincontroller.md
@@ -258,7 +258,7 @@ Accept wildcard characters: False
 ### -RemoveDnsDelegation
 Specifies whether to preserve DNS delegations that point to this DNS server from the parent DNS zone.
 
-By default, this parameter is set to False, which means DNS delegations that point to this server from the parent DNS zone will not be retained after uninstallation of the domain controller.
+By default, this parameter is set to False, which means DNS delegations that point to this server from the parent DNS zone will be retained after uninstallation of the domain controller.
 This setting corresponds to the earlier Dcpromo.exe parameter default of /RemoveDNSDelegation:Yes.
 
 ```yaml


### PR DESCRIPTION
#477 
Action Taken
-remove the NOT

Analysis: If remove dns delegation is false, that means it doesn't delete the delegation pointing to the server.
it will be retained since there is no deletion happened, deletion needs to be manual.
See screenshot for remove dns delegation: https://snag.gy/VvSOol.jpg

References:
https://social.technet.microsoft.com/Forums/windows/en-US/9e51d3fa-6cd1-4c64-b23c-7f1b970f8574/demoting-win-2008-std-32bit-dc-remove-dns-delegation-question

https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc771844(v=ws.10)