### PR TITLE
Replace all firstref instances with OS names

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -22,7 +22,7 @@
           "_dependentPackages/CommonPlugins/tools/PowerShellReference.ps1"
         ]
       },
-     "monikerPath": [
+      "monikerPath": [
         "mapping/monikerMapping.json"
       ]
     }
@@ -30,7 +30,7 @@
   "notification_subscribers": [],
   "sync_notification_subscribers": [],
   "branches_to_filter": [],
-  "git_repository_url_open_to_public_contributors": "https://cpubwin.visualstudio.com/_git/powershell",
+  "git_repository_url_open_to_public_contributors": "https://github.com/MicrosoftDocs/windows-powershell-docs",
   "skip_source_output_uploading": false,
   "need_preview_pull_request": false,
   "contribution_branch_mappings": {},

--- a/docset/windows/netadapter/set-netadapterrss.md
+++ b/docset/windows/netadapter/set-netadapterrss.md
@@ -55,7 +55,7 @@ Set-NetAdapterRss -InputObject <CimInstance[]> [-NumberOfReceiveQueues <UInt32>]
 ## DESCRIPTION
 The **Set-NetAdapterRss** cmdlet sets the receive side scaling (RSS) properties on a network adapter.
 RSS is a scalability technology that distributes the receive network traffic among multiple processors by hashing the header of the incoming packet.
-Without RSS in firstref_longhorn, firstref_server_7, and Windows Server® 2012; network traffic is received on the first processor which can quickly reach full utilization limiting receive network throughput.
+Without RSS in Windows Server® 2008, Windows Server® 2008 R2, and Windows Server® 2012; network traffic is received on the first processor which can quickly reach full utilization limiting receive network throughput.
 Many properties can be configured using the parameters to optimize the performance of RSS.
 The selection of the processors to use for RSS is an important aspect of load balancing.
 Most of the parameters for this cmdlet help to determine the processors used by RSS.
@@ -356,7 +356,7 @@ Specifies the RSS profile.
 
 The acceptable values for this parameter are:
 
-- Closest: Behavior is consistent with the behavior of firstref_server_7. 
+- Closest: Behavior is consistent with the behavior of Windows Server® 2008 R2. 
 - ClosestStatic: No dynamic load balancing, such as distributing but not load balancing at runtime. 
 - NUMA: Assigns RSS processors in a round robin basis across every NUMA node to enable applications that are running on NUMA servers to scale well. 
 - NUMAStatic: Default behavior.

--- a/docset/windows/netadapter/set-netadapterrss.md
+++ b/docset/windows/netadapter/set-netadapterrss.md
@@ -55,7 +55,7 @@ Set-NetAdapterRss -InputObject <CimInstance[]> [-NumberOfReceiveQueues <UInt32>]
 ## DESCRIPTION
 The **Set-NetAdapterRss** cmdlet sets the receive side scaling (RSS) properties on a network adapter.
 RSS is a scalability technology that distributes the receive network traffic among multiple processors by hashing the header of the incoming packet.
-Without RSS in Windows Server® 2008, Windows Server® 2008 R2, and Windows Server® 2012; network traffic is received on the first processor which can quickly reach full utilization limiting receive network throughput.
+If RSS is disabled, network traffic is processed on a single processor core. This may impact network performance as the processor utilization increases.
 Many properties can be configured using the parameters to optimize the performance of RSS.
 The selection of the processors to use for RSS is an important aspect of load balancing.
 Most of the parameters for this cmdlet help to determine the processors used by RSS.


### PR DESCRIPTION
This documentation contained several references to codenames - replaced these with the OS's official release names. 