### PR TITLE
Update add-bgprouter.md

### DIFF
--- a/docset/windows/remoteaccess/add-bgprouter.md
+++ b/docset/windows/remoteaccess/add-bgprouter.md
@@ -247,7 +247,8 @@ Accept wildcard characters: False
 ```
 
 ### -LocalASN
-Specifies the local AS Number of the BGP Router instance.
+Specifies the local AS Number of the BGP Router instance, see [AS numbers by IANA](
+https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) for the list of 32 bit AS numbers.
 
 ```yaml
 Type: UInt32

--- a/docset/windows/remoteaccess/add-bgprouter.md
+++ b/docset/windows/remoteaccess/add-bgprouter.md
@@ -247,8 +247,7 @@ Accept wildcard characters: False
 ```
 
 ### -LocalASN
-Specifies the local AS Number of the BGP Router instance, see [AS numbers by IANA](
-https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) for the list of 32 bit AS numbers.
+Specifies the local AS number of the BGP Router instance. See [AS numbers by IANA](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) for the list of 32 bit AS numbers.
 
 ```yaml
 Type: UInt32


### PR DESCRIPTION
#962 
**Action Taken:**
 
Added reference link from IANA to show all the list of 32 bit AS numbers. link: https://www.iana.org/assignments/as-numbers/as-numbers.xhtml

Perhaps we can verify the supported 32bit ASN for BGP.

**According to this article**, Autonomous System numbers ; url
https://docs.microsoft.com/en-us/azure/expressroute/expressroute-routing#autonomous-system-numbers

**"We have reserved ASNs from 65515 to 65520 for internal use. Both 16 and 32 bit AS numbers are supported."**