### PR TITLE
Adfs Module: Improve Inputs and Outputs for the AdfsWebApiApplication Cmdlets

### DIFF
--- a/docset/windows/adfs/Add-AdfsWebApiApplication.md
+++ b/docset/windows/adfs/Add-AdfsWebApiApplication.md
@@ -526,19 +526,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-String objects are accepted by the *AccessControlPolicyName*, *AdditionalAuthenticationRules*, *ApplicationGroupIdentifier*, *DelegationAuthorizationRules*, *ImpersonationAuthorizationRules*, *IssuanceAuthorizationRules*, and *IssuanceTransformRules* parameters.
+String objects are received by the *AccessControlPolicyName*, *AdditionalAuthenticationRules*, *ApplicationGroupIdentifier*, *DelegationAuthorizationRules*, *ImpersonationAuthorizationRules*, *IssuanceAuthorizationRules*, and *IssuanceTransformRules* parameters.
 
 ### System.Object
 
-Objects are accepted by the *AccessControlPolicyParameters* parameter.
+Objects are received by the *AccessControlPolicyParameters* parameter.
 
 ### System.Management.Automation.SwitchParameter
 
-SwitchParameter objects are accepted by the *AlwaysRequireAuthentication* and *RequestMFAFromClaimsProviders* parameters.
+SwitchParameter objects are received by the *AlwaysRequireAuthentication* and *RequestMFAFromClaimsProviders* parameters.
 
 ### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
 
-ApplicationGroup objects are accepted by the *ApplicationGroup* parameter.
+ApplicationGroup objects are received by the *ApplicationGroup* parameter.
 
 ## OUTPUTS
 

--- a/docset/windows/adfs/Add-AdfsWebApiApplication.md
+++ b/docset/windows/adfs/Add-AdfsWebApiApplication.md
@@ -524,57 +524,27 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### System.String
+
+String objects are accepted by the *AccessControlPolicyName*, *AdditionalAuthenticationRules*, *ApplicationGroupIdentifier*, *DelegationAuthorizationRules*, *ImpersonationAuthorizationRules*, *IssuanceAuthorizationRules*, and *IssuanceTransformRules* parameters.
+
+### System.Object
+
+Objects are accepted by the *AccessControlPolicyParameters* parameter.
+
+### System.Management.Automation.SwitchParameter
+
+SwitchParameter objects are accepted by the *AlwaysRequireAuthentication* and *RequestMFAFromClaimsProviders* parameters.
+
+### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+
+ApplicationGroup objects are accepted by the *ApplicationGroup* parameter.
+
 ## OUTPUTS
 
 ### Microsoft.IdentityServer.Management.Resources.WebApiApplication
-AccessControlPolicyName               string
-AccessControlPolicyParameters         System.Object
-AdditionalAuthenticationRules         string
-AllowedAuthenticationClassReferences  string[]
-AllowedClientTypes                    Microsoft.IdentityServer.Protocols.PolicyStore.AllowedClientTypes
-AlwaysRequireAuthentication           bool
-ApplicationGroupId                    string
-ApplicationGroupIdentifier            string
-ClaimsProviderName                    string[]
-DelegationAuthorizationRules          string
-Description                           string
-Enabled                               bool
-Identifier                            System.Collections.ObjectModel.ReadOnlyCollection[string]
-ImpersonationAuthorizationRules       string
-IssuanceAuthorizationRules            string
-IssuanceTransformRules                string
-IssueOAuthRefreshTokensTo             Microsoft.IdentityServer.Protocols.PolicyStore.RefreshTokenIssuanceDeviceTypes
-Name                                  string
-NotBeforeSkew                         int
-PublishedThroughProxy                 bool
-RefreshTokenProtectionEnabled         bool
-RequestMFAFromClaimsProviders         bool
-ResultantPolicy                       Microsoft.IdentityServer.PolicyModel.Configuration.PolicyTemplate.PolicyMetadata
-TokenLifetime                         int
 
