### PR TITLE
Adfs Module: Improve Inputs and Outputs for the AdfsClient Cmdlets

### DIFF
--- a/docset/windows/adfs/Add-AdfsClient.md
+++ b/docset/windows/adfs/Add-AdfsClient.md
@@ -321,10 +321,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 String objects are received by the *ClientId*, *Description*, *Name*, and *RedirectUri* parameters.
 
-### System.Uri
-
-Uri objects are received by the AcceptanceTransformRules parameter.
-
 ## OUTPUTS
 
 ### Microsoft.IdentityServer.Management.Resources.AdfsClient

--- a/docset/windows/adfs/Add-AdfsClient.md
+++ b/docset/windows/adfs/Add-AdfsClient.md
@@ -325,7 +325,7 @@ String objects are received by the *ClientId*, *Description*, *Name*, and *Redir
 
 ### Microsoft.IdentityServer.Management.Resources.AdfsClient
 
-Returns the new AdfsClient object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
+Returns the new AdfsClient object when the *PassThru* parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Add-AdfsClient.md
+++ b/docset/windows/adfs/Add-AdfsClient.md
@@ -329,7 +329,7 @@ Uri objects are received by the AcceptanceTransformRules parameter.
 
 ### Microsoft.IdentityServer.Management.Resources.AdfsClient
 
-Returns the new AdafsClient object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
+Returns the new AdfsClient object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Add-AdfsClient.md
+++ b/docset/windows/adfs/Add-AdfsClient.md
@@ -317,11 +317,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### string, string, uri[], string
+### System.String
+
+String objects are received by the *ClientId*, *Description*, *Name*, and *RedirectUri* parameters.
+
+### System.Uri
+
+Uri objects are received by the AcceptanceTransformRules parameter.
 
 ## OUTPUTS
 
-### System.Object
+### Microsoft.IdentityServer.Management.Resources.AdfsClient
+
+Returns the new AdafsClient object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Disable-AdfsClient.md
+++ b/docset/windows/adfs/Disable-AdfsClient.md
@@ -153,7 +153,15 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### System.String
+
+String objects are received by the *TargetClient*, *TargetClientId*, and *TargetName* parameters.
+
 ## OUTPUTS
+
+### Microsoft.IdentityServer.Management.Resources.AdfsClient
+
+Returns the disabled AdfsClient object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Disable-AdfsClient.md
+++ b/docset/windows/adfs/Disable-AdfsClient.md
@@ -153,9 +153,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### Microsoft.IdentityServer.Management.Resources.AdfsClient
+
+AdfsClient objects are received by the *TargetClient* parameter.
+
 ### System.String
 
-String objects are received by the *TargetClient*, *TargetClientId*, and *TargetName* parameters.
+String objects are received by the *TargetClientId* and *TargetName* parameters.
 
 ## OUTPUTS
 

--- a/docset/windows/adfs/Disable-AdfsClient.md
+++ b/docset/windows/adfs/Disable-AdfsClient.md
@@ -165,7 +165,7 @@ String objects are received by the *TargetClientId* and *TargetName* parameters.
 
 ### Microsoft.IdentityServer.Management.Resources.AdfsClient
 
-Returns the disabled AdfsClient object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
+Returns the disabled AdfsClient object when the *PassThru* parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Enable-AdfsClient.md
+++ b/docset/windows/adfs/Enable-AdfsClient.md
@@ -166,7 +166,7 @@ String objects are received by the *TargetClientId* and *TargetName* parameters.
 
 ### Microsoft.IdentityServer.Management.Resources.AdfsClient
 
-Returns the enabled AdfsClient object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
+Returns the enabled AdfsClient object when the *PassThru* parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Enable-AdfsClient.md
+++ b/docset/windows/adfs/Enable-AdfsClient.md
@@ -154,7 +154,15 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### System.String
+
+String objects are received by the *TargetClient*, *TargetClientId*, and *TargetName* parameters.
+
 ## OUTPUTS
