### PR TITLE
"Name" is not a valid parameter for this command.

### DIFF
--- a/docset/windows/failoverclusters/set-clusterownernode.md
+++ b/docset/windows/failoverclusters/set-clusterownernode.md
@@ -38,7 +38,7 @@ The settings that control the possible or preferred owners affect the way the cl
 
 ### Example 1
 ```
-PS C:\> Get-ClusterResource -Name "Cluster Disk 3" | Set-ClusterOwnerNode -Owners node1,node2
+PS C:\> Get-ClusterResource -Resource "Cluster Virtual Disk (Volume03)" | Set-ClusterOwnerNode -Owners node1,node2
 ```
 
 This example sets the possible owners for cluster named Cluster Disk 3 on the local cluster to the nodes named node1 and node2.


### PR DESCRIPTION
When attempting to run the command as specified the following error is displayed.  Parameter should be "Resource" rather than "Name":

```
PS C:\Windows\system32> Get-ClusterOwnerNode -Name "Cluster Virtual Disk (Volume03)"
Get-ClusterOwnerNode : A parameter cannot be found that matches parameter name 'Name'.
At line:1 char:22
+ Get-ClusterOwnerNode -Name "Cluster Virtual Disk (Volume03)"
+                      ~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Get-ClusterOwnerNode], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.FailoverClusters.PowerShell.GetClusterOwnerNodeCommand
```