### PR TITLE
Update get-netfirewallrule.md

### DIFF
--- a/docset/windows/netsecurity/get-netfirewallrule.md
+++ b/docset/windows/netsecurity/get-netfirewallrule.md
@@ -649,7 +649,8 @@ Computer GPOs can be specified as follows.
 Optional and product-dependent features are considered part of Windows Server 2012 for the purposes of WFAS. 
 - ConfigurableServiceStore: This read-write store contains all the service restrictions that are added for third-party services.
 In addition, network isolation rules that are created for Windows Store application containers will appear in this policy store. 
-The default value is PersistentStore. 
+The default value is PersistentStore.
+This will also appear in regedit : HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\RestrictedServices\AppIso\FirewallRules but this is not accessible by get-netfirewallrule. 
 The Set-NetFirewallRule cmdlet cannot be used to add an object to a policy store.
 An object can only be added to a policy store at creation time with the Copy-NetFirewallRule or with the New-NetFirewallRule cmdlet.
 


### PR DESCRIPTION
#414 
Action Taken:
- added "This will also appear in regedit : HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\RestrictedServices\AppIso\FirewallRules but this is not accessible by get-netfirewallrule. "

Did the following test:  
RUN: get-netfirewallrule still shows up all the application

It says PolicyStoreSource is PersistenceStore:
see screenshot: https://snag.gy/Xf5G6k.jpg

Access: HKLM:\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\RestrictedServices\AppIso\FirewallRules
- was able to find all app as well
see screenshot: https://snag.gy/4OsGFe.jpg

Here in the following article that has the same line as below, there are more article but just added 3:
"ConfigurableServiceStore: This read-write store contains all the service restrictions that are added for third-party services. In addition, network isolation rules that are created for Windows Store application containers will appear in this policy store."

Get-NetFirewallSetting
https://docs.microsoft.com/es-es/previous-versions/windows/powershell-scripting/jj554871(v=wps.620)

Set-NetFirewallServiceFilter
https://docs.microsoft.com/it-it/previous-versions/windows/powershell-scripting/jj554841(v=wps.620)

New-NetIPsecQuickModeCryptoSet
https://docs.microsoft.com/en-us/powershell/module/netsecurity/new-netipsecquickmodecryptoset?view=win10-ps

Based on this Articles: There is a known issue that each time user logs on, firewall rules are added, which already exist and are unnecessary as they are duplicates. deleting the registry keys ,HKLM:\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\RestrictedServices\AppIso\FirewallRules fixed the issue. Added this info because it said that if run  you run the key you don't need to run ConfigurableServiceStore

https://social.technet.microsoft.com/Forums/windows/en-US/992e86c8-2bee-4951-9461-e3d7710288e9/windows-servr-2016-rdsh-firewall-rules-created-at-every-login
Indicated: because there can be rules under ConfigurableServiceStore for a username with different direction: Inbound/Outbound. This way the uniqueness is ensured. However, if you run the deletion of the Key, there's no need to run the script to delete the ConfigurableRules.

https://stackoverflow.com/questions/40620634/speed-up-powershells-remove-netfirewallrule

https://social.technet.microsoft.com/Forums/windows/en-US/fda93547-72b0-4275-9fec-1b326507bf12/apps-break-after-about-4000-profiles-260000-firewall-rules

The update confirm the resolution: April 2, 2019—KB4490481 (OS Build 17763.404)
https://support.microsoft.com/en-us/help/4490481/windows-10-update-kb4490481