-### Microsoft.IdentityServer.Protocols.PolicyStore.AllowedClientTypes
-
-AllowedClientTypes
-{
-  None = 0,
-  Public = 2,
-  Confidential=4,
-}
-
-### Microsoft.IdentityServer.Protocols.PolicyStore.RefreshTokenIssuanceDeviceTypes
-
-RefreshTokenIssuanceDeviceTypes
-{
-  NoDevice = 0,
-  WorkplaceJoinedDevices = 1,
-  AllDevices = 2
-}
-
-
-### Microsoft.IdentityServer.PolicyModel.Configuration.PolicyTemplate.PolicyMetadata
-IsParameterized  bool
-Summary          string
-Serialized       string
+Returns the new WebApiApplication object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Get-AdfsWebApiApplication.md
+++ b/docset/windows/adfs/Get-AdfsWebApiApplication.md
@@ -160,7 +160,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.IdentityServer.Management.Resources.WebApiApplication
 
-WebApiApplication objects are accepted by the *application* parameter.
+WebApiApplication objects are accepted by the *Application* parameter.
 
 ### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
 

--- a/docset/windows/adfs/Get-AdfsWebApiApplication.md
+++ b/docset/windows/adfs/Get-AdfsWebApiApplication.md
@@ -158,80 +158,25 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.String[]
-Microsoft.IdentityServer.Management.Resources.WebApiApplication
-System.String
-Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+### Microsoft.IdentityServer.Management.Resources.WebApiApplication
+
+WebApiApplication objects are accepted by the *application* parameter.
+
+### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+
+ApplicationGroup objects are accepted by the *ApplicationGroup* parameter.
+
+### System.String
+
+String objects are accepted by the *ApplicationGroupIdentifier*, *Identifier*, and *Name* parameters.
 
 ## OUTPUTS
 
 ### Microsoft.IdentityServer.Management.Resources.WebApiApplication
-AccessControlPolicyName               string
-AccessControlPolicyParameters         System.Object
-AdditionalAuthenticationRules         string
-AllowedAuthenticationClassReferences  string[]
-AllowedClientTypes                    Microsoft.IdentityServer.Protocols.PolicyStore.AllowedClientTypes
-AlwaysRequireAuthentication           bool
-ApplicationGroupId                    string
-ApplicationGroupIdentifier            string
-ClaimsProviderName                    string[]
-DelegationAuthorizationRules          string
-Description                           string
-Enabled                               bool
-Identifier                            System.Collections.ObjectModel.ReadOnlyCollection[string]
-ImpersonationAuthorizationRules       string
-IssuanceAuthorizationRules            string
-IssuanceTransformRules                string
-IssueOAuthRefreshTokensTo             Microsoft.IdentityServer.Protocols.PolicyStore.RefreshTokenIssuanceDeviceTypes
-Name                                  string
-NotBeforeSkew                         int
-PublishedThroughProxy                 bool
-RefreshTokenProtectionEnabled         bool
-RequestMFAFromClaimsProviders         bool
-ResultantPolicy                       Microsoft.IdentityServer.PolicyModel.Configuration.PolicyTemplate.PolicyMetadata
-TokenLifetime                         int
 
-### Microsoft.IdentityServer.Protocols.PolicyStore.AllowedClientTypes
-
-AllowedClientTypes
-{
-  None = 0,
-  Public = 2,
-  Confidential=4,
-}
-
-### Microsoft.IdentityServer.Protocols.PolicyStore.RefreshTokenIssuanceDeviceTypes
-
-RefreshTokenIssuanceDeviceTypes
-{
-  NoDevice = 0,
-  WorkplaceJoinedDevices = 1,
-  AllDevices = 2
-}
-
-
-### Microsoft.IdentityServer.PolicyModel.Configuration.PolicyTemplate.PolicyMetadata
-IsParameterized  bool
-Summary          string
-Serialized       string
+Returns one or more WebApiApplication objects that represent the web API applications of the Federation Service.
 
 ## NOTES
