### PR TITLE
Update Get-AdfsGlobalWebContent

### DIFF
--- a/docset/windows/adfs/Get-AdfsGlobalWebContent.md
+++ b/docset/windows/adfs/Get-AdfsGlobalWebContent.md
@@ -115,7 +115,6 @@ The object includes the following properties:
 - ErrorPageAuthorizationErrorMessage: **System.String**
 - ErrorPageDeviceAuthenticationErrorMessage: **System.String**
 - ErrorPageSupportEmail: **System.String**
-- ErrorPageSupportEmailText: **System.String**
 - UpdatePasswordPageDescriptionText: **System.String**
 - CertificatePageDescriptionText: **System.String**
 - SignInPageAdditionalAuthenticationDescriptionText: **System.String**


### PR DESCRIPTION
This PR removes the `ErrorPageSupportEmailText` property from the output object, as it does not exist.