### PR TITLE
Update Set-ADAccountPassword.md

### DIFF
--- a/docset/winserver2012-ps/activedirectory/Set-ADAccountPassword.md
+++ b/docset/winserver2012-ps/activedirectory/Set-ADAccountPassword.md
@@ -34,9 +34,6 @@ Similarly, you can use Get-ADUser, Get-ADComputer or Get-ADServiceAccount, for s
 
 Note: Group MSAs cannot set password since they are changed at predetermined intervals.
 
-You must set the OldPassword and the NewPassword parameters to set the password unless you specify the Reset parameter.
-When you specify the Reset parameter, the password is set to the NewPassword value that you provide and the OldPassword parameter is not required.
-
 For AD LDS environments, the Partition parameter must be specified except in the following two conditions:
 
 -The cmdlet is run from an Active Directory provider drive.
@@ -67,6 +64,7 @@ Description
 -----------
 
 Sets the password of the user account with SamAccountName: tmakovec to 'qwert@12345'.
+Using -NewPassword with a value without providing an -OldPassword parameter value will also reset the password.
 
 ### -------------------------- EXAMPLE 3 --------------------------
 ```


### PR DESCRIPTION
#964 
Same changes made from PR #1173

Action Taken:
Removed
"You must set the OldPassword and the NewPassword parameters to set the password unless you specify the Reset parameter.
When you specify the Reset parameter, the password is set to the NewPassword value that you provide and the OldPassword parameter is not required."
In Example 1: Command will run with / without -Reset , so no added notes.
In Example 2: Added "Using -Newpassword with a value without providing an -Oldpassword parameter value will also reset the password."
Test the following cmd:
1.) Run CMd With an -OldPassword , Case sensitive with password requirements
tried several password it does not accept.
Cmd:
Set-ADAccountPassword -Identity Name -OldPassword (ConvertTo-SecureString -AsPlainText "p@ssw0rd" -Force) -NewPassword (ConvertTo-SecureString -AsPlainText "qwert@12345" -Force)
Screenshot:
https://snag.gy/fVInAi.jpg
2.) Run Cmd: Without -OldPassword , Password reset works
Cmd:
Set-ADAccountPassword -Identity Name (ConvertTo-SecureString -AsPlainText "p@ssw0rd" -Force) -NewPassword (ConvertTo-SecureString -AsPlainText "qwert@12345" -Force)
Screenshot:
https://snag.gy/fzUQDb.jpg
3.) Run CMD: With -Reset and without -Reset , both cmdlet works
Cmd:
Set-ADAccountPassword -Identity 'Name' -Reset -NewPassword (ConvertTo-SecureString -AsPlainText "p@ssw0rd" -Force)
Set-ADAccountPassword -Identity 'Name' -NewPassword (ConvertTo-SecureString -AsPlainText "p@ssw0rd" -Force)
Screenshot:
https://snag.gy/cx8nf4.jpg