+
+### Microsoft.IdentityServer.Management.Resources.AdfsClient
+
+Returns the enabled AdfsClient object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Enable-AdfsClient.md
+++ b/docset/windows/adfs/Enable-AdfsClient.md
@@ -154,9 +154,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### Microsoft.IdentityServer.Management.Resources.AdfsClient
+
+AdfsClient objects are received by the *TargetClient* parameter.
+
 ### System.String
 
-String objects are received by the *TargetClient*, *TargetClientId*, and *TargetName* parameters.
+String objects are received by the *TargetClientId* and *TargetName* parameters.
 
 ## OUTPUTS
 

--- a/docset/windows/adfs/Get-AdfsClient.md
+++ b/docset/windows/adfs/Get-AdfsClient.md
@@ -157,9 +157,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### System.String
+
+String objects are received by the *ClientId* and *Name* parameters.
+
+### Microsoft.IdentityServer.Management.Resources.AdfsClient
+
+AdfsClient objects are received by the *InputObject* parameter.
+
 ## OUTPUTS
 
-### System.Object
+### Microsoft.IdentityServer.Management.Resources.AdfsClient
+
+Returns one or more AdfsClient objects that represent the Adfs Clients for the Federation Service.
 
 ## NOTES
 

--- a/docset/windows/adfs/Remove-AdfsClient.md
+++ b/docset/windows/adfs/Remove-AdfsClient.md
@@ -153,9 +153,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### Microsoft.IdentityServer.Management.Resources.AdfsClient
+
+AdfsClient objects are received by the *TargetClient* parameter.
+
 ### System.String
 
-String objects are received by the *TargetClient*, *TargetClientId*, and *TargetName* parameters.
+String objects are received by the *TargetClientId* and *TargetName* parameters.
 
 ## OUTPUTS
 

--- a/docset/windows/adfs/Remove-AdfsClient.md
+++ b/docset/windows/adfs/Remove-AdfsClient.md
@@ -165,7 +165,7 @@ String objects are received by the *TargetClientId* and *TargetName* parameters.
 
 ### Microsoft.IdentityServer.Management.Resources.AdfsClient
 
-Returns the deleted AdfsClient object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
+Returns the deleted AdfsClient object when the *PassThru* parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Remove-AdfsClient.md
+++ b/docset/windows/adfs/Remove-AdfsClient.md
@@ -153,9 +153,15 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### System.String
+
+String objects are received by the *TargetClient*, *TargetClientId*, and *TargetName* parameters.
+
 ## OUTPUTS
 
-### System.Object
+### Microsoft.IdentityServer.Management.Resources.AdfsClient
+
+Returns the deleted AdfsClient object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Set-AdfsClient.md
+++ b/docset/windows/adfs/Set-AdfsClient.md
@@ -412,7 +412,7 @@ String objects are received by the *ClientId*, *Description*, *Name*, *RedirectU
 
 ### Microsoft.IdentityServer.Management.Resources.AdfsClient
 
-Returns the updated AdfsClient object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
+Returns the updated AdfsClient object when the *PassThru* parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Set-AdfsClient.md
+++ b/docset/windows/adfs/Set-AdfsClient.md
@@ -400,9 +400,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### Microsoft.IdentityServer.Management.Resources.AdfsClient
+
+AdfsClient objects are received by the *TargetClient* parameter.
+
+### System.String
+
+String objects are received by the *ClientId*, *Description*, *Name*, *RedirectUri*, *TargetClientId*, and *TargetName* parameters.
+
 ## OUTPUTS
 
-### System.Object
+### Microsoft.IdentityServer.Management.Resources.AdfsClient
+
+Returns the updated AdfsClient object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 


### PR DESCRIPTION
This PR improves the descriptions for the Inputs and Outputs section of the following `AdfsClient` cmdlets:

- Add-AdfsClient
- Disable-AdfsClient
- Enable-AdfsClient
- Get-AdfsClient
- Remove-AdfsClient
- Set-AdfsClient
