### PR TITLE
Update new-eapconfiguration.md

### DIFF
--- a/docset/windows/vpnclient/new-eapconfiguration.md
+++ b/docset/windows/vpnclient/new-eapconfiguration.md
@@ -75,7 +75,7 @@ This command creates an EAP configuration object, customized by the *UseWinlogon
 By specifying the *UseWinlogonCredential* parameter, the EAP configuration object is configured to use MSCHAPv2 as the authentication method, and that Windows logon credentials are used automatically when connecting with the VPN connection profile.
 
 See [VPN authentication options](https://docs.microsoft.com/windows/security/identity-protection/vpn/vpn-authentication) 
-and [Add connectivity profiles](https://docs.microsoft.com/windows/configuration/wcd/wcd-connectivityprofiles#vpn-1) to learn more about VPN authentication method.
+and [Add connectivity profiles](https://docs.microsoft.com/windows/configuration/wcd/wcd-connectivityprofiles#vpn-1) to learn more about VPN authentication methods.
 
 ### Example 3: Create a TLS customized EAP configuration object
 ```

--- a/docset/windows/vpnclient/new-eapconfiguration.md
+++ b/docset/windows/vpnclient/new-eapconfiguration.md
@@ -74,6 +74,9 @@ PS C:\> $A = New-EapConfiguration -UseWinlogonCredential
 This command creates an EAP configuration object, customized by the *UseWinlogonCredential* parameter, and stores it in the variable named $A.
 By specifying the *UseWinlogonCredential* parameter, the EAP configuration object is configured to use MSCHAPv2 as the authentication method, and that Windows logon credentials are used automatically when connecting with the VPN connection profile.
 
+See [VPN authentication options](https://docs.microsoft.com/windows/security/identity-protection/vpn/vpn-authentication) 
+and [Add connectivity profiles](https://docs.microsoft.com/windows/configuration/wcd/wcd-connectivityprofiles#vpn-1) to learn more about VPN authentication method.
+
 ### Example 3: Create a TLS customized EAP configuration object
 ```
 PS C:\> $A = New-EapConfiguration -Tls -VerifyServerIdentity -UserCertificate


### PR DESCRIPTION
#729 
I cannot verify if the "WinLogonCredential with MSCAPv2, can use NON Window credential username + password" , I cannot find any article with regard to this.

Article: https://docs.microsoft.com/en-us/windows/security/identity-protection/vpn/vpn-authentication

Although according to the above article: "EAP-Microsoft Challenge Handshake Authentication Protocol version 2 (EAP-MSCHAPv2) supports User name and password authentication", Could you please help me to verify if this mean it accept a Non-windows credentials username + password.

Additionally in this article, it said that "UWP VPN plug-in can use the authentication method "User name and password" and supports custom credential type.
Can we recommend this to the user instead?

Technet Forum: https://social.technet.microsoft.com/Forums/en-US/4d677476-0440-4276-ab07-c142f07a7bc8/really-confused-about-peap-and-mschap-v2-why-sometimes-they-are-separated-and-sometimes-one-is-the?forum=winserverNIS
It said in this forum the " Passwords from the clients are send using hashes to the authentication server. To protect these password hashes being send over the network, you can use PEAP which act as a TLS/SSL tunnel to protect the authentication traffic." - so does this mean it is just accepts a Windows login credential?

=====================================================



References:

https://github.com/MicrosoftDocs/windows-powershell-docs/blob/master/docset/windows/vpnclient/add-vpnconnection.md

https://docs.microsoft.com/en-us/windows/security/identity-protection/vpn/vpn-authentication

https://docs.microsoft.com/windows/configuration/wcd/wcd-connectivityprofiles#vpn-1

AuthenticationUserMethod When you set NativeProtocolType to IKEv2, choose between EAP and MSChapv2. 
https://docs.microsoft.com/en-us/windows/configuration/wcd/wcd-connectivityprofiles

https://docs.microsoft.com/en-us/windows/client-management/mdm/eap-configuration

https://support.microsoft.com/en-us/help/2744850/implementing-peap-ms-chap-v2-authentication-for-microsoft-pptp-vpns

https://social.technet.microsoft.com/Forums/en-US/4d677476-0440-4276-ab07-c142f07a7bc8/really-confused-about-peap-and-mschap-v2-why-sometimes-they-are-separated-and-sometimes-one-is-the?forum=winserverNIS