### PR TITLE
Update get-windowsfeature.md

### DIFF
--- a/docset/windows/Microsoft.Windows.ServerManager.Migration/get-windowsfeature.md
+++ b/docset/windows/Microsoft.Windows.ServerManager.Migration/get-windowsfeature.md
@@ -33,9 +33,8 @@ Get-WindowsFeature [[-Name] <String[]>] [-Vhd <String>] [-ComputerName <String>]
 ## DESCRIPTION
 The **Get-WindowsFeature** cmdlet gets information about rrsandf_plural that are both available for installation and already installed on a computer that is running Windows Server 2012 R2 or an offline virtual hard disk (VHD) that is running Windows Server 2012 R2.
 
-
 > [!Note]
-> Get-WindowsFeature is a Server-Manager cmdlets that are only available on servers and when the remote administration tools on a workstation is install, see [Windows Server: Installing roles and features in different ways](https://social.technet.microsoft.com/wiki/contents/articles/52780.windows-server-installing-roles-and-features-in-different-ways.aspx)
+> Get-WindowsFeature is a Server-Manager cmdlet that is only available on servers, and only when the remote administration tools are installed on a workstation. See [Windows Server: Installing roles and features in different ways](https://social.technet.microsoft.com/wiki/contents/articles/52780.windows-server-installing-roles-and-features-in-different-ways.aspx) for more details.
 
 ## EXAMPLES
 

--- a/docset/windows/Microsoft.Windows.ServerManager.Migration/get-windowsfeature.md
+++ b/docset/windows/Microsoft.Windows.ServerManager.Migration/get-windowsfeature.md
@@ -31,7 +31,7 @@ Get-WindowsFeature [[-Name] <String[]>] [-Vhd <String>] [-ComputerName <String>]
 ```
 
 ## DESCRIPTION
-The **Get-WindowsFeature** cmdlet gets information about rrsandf_plural that are both available for installation and already installed on a computer that is running Windows Server 2012 R2 or an offline virtual hard disk (VHD) that is running Windows Server 2012 R2.
+The **Get-WindowsFeature** cmdlet gets information about features that are both available for installation and already installed on a computer that is running Windows Server 2012 R2 or an offline virtual hard disk (VHD) that is running Windows Server 2012 R2.
 
 ## EXAMPLES
 

--- a/docset/windows/Microsoft.Windows.ServerManager.Migration/get-windowsfeature.md
+++ b/docset/windows/Microsoft.Windows.ServerManager.Migration/get-windowsfeature.md
@@ -33,6 +33,10 @@ Get-WindowsFeature [[-Name] <String[]>] [-Vhd <String>] [-ComputerName <String>]
 ## DESCRIPTION
 The **Get-WindowsFeature** cmdlet gets information about rrsandf_plural that are both available for installation and already installed on a computer that is running Windows Server 2012 R2 or an offline virtual hard disk (VHD) that is running Windows Server 2012 R2.
 
+
+> [!Note]
+> Get-WindowsFeature is a Server-Manager cmdlets that are only available on servers and when the remote administration tools on a workstation is install, see [Windows Server: Installing roles and features in different ways](https://social.technet.microsoft.com/wiki/contents/articles/52780.windows-server-installing-roles-and-features-in-different-ways.aspx)
+
 ## EXAMPLES
 
 ### Example 1: Get a list of features that are available and installed on the specified computer

--- a/docset/windows/Microsoft.Windows.ServerManager.Migration/get-windowsfeature.md
+++ b/docset/windows/Microsoft.Windows.ServerManager.Migration/get-windowsfeature.md
@@ -33,9 +33,6 @@ Get-WindowsFeature [[-Name] <String[]>] [-Vhd <String>] [-ComputerName <String>]
 ## DESCRIPTION
 The **Get-WindowsFeature** cmdlet gets information about rrsandf_plural that are both available for installation and already installed on a computer that is running Windows Server 2012 R2 or an offline virtual hard disk (VHD) that is running Windows Server 2012 R2.
 
-> [!Note]
-> Get-WindowsFeature is a Server-Manager cmdlet that is only available on servers, and only when the remote administration tools are installed on a workstation. See [Windows Server: Installing roles and features in different ways](https://social.technet.microsoft.com/wiki/contents/articles/52780.windows-server-installing-roles-and-features-in-different-ways.aspx) for more details.
-
 ## EXAMPLES
 
 ### Example 1: Get a list of features that are available and installed on the specified computer


### PR DESCRIPTION
#1106 
Step Taken
Added Notes:
Get-WindowsFeature is a Server-Manager cmdlets that are only available on servers and when the remote administration tools on a workstation is install, see Windows Server: Installing roles and features in different ways https://social.technet.microsoft.com/wiki/contents/articles/52780.windows-server-installing-roles-and-features-in-different-ways.aspx

TS:
Tried to test Get-WindowsFeature in  Windows Server 2010 R2 it works
See screenshot below:

https://snag.gy/fmuRgS.jpg
https://snag.gy/DMjK14.jpg

Verified that Get-WindowsFeature is a Server cmdlet 
References:
https://social.technet.microsoft.com/Forums/office/en-US/76189558-9da8-413f-b0ed-5b772a7edc7c/installwindowsfeature-command-does-not-work-in-ps-50-on-windows-10?forum=win10itprosetup

Alternatively, Get-WindowsOptionalFeature can be use, see reference:
https://social.technet.microsoft.com/wiki/contents/articles/52780.windows-server-installing-roles-and-features-in-different-ways.aspx