### PR TITLE
Add description for LacpTimer parameter

### DIFF
--- a/docset/windows/netlbfo/new-netlbfoteam.md
+++ b/docset/windows/netlbfo/new-netlbfoteam.md
@@ -116,7 +116,7 @@ Accept wildcard characters: False
 ```
 
 ### -LacpTimer
-{{Fill LacpTimer Description}}
+How often  inter-connected devices exchange LACP PDUs or control messages.
 
 ```yaml
 Type: LacpTimers


### PR DESCRIPTION
Add description for LacpTimer parameter in New-NetLbfoTeam. From http://blog.glinskiy.com/2013/07/lacp-timer-and-what-it-means.html