### PR TITLE
Add note about Thumbprint to example using it

### DIFF
--- a/docset/windows/remotedesktop/set-rdcertificate.md
+++ b/docset/windows/remotedesktop/set-rdcertificate.md
@@ -78,7 +78,7 @@ The following example applies an existing certificate to use with an RDS role.
 PS C:\> Set-RDCertificate -Role RDRedirector -Thumbprint fedd995b45e633d4ef30fcbc8f3a48b627e9a28b -ConnectionBroker "RDCB.Contoso.com"
 ```
 
-The first part of the example specifies the thumbprint of the certificate to use for the RD Connection Broker's redirector role, which in this example is named "RDCB.Contoso.com." The certificate must be installed in the "localmachine\my" store on each server running the specified RDS role.
+The first part of the example specifies the thumbprint of the certificate to use for the RD Connection Broker's redirector role, which in this example is named "RDCB.Contoso.com." The certificate must be installed in the "localmachine\my" store on each server running the specified RDS role. The `-Thumbprint` parameter is only available in Windows Server 2019.
 
 ## Parameters
 


### PR DESCRIPTION
A note stating the Thumbprint parameter is only available in Windows Server 2019 was added to the description of the parameter in commit d0ff4616b0c071190f91f4e6e8f78b5736ebcde5 in response to issue #1159. This commit replicates this in the example that uses the thumbprint parameter.