### PR TITLE
Update set-dhcpserverauditlog.md

### DIFF
--- a/docset/windows/dhcpserver/set-dhcpserverauditlog.md
+++ b/docset/windows/dhcpserver/set-dhcpserverauditlog.md
@@ -147,7 +147,7 @@ Accept wildcard characters: False
 ```
 
 ### -MaxMBFileSize
-Specifies the maximum size of the audit log, in megabytes (MB).
+Specifies the maximum size on disk available for all DHCP service audit log files, in megabytes (MB).
 
 ```yaml
 Type: UInt32

--- a/docset/windows/dhcpserver/set-dhcpserverauditlog.md
+++ b/docset/windows/dhcpserver/set-dhcpserverauditlog.md
@@ -147,7 +147,7 @@ Accept wildcard characters: False
 ```
 
 ### -MaxMBFileSize
-Specifies the maximum size on disk available for all DHCP service audit log files, in megabytes (MB).
+Specifies the maximum disk space available for all DHCP service audit log files, in megabytes (MB).
 
 ```yaml
 Type: UInt32


### PR DESCRIPTION
Issue #531 ,
the parameter specifies limit for all the files, not for the single file, old description could be misleading