### PR TITLE
Fix Markdown formatting for CimSession links

### DIFF
--- a/docset/winserver2012r2-ps/msdtc/Get-DtcLog.md
+++ b/docset/winserver2012r2-ps/msdtc/Get-DtcLog.md
@@ -81,7 +81,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a New-CimSessionhttp://go.microsoft.com/fwlink/p/?LinkId=227967 or Get-CimSessionhttp://go.microsoft.com/fwlink/p/?LinkId=227966 cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2012r2-ps/msdtc/Get-DtcLog.md
+++ b/docset/winserver2012r2-ps/msdtc/Get-DtcLog.md
@@ -81,7 +81,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2012r2-ps/msdtc/Get-DtcTransaction.md
+++ b/docset/winserver2012r2-ps/msdtc/Get-DtcTransaction.md
@@ -73,7 +73,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2012r2-ps/msdtc/Get-DtcTransaction.md
+++ b/docset/winserver2012r2-ps/msdtc/Get-DtcTransaction.md
@@ -73,7 +73,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a New-CimSessionhttp://go.microsoft.com/fwlink/p/?LinkId=227967 or Get-CimSessionhttp://go.microsoft.com/fwlink/p/?LinkId=227966 cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml


### PR DESCRIPTION
@traya1 Addressing your comment at https://github.com/MicrosoftDocs/windows-powershell-docs/pull/1476#issuecomment-539727410 and https://github.com/MicrosoftDocs/windows-powershell-docs/pull/1477#issuecomment-539728490

_Note: The broken links in the format as fixed in this PR are known to be widespread across the repository and a mass-fix has been planned._

Thanks.