### PR TITLE
Changed required state for ScopeId parameter

### DIFF
--- a/docset/windows/dhcpserver/invoke-dhcpserverv4failoverreplication.md
+++ b/docset/windows/dhcpserver/invoke-dhcpserverv4failoverreplication.md
@@ -179,7 +179,7 @@ Type: IPAddress[]
 Parameter Sets: ScopeId
 Aliases: 
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)


### PR DESCRIPTION
ScopeId is actually optional https://github.com/MicrosoftDocs/windows-powershell-docs/issues/462