### PR TITLE
Update add-windowspackage.md

### DIFF
--- a/docset/windows/dism/add-windowspackage.md
+++ b/docset/windows/dism/add-windowspackage.md
@@ -41,6 +41,7 @@ Add-WindowsPackage -PackagePath <String> [-IgnoreCheck] [-PreventPending] [-NoRe
 
 ## DESCRIPTION
 The **Add-WindowsPackage** cmdlet installs a specified .cab or .msu package in the image.
+See also (Add or remove packages offline by using DISM)[https://docs.microsoft.com/windows-hardware/manufacture/desktop/dism-operating-system-package-servicing-command-line-options#add-package].
 
 ## EXAMPLES
 


### PR DESCRIPTION
#1115 
Action Taken 
Add:
See also (Add or remove packages offline by using DISM)[https://docs.microsoft.com/windows-hardware/manufacture/desktop/dism-operating-system-package-servicing-command-line-options#add-package].

-It seems that Add-WindowsPackage does not really work, instead DISM.exe /Online /Add-Package /PackagePath alternatively works.
- Can you please help me verify this or perhaps I have run the command incorrectly
Thank you in advance for the help . 

**Did the following Step as reference from the test and  research I have run**

-Install .msu Adobe Flash Player update in https://www.catalog.update.microsoft.com/Search.aspx?q=KB4503308

-Followed this article to expand .msu to .cab
https://blogs.technet.microsoft.com/askcore/2011/02/15/how-to-use-dism-to-install-a-hotfix-from-within-windows/

Run the following for comparison
Add-WindowsPackage -Online -PackagePath "c:\Temp\4503308\Windows10.0-KB4503308-arm64.cab"

See screenshot: Error: Failed to add package / Add-WindowsPackage failed
https://snag.gy/gMUDEd.jpg

DISM.exe /Online /Add-Package /PackagePath:c:\temp\4503308\Windows10.0-KB4503308-arm64.cab

This work successfully, see screenshot
https://snag.gy/O3RZuA.jpg

-Followed this article: Add-WindowsPackage still do not work
https://answers.microsoft.com/en-us/windows/forum/windows8_1/error-0x80070003-when-installing-kb-2919355/c4f931a4-d841-4a25-954c-300b62da8b99

Run the following in WIndows 10 and window server R2 and did the test again but issue persist for Add-WindowsPackage
DISM.exe /Online /Cleanup-image /Scanhealth
DISM.exe /Online /Cleanup-image /Restorehealth
RUn windows update