### PR TITLE
DNSServer: Remove Blank Lines from Example Output

### DIFF
--- a/docset/windows/dnsserver/Add-DnsServerConditionalForwarderZone.md
+++ b/docset/windows/dnsserver/Add-DnsServerConditionalForwarderZone.md
@@ -49,11 +49,10 @@ Conditional forwarders are stored as zones on a DNS server.
 
 ### Example 1: Create a non-Active Directory-integrated forwarder
 ```
-PS C:\> Add-DnsServerConditionalForwarderZone -Name "contoso.com" -MasterServers 2001:4898:7020:f100:458f:e6a2:fcaf:698c,172.23.90.124 -PassThru 
+PS C:\> Add-DnsServerConditionalForwarderZone -Name "contoso.com" -MasterServers 2001:4898:7020:f100:458f:e6a2:fcaf:698c,172.23.90.124 -PassThru
+
 ZoneName                            ZoneType        IsAutoCreated   IsDsIntegrated  IsReverseLookupZone  IsSigned
-
 --------                            --------        -------------   --------------  -------------------  --------
-
 contoso.com                         Forwarder       False           False           False
 ```
 

--- a/docset/windows/dnsserver/Add-DnsServerPrimaryZone.md
+++ b/docset/windows/dnsserver/Add-DnsServerPrimaryZone.md
@@ -78,11 +78,10 @@ This command creates a file-backed primary forward lookup zone called west02.con
 
 ### Example 3: Create a reverse lookup zone
 ```
-PS C:\> Add-DnsServerPrimaryZone -NetworkID "10.1.0.0/24" -ReplicationScope "Forest" 
+PS C:\> Add-DnsServerPrimaryZone -NetworkID "10.1.0.0/24" -ReplicationScope "Forest"
+
 ZoneName                            ZoneType        IsAutoCreated   IsDsIntegrated  IsReverseLookupZone  IsSigned
-
 --------                            --------        -------------   --------------  -------------------  --------
-
 1.10.in-addr.arpa                   Primary         False           True            True                 False
 ```
 

--- a/docset/windows/dnsserver/Add-DnsServerResourceRecord.md
+++ b/docset/windows/dnsserver/Add-DnsServerResourceRecord.md
@@ -230,18 +230,11 @@ It specifies a TTL value and enables a time stamp for the record.
 
 ### Example 2: Add an A resource record under the Admin node
 ```
-PS C:\> Add-DnsServerResourceRecord -ZoneName "Contoso.com" -A -Name "Host21.admin" -IPv4Address "10.17.1.21" 
-VERBOSE: Adding DNS resource record host21.admin of type A in zone contoso.com on ROOT server. 
-VERBOSE: Adding DNS resource record host21.admin of type A in zone contoso.com on ROOT server. 
+PS C:\> Add-DnsServerResourceRecord -ZoneName "Contoso.com" -A -Name "Host21.admin" -IPv4Address "10.17.1.21"
+
+VERBOSE: Adding DNS resource record host21.admin of type A in zone contoso.com on ROOT server.
 HostName                  RecordType Timestamp            TimeToLive      RecordData
-
 --------                  ---------- ---------            ----------      ----------
-
-host21.admin              A          0                    01:00:00        10.17.1.74
-HostName                  RecordType Timestamp            TimeToLive      RecordData
-
---------                  ---------- ---------            ----------      ----------
-
 host21.admin              A          0                    01:00:00        10.17.1.74
 ```
 

--- a/docset/windows/dnsserver/ConvertTo-DnsServerPrimaryZone.md
+++ b/docset/windows/dnsserver/ConvertTo-DnsServerPrimaryZone.md
@@ -48,12 +48,11 @@ For a file-backed zone, ensure there is only one server that hosts the primary z
 
 ### Example 1: Convert a file-backed zone
 ```
-PS C:\> ConvertTo-DnsServerPrimaryZone -Name "west03.contoso.com" -PassThru -Verbose -ZoneFile "west03.contoso.com" -Force 
+PS C:\> ConvertTo-DnsServerPrimaryZone -Name "west03.contoso.com" -PassThru -Verbose -ZoneFile "west03.contoso.com" -Force
+
 VERBOSE: Convert west03.contoso.com zone to (file backed/AD integrated) DNS primary zone on DNS-11 server.
 ZoneName                            ZoneType        IsAutoCreated   IsDsIntegrated  IsReverseLookupZone  IsSigned
-
 --------                            --------        -------------   --------------  -------------------  --------
-
 west03.contoso.com                  Primary         False           False           False                False
 ```
 

