### PR TITLE
Update SetDnsServerDiagnostics.md EventLogLevel Description

### DIFF
--- a/docset/windows/dnsserver/Set-DnsServerDiagnostics.md
+++ b/docset/windows/dnsserver/Set-DnsServerDiagnostics.md
@@ -419,7 +419,15 @@ Accept wildcard characters: False
 
 ### -EventLogLevel
 Specifies an event log level.
-Valid values are Warning, Error, and None.
+Valid values are:
+
+0: No Events
+
+1: Errors Only
+
+2: Errors and warnings
+
+7: All Events
 
 ```yaml
 Type: UInt32

--- a/docset/windows/dnsserver/Set-DnsServerDiagnostics.md
+++ b/docset/windows/dnsserver/Set-DnsServerDiagnostics.md
@@ -427,7 +427,7 @@ Valid values are:
 
 - 2: Errors and warnings
 
-7: All Events
+- 3-7: All Events
 
 ```yaml
 Type: UInt32

--- a/docset/windows/dnsserver/Set-DnsServerDiagnostics.md
+++ b/docset/windows/dnsserver/Set-DnsServerDiagnostics.md
@@ -421,7 +421,7 @@ Accept wildcard characters: False
 Specifies an event log level.
 Valid values are:
 
-0: No Events
+- 0: No Events
 
 1: Errors Only
 

--- a/docset/windows/dnsserver/Set-DnsServerDiagnostics.md
+++ b/docset/windows/dnsserver/Set-DnsServerDiagnostics.md
@@ -423,7 +423,7 @@ Valid values are:
 
 - 0: No Events
 
-1: Errors Only
+- 1: Errors Only
 
 2: Errors and warnings
 

--- a/docset/windows/dnsserver/Set-DnsServerDiagnostics.md
+++ b/docset/windows/dnsserver/Set-DnsServerDiagnostics.md
@@ -425,7 +425,7 @@ Valid values are:
 
 - 1: Errors Only
 
-2: Errors and warnings
+- 2: Errors and warnings
 
 7: All Events
 


### PR DESCRIPTION
EventLogLevel is of type `UInt32`, so won't accept the string values that are currently specified.

Updated the description to include the correct numerical values mapped to the options available on the `Event Logging` tab of the DNS Manager interface.