### PR TITLE
Update .openpublishing.publish.config.json to fix 404 issue for module page

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -9,7 +9,8 @@
       "moniker_ranges": [],
       "open_to_public_contributors": true,
       "type_mapping": {
-        "Conceptual": "Content"
+        "Conceptual": "Content",
+        "AzurePSModulePage": "Content"
       },
       "build_entry_point": "docs",
       "template_folder": "_themes",


### PR DESCRIPTION
404 issue for module page: https://docs.microsoft.com/en-us/powershell/module/adcsadministration/?view=win10-ps

After this fix is merged into live, the issue will be fixed. Here's the preview page for this PR: https://review.docs.microsoft.com/en-us/powershell/module/adcsadministration/?view=win10-ps&branch=qinezh-patch-1
