### PR TITLE
Update Install-AdfsFarm and Add-AdfsFarmNode

### DIFF
--- a/docset/windows/adfs/Add-AdfsFarmNode.md
+++ b/docset/windows/adfs/Add-AdfsFarmNode.md
@@ -124,7 +124,7 @@ Accept wildcard characters: False
 ```
 
 ### -GroupServiceAccountIdentifier
-Specifies the firstref_adds Group Managed Service Account under which the Active Directory Federation Services (AD FS) service runs.
+Specifies the Group Managed Service Account under which the Active Directory Federation Services (AD FS) service runs.
 
 ```yaml
 Type: String

--- a/docset/windows/adfs/Install-AdfsFarm.md
+++ b/docset/windows/adfs/Install-AdfsFarm.md
@@ -245,7 +245,7 @@ Accept wildcard characters: False
 ```
 
 ### -GroupServiceAccountIdentifier
-Specifies the firstref_adds Group Managed Service Account under which the Active Directory Federation Services (AD FS) service runs.
+Specifies the Group Managed Service Account under which the Active Directory Federation Services (AD FS) service runs.
 
 ```yaml
 Type: String

--- a/docset/winserver2012r2-ps/adfs/Add-AdfsFarmNode.md
+++ b/docset/winserver2012r2-ps/adfs/Add-AdfsFarmNode.md
@@ -133,7 +133,7 @@ Accept wildcard characters: False
 ```
 
 ### -GroupServiceAccountIdentifier
-Specifies the firstref_adds Group Managed Service Account under which the Active Directory Federation Services (AD FS) service runs.
+Specifies the Group Managed Service Account under which the Active Directory Federation Services (AD FS) service runs.
 
 ```yaml
 Type: String

--- a/docset/winserver2012r2-ps/adfs/Install-AdfsFarm.md
+++ b/docset/winserver2012r2-ps/adfs/Install-AdfsFarm.md
@@ -260,7 +260,7 @@ Accept wildcard characters: False
 ```
 
 ### -GroupServiceAccountIdentifier
-Specifies the firstref_adds Group Managed Service Account under which the Active Directory Federation Services (AD FS) service runs.
+Specifies the Group Managed Service Account under which the Active Directory Federation Services (AD FS) service runs.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Remove spurious 'firstref_adds' text from the `GroupServiceAccountIdentifier` parameter description of the `Install-AdfsFarm` and `Add-AdfsFarmNode` cmdlets of the ADFS module.