### PR TITLE
Update set-adfsproperties.md with corrupt/missing EnableOAuthDeviceFlow Parameter details

### DIFF
--- a/docset/windows/adfs/set-adfsproperties.md
+++ b/docset/windows/adfs/set-adfsproperties.md
@@ -493,7 +493,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### - EnableOAuthDeviceFlow
+### -EnableOAuthDeviceFlow
 Enables the OAuth Device Flow.
 
 ```yaml

--- a/docset/windows/adfs/set-adfsproperties.md
+++ b/docset/windows/adfs/set-adfsproperties.md
@@ -33,7 +33,7 @@ Set-AdfsProperties [-AuthenticationContextOrder <Uri[]>] [-AcceptableIdentifiers
  [-CertificateGenerationThreshold <Int32>] [-CertificatePromotionThreshold <Int32>]
  [-CertificateRolloverInterval <Int32>] [-CertificateThresholdMultiplier <Int32>]
  [-ClientCertRevocationCheck <String>] [-ContactPerson <ContactPerson>] [-DisplayName <String>]
- [-EnableEnableOAuthDeviceFlow M\]
+ [-EnableOAuthDeviceFlow <Boolean>]
  [-EnableOAuthLogout <Boolean>] [-FederationPassiveAddress <String>] [-HostName <String>] [-HttpPort <Int32>]
  [-HttpsPort <Int32>] [-IntranetUseLocalClaimsProvider <Boolean>] [-TlsClientPort <Int32>] [-Identifier <Uri>]
  [-LogLevel <String[]>] [-MonitoringInterval <Int32>] [-NetTcpPort <Int32>]
@@ -480,6 +480,21 @@ Accept wildcard characters: False
 Indicates whether to enable loop detection.
 Loops occur when a relying party continuously rejects a valid security token and redirects back to AD FS.
 The cycle terminates after 6 loops have been detected.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### - EnableOAuthDeviceFlow
+Enables the OAuth device flow.
 
 ```yaml
 Type: Boolean

--- a/docset/windows/adfs/set-adfsproperties.md
+++ b/docset/windows/adfs/set-adfsproperties.md
@@ -494,7 +494,7 @@ Accept wildcard characters: False
 ```
 
 ### - EnableOAuthDeviceFlow
-Enables the OAuth device flow.
+Enables the OAuth Device Flow.
 
 ```yaml
 Type: Boolean


### PR DESCRIPTION
The `Set-AdfsProperties` document page has a corrupted version of the `EnableOAuthDeviceFlow` parameter in its parameter list, and is also missing the parameter details for this.