### PR TITLE
Update Get-ADTrust.md

### DIFF
--- a/docset/winserver2012-ps/activedirectory/Get-ADTrust.md
+++ b/docset/winserver2012-ps/activedirectory/Get-ADTrust.md
@@ -420,3 +420,4 @@ A trusted domain object is received by the Identity parameter.
 
 ## RELATED LINKS
 
+


### PR DESCRIPTION
#1137 
Hello Team, I did not change anything on the PR/article as the "Get-ADTrust" parameter returns all the domain trusted in AD
Kindly verify if this is correct, feel free to let me know of any actions needed to take.

_Steps taken:_ 

1.) Run **Get-ADTrust -Filter*** , shows all the domain trusted by the domain configure in AD/ADDS
see screenshot: https://snipboard.io/O2Aqls.jpg

2.) **Get-ADTrust -Filter {Target -eq "domain.info"}** and **Get-ADTrust "domain.tk"**
These returns all trusted domain objects in the domain that you are querying

see screenshot: https://snipboard.io/3k4VcI.jpg
https://snipboard.io/CYQhXc.jpg