--- a/docset/windows/dnsserver/Get-DnsServerCache.md
+++ b/docset/windows/dnsserver/Get-DnsServerCache.md
@@ -38,16 +38,12 @@ The **Get-DnsServerCache** cmdlet retrieves the following Domain Name System (DN
 ### Example 1: Get DNS server cache properties
 ```
 PS C:\> Get-DnsServerCache -ComputerName "Win12S-05.DNSServer-01.Contoso.com"
+
 MaxTTL                           : 1.00:00:00
-
 MaxNegativeTTL                   : 00:15:00
-
 MaxKBSize                        : 10240
-
 EnablePollutionProtection        : True
-
 LockingPercent                   : 100
-
 StoreEmptyAuthenticationResponse : True
 ```
 

--- a/docset/windows/dnsserver/Get-DnsServerDiagnostics.md
+++ b/docset/windows/dnsserver/Get-DnsServerDiagnostics.md
@@ -38,60 +38,34 @@ The **Get-DnsServerDiagnostics** cmdlet retrieves Domain Name System (DNS) serve
 ### Example 1: Get DNS event logging details
 ```
 PS C:\> Get-DnsServerDiagnostics
+
 SaveLogsToPersistentStorage          : False
-
 Queries                              : False
-
 Answers                              : False
-
 Notifications                        : False
-
 Update                               : False
-
 QuestionTransactions                 : False
-
 UnmatchedResponse                    : False
-
 SendPackets                          : False
-
 ReceivePackets                       : False
-
 TcpPackets                           : False
-
 UdpPackets                           : False
-
 FullPackets                          : False
-
 FilterIPAddressList                  :
-
 EventLogLevel                        : 4
-
 UseSystemEventLog                    : False
-
 EnableLoggingToFile                  : True
-
 EnableLogFileRollover                : False
-
 LogFilePath                          :
-
 MaxMBFileSize                        : 500000000
-
 WriteThrough                         : False
-
 EnableLoggingForLocalLookupEvent     : False
-
 EnableLoggingForPluginDllEvent       : False
-
 EnableLoggingForRecursiveLookupEvent : False
-
 EnableLoggingForRemoteServerEvent    : False
-
 EnableLoggingForServerStartStopEvent : False
-
 EnableLoggingForTombstoneEvent       : False
-
 EnableLoggingForZoneDataWriteEvent   : False
-
 EnableLoggingForZoneLoadingEvent     : False
 ```
 

--- a/docset/windows/dnsserver/Get-DnsServerDirectoryPartition.md
+++ b/docset/windows/dnsserver/Get-DnsServerDirectoryPartition.md
@@ -45,12 +45,10 @@ The **Get-DnsServerDirectoryPartition** cmdlet gets one or more Domain Name Syst
 ### Example 1: Get all DNS application directory partitions
 ```
 PS C:\> Get-DnsServerDirectoryPartition
+
 server.DirectoryPartitionName        State                         Flags                         ZoneCount
-
 -----------------------------        -----                         -----                         ---------
-
 DomainDnsZones.mytest.cont...        0(DNS_DP_OKAY)                Enlisted Auto Domain          3
-
 ForestDnsZones.mytest.cont...        0(DNS_DP_OKAY)                Enlisted Auto Forest          2
 ```
 
@@ -59,10 +57,9 @@ This command gets all the DNS application directory partitions on the local comp
 ### Example 2: Get all custom application directory partitions
 ```
 PS C:\> Get-DnsServerDirectoryPartition -Custom
+
 DirectoryPartitionName        State                         Flags                         ZoneCount
-
 ----------------------        -----                         -----                         ---------
-
 DomainDnsZones.mytest.cont... 0(DNS_DP_OKAY)                Enlisted Auto Domain          3
 ```
 

--- a/docset/windows/dnsserver/Get-DnsServerDsSetting.md
+++ b/docset/windows/dnsserver/Get-DnsServerDsSetting.md
@@ -38,16 +38,12 @@ The **Get-DnsServerDsSetting** cmdlet retrieves the following Domain Name System
 ### Example 1: Get Active Directory service settings
 ```
 PS C:\> Get-DnsServerDsSetting
+
 PollingInterval(s)                   : 180
-
 TombstoneInterval                    : 14.00:00:00
-
 DirectoryPartitionAutoEnlistInterval : 1.00:00:00
-
 LazyUpdateInterval(s)                : 3
-
 MinimumBackgroundLoadThreads         : 1
-
 RemoteReplicationDelay(s)            : 30
 ```
 

--- a/docset/windows/dnsserver/Get-DnsServerRecursion.md
+++ b/docset/windows/dnsserver/Get-DnsServerRecursion.md
@@ -39,14 +39,11 @@ Recursion occurs when a DNS server queries other DNS servers on behalf of a requ
 ### Example 1: Get DNS server recursion settings
 ```
 PS C:\> Get-DnsServerRecursion
+
 Enable               : False
-
 AdditionalTimeout(s) : 4
-
 RetryInterval(s)     : 15
-
 Timeout(s)           : 8
-
 SecureResponse       : True
 ```
 

--- a/docset/windows/dnsserver/Get-DnsServerSetting.md
+++ b/docset/windows/dnsserver/Get-DnsServerSetting.md
@@ -46,146 +46,77 @@ To get advanced DNS server settings, use the *All* parameter.
 ### Example 1: Get all DNS server settings
 ```
 PS C:\> Get-DnsServerSetting -All
+
 ComputerName                            : WIN-OLPN33S5Q3M.mytest.contoso.com
-
 MajorVersion                            : 6
-
 MinorVersion                            : 2
-
 BuildNumber                             : 8230
-
 IsReadOnlyDC                            : False
-
 EnableDnsSec                            : True
-
 EnableIPv6                              : True
-
 EnableOnlineSigning                     : True
-
 NameCheckFlag                           : 2
-
 AddressAnswerLimit                      : 0
-
 XfrConnectTimeout(s)                    : 30
-
 BootMethod                              : 3
-
 AllowUpdate                             : True
-
 UpdateOptions                           : 783
-
 DsAvailable                             : True
-
 DisableAutoReverseZone                  : False
-
 AutoCacheUpdate                         : False
-
 RoundRobin                              : True
-
 LocalNetPriority                        : True
-
 StrictFileParsing                       : False
-
 LooseWildcarding                        : False
-
 BindSecondaries                         : False
-
 WriteAuthorityNS                        : False
-
 ForwardDelegations                      : False
-
 AutoConfigFileZones                     : 1
-
 EnableDirectoryPartitions               : True
-
 RpcProtocol                             : 5
-
 EnableVersionQuery                      : 0
-
 EnableDuplicateQuerySuppression         : True
-
 LameDelegationTTL                       : 00:00:00
-
 AutoCreateDelegation                    : 2
-
 AllowCnameAtNs                          : True
-
 RemoteIPv4RankBoost                     : 5
-
 RemoteIPv6RankBoost                     : 0
-
 EnableRsoForRodc                        : True
-
 MaximumRodcRsoQueueLength               : 300
-
 MaximumRodcRsoAttemptsPerCycle          : 100
-
 OpenAclOnProxyUpdates                   : True
-
 NoUpdateDelegations                     : False
-
 EnableUpdateForwarding                  : False
-
 MaxResourceRecordsInNonSecureUpdate     : 30
-
 EnableWinsR                             : True
-
 LocalNetPriorityMask                    : 255
-
 DeleteOutsideGlue                       : False
-
 AppendMsZoneTransferTag                 : False
-
 AllowReadOnlyZoneTransfer               : False
-
 MaximumUdpPacketSize                    : 4000
-
 TcpReceivePacketSize                    : 65536
-
 EnableSendErrorSuppression              : True
-
 SelfTest                                : 4294967295
-
 XfrThrottleMultiplier                   : 10
-
 SilentlyIgnoreCnameUpdateConflicts      : False
-
 EnableIQueryResponseGeneration          : False
-
 SocketPoolSize                          : 2500
-
 AdminConfigured                         : True
-
 SocketPoolExcludedPortRanges            : {}
-
 ForestDirectoryPartitionBaseName        : ForestDnsZones
-
 DomainDirectoryPartitionBaseName        : DomainDnsZones
-
 ServerLevelPluginDll                    :
-
 EnableRegistryBoot                      :
-
 PublishAutoNet                          : False
-
 QuietRecvFaultInterval(s)               : 0
-
 QuietRecvLogInterval(s)                 : 0
-
 ReloadException                         : False
-
 SyncDsZoneSerial                        : 2
-
 EnableDuplicateQuerySuppression         : True
-
 SendPort                                : Random
-
 MaximumSignatureScanPeriod              : 2.00:00:00
-
 MaximumTrustAnchorActiveRefreshInterval : 15.00:00:00
-
 ListeningIPAddress                      : {172.23.90.136}
-
 AllIPAddress                            : {172.23.90.136}
 ```
 

--- a/docset/windows/dnsserver/Remove-DnsServerResourceRecord.md
+++ b/docset/windows/dnsserver/Remove-DnsServerResourceRecord.md
@@ -67,10 +67,9 @@ This command removes all root hints for a DNS server.
 ### Example 2: Remove multiple A records
 ```
 PS C:\> Remove-DnsServerResourceRecord -ZoneName "contoso.com" -RRType "A" -Name "Host01"
+
 Confirm
-
 Removing DNS resource record Host01 of type A from zone contoso.com on ROOT server. Do you want to continue?
-
 [Y] Yes  [N] No  [S] Suspend  [?] Help (default is "Y"): n
 ```
 

--- a/docset/windows/dnsserver/Set-DnsServerDsSetting.md
+++ b/docset/windows/dnsserver/Set-DnsServerDsSetting.md
@@ -43,16 +43,12 @@ It must continue to set other operations and display the modified settings.
 ### Example 1: Set an auto-enlist interval for a directory partition
 ```
 PS C:\> Set-DnsServerDsSetting -DirectoryPartitionAutoEnlistInterval 15.00:00:00 -PassThru
+
 PollingInterval(s)                   : 180
-
 TombstoneInterval                    : 14.00:00:00
-
 DirectoryPartitionAutoEnlistInterval : 15.00:00:00
-
 LazyUpdateInterval(s)                : 3
-
 MinimumBackgroundLoadThreads         : 1
-
 RemoteReplicationDelay(s)            : 30
 ```
 

--- a/docset/windows/dnsserver/Set-DnsServerPrimaryZone.md
+++ b/docset/windows/dnsserver/Set-DnsServerPrimaryZone.md
@@ -59,9 +59,7 @@ You can change values that are relevant for either Active Directory-integrated z
 PS C:\> Set-DnsServerPrimaryZone -Name "western.contoso.com" -DynamicUpdate "NonsecureAndSecure" -PassThru
 
 ZoneName                            ZoneType        IsAutoCreated   IsDsIntegrated  IsReverseLookupZone  IsSigned
-
 --------                            --------        -------------   --------------  -------------------  --------
-
 western.contoso.com                 Primary         False           True            False                False
 ```
 
@@ -73,9 +71,7 @@ The example uses the *PassThru* parameter to return output.
 PS C:\> Set-DnsServerPrimaryZone -Name "western.contoso.com" -ReplicationScope "Forest" -PassThru
 
 ZoneName                            ZoneType        IsAutoCreated   IsDsIntegrated  IsReverseLookupZone  IsSigned
-
 --------                            --------        -------------   --------------  -------------------  --------
-
 western.contoso.com                 Primary         False           True            False                False
 ```
 
@@ -87,9 +83,7 @@ The example uses the *PassThru* parameter to return output.
 PS C:\> Set-DnsServerPrimaryZone -Name "western.contoso.com" -ZoneFile "tet23.dns" -PassThru
 
 ZoneName                            ZoneType        IsAutoCreated   IsDsIntegrated  IsReverseLookupZone  IsSigned
-
 --------                            --------        -------------   --------------  -------------------  --------
-
 western.contoso.com                 Primary         False           False           False                False
 ```
 

--- a/docset/windows/dnsserver/Set-DnsServerRecursion.md
+++ b/docset/windows/dnsserver/Set-DnsServerRecursion.md
@@ -42,13 +42,9 @@ Recursion occurs when a DNS server queries other DNS servers on behalf of a requ
 PS C:\> Set-DnsServerRecursion -RetryInterval 3 -PassThru
 
 Enable               : False
-
 AdditionalTimeout(s) : 4
-
 RetryInterval(s)     : 15
-
 Timeout(s)           : 8
-
 SecureResponse       : True
 ```
 

--- a/docset/windows/dnsserver/Set-DnsServerResourceRecord.md
+++ b/docset/windows/dnsserver/Set-DnsServerResourceRecord.md
@@ -47,9 +47,7 @@ PS C:\> $NewObj.TimeToLive = [System.TimeSpan]::FromHours(2)
 PS C:\> Set-DnsServerResourceRecord -NewInputObject $NewObj -OldInputObject $OldObj -ZoneName "contoso.com" -PassThru
 
 HostName                  RecordType Timestamp            TimeToLive      RecordData
-
 --------                  ---------- ---------            ----------      ----------
-
 Host01                       A          0                    02:00:00        2.2.2.2
 ```
 

--- a/docset/windows/dnsserver/Set-DnsServerStubZone.md
+++ b/docset/windows/dnsserver/Set-DnsServerStubZone.md
@@ -60,9 +60,7 @@ This command changes the master servers for a stub zone named west03.contoso.com
 PS C:\> Set-DnsServerStubZone  -Name "west04.contoso.com" -ReplicationScope "Domain" -PassThru
 
 ZoneName                            ZoneType        IsAutoCreated   IsDsIntegrated  IsReverseLookupZone  IsSigned
-
 --------                            --------        -------------   --------------  -------------------  --------
-
 west04.contoso.com                  Stub            False           True            False
 ```
 

--- a/docset/windows/dnsserver/Show-DnsServerCache.md
+++ b/docset/windows/dnsserver/Show-DnsServerCache.md
@@ -40,29 +40,17 @@ The **Show-DNSServerCache** cmdlet shows all cached Domain Name System (DNS) ser
 PS C:\> Show-DnsServerCache -ComputerName "Win12S-05.DNSServer-01.Contoso.com"
 
 HostName                  RecordType Timestamp            TimeToLive      RecordData
-
 --------                  ---------- ---------            ----------      ----------
-
 @                         NS         0                    00:00:00        a.root-servers.net.
-
 @                         NS         0                    00:00:00        b.root-servers.net.
-
 @                         NS         0                    00:00:00        c.root-servers.net.
-
 @                         NS         0                    00:00:00        d.root-servers.net.
-
 @                         NS         0                    00:00:00        e.root-servers.net.
-
 @                         NS         0                    00:00:00        f.root-servers.net.
-
-@                         NS         0                    00:00:00        g.root- 
-
+@                         NS         0                    00:00:00        g.root-
 Win12S-05.DNSServer-01.... A          0                    00:46:48        172.23.90.136
-
 localhost                 A          0                    17089.09:29:04  127.0.0.1
-
 a.root-servers.net        A          0                    00:00:00        198.41.0.4
-
 b.root-servers.net        A          0                    00:00:00
 ```
 


### PR DESCRIPTION
This PR removes all the blank lines from within the example output blocks of the DNS server cmdlet documentation.

It also removes the duplicated output on the `Add-DnsServerResourceRecord` document.