-Microsoft.IdentityServer.Management.Resources.WebApiApplication inherits from Microsoft.IdentityServer.Management.Resources.ClientApplication object and implements the Microsoft.IdentityServer.Management.Resources.IApplication interface.
-
-Microsoft.IdentityServer.Management.Resources.ClientApplication
-
-ApplicationGroupIdentifier                        string
-Description                                       string
-Enabled                                           bool
-Identifier                                        string
-Name                                              string
-RedirectUri                                       string[]
-
-Microsoft.IdentityServer.Management.Resources.IApplication
-
-ApplicationGroupIdentifier                        string
-Enabled                                           bool
-Name                                              string
 
 ## RELATED LINKS
 

--- a/docset/windows/adfs/Get-AdfsWebApiApplication.md
+++ b/docset/windows/adfs/Get-AdfsWebApiApplication.md
@@ -160,15 +160,15 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.IdentityServer.Management.Resources.WebApiApplication
 
-WebApiApplication objects are accepted by the *Application* parameter.
+WebApiApplication objects are received by the *Application* parameter.
 
 ### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
 
-ApplicationGroup objects are accepted by the *ApplicationGroup* parameter.
+ApplicationGroup objects are received by the *ApplicationGroup* parameter.
 
 ### System.String
 
-String objects are accepted by the *ApplicationGroupIdentifier*, *Identifier*, and *Name* parameters.
+String objects are received by the *ApplicationGroupIdentifier*, *Identifier*, and *Name* parameters.
 
 ## OUTPUTS
 

--- a/docset/windows/adfs/Remove-AdfsWebApiApplication.md
+++ b/docset/windows/adfs/Remove-AdfsWebApiApplication.md
@@ -156,6 +156,8 @@ String objects are received by the *TargetIdentifier* and *TargetName* parameter
 
 ## OUTPUTS
 
+### Microsoft.IdentityServer.Management.Resources.WebApiApplication
+
 Returns the removed WebApiApplication object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES

--- a/docset/windows/adfs/Remove-AdfsWebApiApplication.md
+++ b/docset/windows/adfs/Remove-AdfsWebApiApplication.md
@@ -146,7 +146,17 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### Microsoft.IdentityServer.Management.Resources.WebApiApplication
+
+WebApiApplication objects are received by the 'TargetApplication' parameter.
+
+### System.String
+
+String objects are received by the *TargetIdentifier* and *TargetName* parameters.
+
 ## OUTPUTS
+
+Returns the removed WebApiApplication object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Set-AdfsWebApiApplication.md
+++ b/docset/windows/adfs/Set-AdfsWebApiApplication.md
@@ -555,7 +555,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### System.String
+
+String objects are received by the *AccessControlPolicyName*, *AdditionalAuthenticationRules*, *DelegationAuthorizationRules*, *Description*, *ImpersonationAuthorizationRules*, *IssuanceAuthorizationRules*, *IssuanceTransformRules*, *TargetIdentifier*, and *TargetName* parameters.
+
+### System.Object
+
+Objects are received by the *AccessControlPolicyParameters* parameter.
+
+### Microsoft.IdentityServer.Management.Resources.WebApiApplication
+
+WebApiApplication objects are received by the *TargetApplication* parameter.
+
 ## OUTPUTS
+
+### Microsoft.IdentityServer.Management.Resources.WebApiApplication
+
+Returns the updated WebApiApplication object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 


### PR DESCRIPTION
This PR improves the descriptions for the Inputs and Outputs section of the following `AdfsWebApiApplication` cmdlets:

- Add-AdfsWebApiApplication
- Get-AdfsWebApiApplication
- Remove-AdfsWebApiApplication
- Set-AdfsWebApiApplication

It also removes some spurious notes from the `Get-AdfsWebApiApplication` document.