### PR TITLE
Update Set-AdfsProperties.md

### DIFF
--- a/docset/windows/adfs/Set-AdfsProperties.md
+++ b/docset/windows/adfs/Set-AdfsProperties.md
@@ -980,7 +980,7 @@ Accept wildcard characters: False
 
 ### -PromptLoginFallbackAuthenticationType
 
-Specifies a fallback authentication type for a prompt login request.
+This parameter is obsolete. Please set this property on individual Claims Provider Trusts.
 
 ```yaml
 Type: String
@@ -996,12 +996,7 @@ Accept wildcard characters: False
 
 ### -PromptLoginFederation
 
-The acceptable values for this parameter are:
-
-- None. Do not federate prompt=login request and error instead.
-- FallbackToProtocolSpecificParameters. Translate prompt=login to wfresh=0 and Wauth=forms during federation. If wauth is present in the original request, it will be preserved.
-- ForwardPromptAndHintsOverWsFederation. Forward prompt, login_hint, and domain_hint parameters during federation.
-- Disabled. Discard prompt parameter from the request during federation.
+This parameter is obsolete. Please set this property on individual Claims Provider Trusts.
 
 ```yaml
 Type: PromptLoginFederation


### PR DESCRIPTION
This PR updates the descriptions of the `PromptLoginFallbackAuthenticationType` and `PromptLoginFederation` parameters of the `Set-AdfsProperties` cmdlet to say they are obsolete.

```
Set-AdfsProperties : PS0346: PromptLoginFederation and PromptLoginFallbackAuthenticationType are obselete. Please set these properties on individual 
Claims Provider Trusts.
At line:1 char:1
+ Set-AdfsProperties -PromptLoginFederation None
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Set-AdfsProperties], ArgumentException
    + FullyQualifiedErrorId : PS0346,Microsoft.IdentityServer.Management.Commands.SetServicePropertiesCommand
```