### PR TITLE
Adfs Module: Improve Inputs and Outputs for the AdfsApplicationGroup Cmdlets

### DIFF
--- a/docset/windows/adfs/Disable-AdfsApplicationGroup.md
+++ b/docset/windows/adfs/Disable-AdfsApplicationGroup.md
@@ -147,7 +147,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+
+ApplicationGroup objects are received by the *TargetApplicationGroup* parameter.
+
+### System.String
+
+String objects are received by the *TargetApplicationGroupIdentifier* and *TargetName* parameters.
+
 ## OUTPUTS
+
+### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+
+Returns the disabled ApplicationGroup object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Enable-AdfsApplicationGroup.md
+++ b/docset/windows/adfs/Enable-AdfsApplicationGroup.md
@@ -147,7 +147,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+
+ApplicationGroup objects are received by the *TargetApplicationGroup* parameter.
+
+### System.String
+
+String objects are received by the *TargetApplicationGroupIdentifier* and *TargetName* parameters.
+
 ## OUTPUTS
+
+### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+
+Returns the disabled ApplicationGroup object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Get-AdfsApplicationGroup.md
+++ b/docset/windows/adfs/Get-AdfsApplicationGroup.md
@@ -98,43 +98,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.String[]
-Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+
+ApplicationGroup objects are received by the *ApplicationGroup* parameter.
+
+### System.String
+
+String objects are received by the *ApplicationGroupIdentifier* and *Name* parameters.
 
 ## OUTPUTS
 
 ### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
-ApplicationGroupIdentifier  string
-Applications                Microsoft.IdentityServer.Management.Resources.IApplication[]
-Description                 string
-Enabled                     bool
-Name                        string
 
-### Microsoft.IdentityServer.Management.Resources.IApplication
-ADUserPrincipalName                   string
-ApplicationGroupIdentifier            string
-ClientSecret                          string
-Description                           string
-Enabled                               bool
-Identifier                            string
-JWKSUri                               uri
-JWTSigningCertificateRevocationCheck  Microsoft.IdentityServer.PolicyModel.Configuration.RevocationSetting
-JWTSigningKeys                        System.Collections.Generic.IDictionary[string,System.Object]
-Name                                  string
-RedirectUri                           string[]
-
-### Microsoft.IdentityServer.PolicyModel.Configuration.RevocationSetting
-
-RevocationSetting
-{
-   None = 0,
-   CheckEndCert = 1,
-   CheckEndCertCacheOnly = 2,
-   CheckChain = 3,
-   CheckChainCacheOnly = 4,
-   CheckChainExcludeRoot = 5,
-   CheckChainExcludeRootCacheOnly = 6,
-}
+Returns one or more ApplicationGroup objects that represent the Application Groups for the Federation Service.
 
 ## NOTES
 

--- a/docset/windows/adfs/New-AdfsApplicationGroup.md
+++ b/docset/windows/adfs/New-AdfsApplicationGroup.md
@@ -150,7 +150,15 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### System.String
+
+String objects are received by the *ApplicationGroupIdentifier*, *Description*, and *Name* parameters.
+
 ## OUTPUTS
+
+### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+
+Returns the new ApplicationGroup object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Remove-AdfsApplicationGroup.md
+++ b/docset/windows/adfs/Remove-AdfsApplicationGroup.md
@@ -147,7 +147,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+
+ApplicationGroup objects are received by the *TargetApplicationGroup* parameter.
+
+### System.String
+
+String objects are received by the *TargetApplicationGroupIdentifier* and *TargetName* parameters.
+
 ## OUTPUTS
+
+### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+
+Returns the removed ApplicationGroup object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Set-AdfsApplicationGroup.md
+++ b/docset/windows/adfs/Set-AdfsApplicationGroup.md
@@ -195,7 +195,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### System.String
+
+String objects are received by the *ApplicationGroupIdentifer*, *Description*, *Name*, *TargetApplicationGroupIdentifier*, and *TargetName* parameters.
+
+### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+
+ApplicationGroup objects are received by the *TargetApplicationGroup* parameter.
+
 ## OUTPUTS
+
+### Microsoft.IdentityServer.Management.Resources.ApplicationGroup
+
+Returns the updated ApplicationGroup object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 


### PR DESCRIPTION
This PR improves the descriptions for the Inputs and Outputs section of the following `AdfsApplicationGroup` cmdlets:

- New-AdfsApplicationGroup
- Disable-AdfsApplicationGroup
- Enable-AdfsApplicationGroup
- Get-AdfsApplicationGroup
- Remove-AdfsApplicationGroup
- Set-AdfsApplicationGroup