### PR TITLE
Update set-netconnectionprofile.md

### DIFF
--- a/docset/windows/netconnection/set-netconnectionprofile.md
+++ b/docset/windows/netconnection/set-netconnectionprofile.md
@@ -48,17 +48,16 @@ A connection profile represents a network connection.
 
 ### Example 1: Change the network category of a connection profile
 ```
-This first command gets the connection profile for the network adapter named Ethernet1. The command stores the results in the $Profile variable.
-PS C:\> $Profile = Get-NetConnectionProfile -InterfaceAlias Ethernet1
 
-This second command assigns the value of Public to the **NetworkCategory** property of the connection profile stored in the $Profile variable.
-PS C:\> $Profile.NetworkCategory = Public
+PS C:\> $NetworkProfile = Get-NetConnectionProfile -InterfaceAlias Ethernet1
 
-This third command sets the network category of the connection profile stored in the $Profile variable.
-PS C:\> Set-NetConnectionProfile -InputObject $Profile
+PS C:\> $NetworkProfile.NetworkCategory = Public
+
+PS C:\> Set-NetConnectionProfile -InputObject $NetworkProfile
 ```
-
-This example changes the network category of a connection profile.
+This first command gets the connection profile for the network adapter named Ethernet1. The command stores the results in the $NetworkProfile variable.
+This second command assigns the value of Public to the **NetworkCategory** property of the connection profile stored in the $NetworkProfile variable.
+This third command sets the network category of the connection profile stored in the $NetworkProfile variable.
 
 ## PARAMETERS
 


### PR DESCRIPTION
#984
*Action Taken :
Changes $Profile to $NetworkProfile variable.
Run the following:
1.) Run $Profile as a variable for the following command: works successfully
$Profile = Get-NetConnectionProfile -InterfaceAlias Ethernet
Set-NetConnectionProfile -InputObject $Profile (Just did not continue as I don't want to change my networkprofile)
See screenshot:
https://snipboard.io/CArlOe.jpg
2.) Run $NetworkProfile and $NWProfile as a variable for the following command: works successfully
$NetworkProfile = Get-NetConnectionProfile -InterfaceAlias Ethernet
$NWProfile = Get-NetConnectionProfile -InterfaceAlias Ethernet
According to the below references the $PROFILE variable is an automatic variable stores the paths to the PowerShell profiles that are available in the current session.
References:
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-6#the-profile-variable
https://docs.microsoft.com/en-us/powershell/scripting/components/ise/how-to-use-profiles-in-windows-powershell-ise?view=powershell-6