### PR TITLE
Adfs Module: Improve Inputs and Outputs for the AdfsApplicationPermission Cmdlets

### DIFF
--- a/docset/windows/adfs/Get-AdfsApplicationPermission.md
+++ b/docset/windows/adfs/Get-AdfsApplicationPermission.md
@@ -98,28 +98,15 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.String[]
+### System.String
+
+String objects are received by the *ClientRoleIdentifiers*, *Identifiers*, and *ServerRoleIdentifiers* parameters.
 
 ## OUTPUTS
 
 ### Microsoft.IdentityServer.Management.Resources.OAuthPermission
-ClientRoleIdentifier  string
-ConsentType           Microsoft.IdentityServer.Protocols.PolicyStore.OAuthConsentType
-Description           string
-GrantedAt             datetime
-GrantedBy             string
-ObjectIdentifier      string
-ScopeNames            string[]
-ServerRoleIdentifier  string
 
-### Microsoft.IdentityServer.Protocols.PolicyStore.OAuthConsentType
-
-OAuthConsentType
-{
-  Unknown = 0,
-  Administrator = 1,
-  User = 2,
-}
+Returns one or more OAuthPermission objects that represent the application permssions for the Federation Service.
 
 ## NOTES
 

--- a/docset/windows/adfs/Get-AdfsApplicationPermission.md
+++ b/docset/windows/adfs/Get-AdfsApplicationPermission.md
@@ -106,7 +106,7 @@ String objects are received by the *ClientRoleIdentifiers*, *Identifiers*, and *
 
 ### Microsoft.IdentityServer.Management.Resources.OAuthPermission
 
-Returns one or more OAuthPermission objects that represent the application permssions for the Federation Service.
+Returns one or more OAuthPermission objects that represent the application permissions for the Federation Service.
 
 ## NOTES
 

--- a/docset/windows/adfs/Grant-AdfsApplicationPermission.md
+++ b/docset/windows/adfs/Grant-AdfsApplicationPermission.md
@@ -173,7 +173,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### System.Management.Automation.SwitchParameter
+
+SwitchParameter objects are received by the *AllowAllRegisteredClients* parameter.
+
+### System.String
+
+String objects are received by the *ClientRoleIdentifier*, *Description*, *ScopeNames*, and *ServerRoleIdentifier* parameters.
+
 ## OUTPUTS
+
+### Microsoft.IdentityServer.Management.Resources.OAuthPermission
+
+Returns the new OAuthPermission object when the PassThru parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Revoke-AdfsApplicationPermission.md
+++ b/docset/windows/adfs/Revoke-AdfsApplicationPermission.md
@@ -139,6 +139,14 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### Microsoft.IdentityServer.Management.Resources.OAuthPermission
+
+OAuthPermission objects are received by the *InputObject* parameter.
+
+### System.String
+
+String objects are received by the *TargetClientRoleIdentifier*, *TargetIdentifier*, and *TargetServerRoleIdentifier* parameters.
+
 ## OUTPUTS
 
 ## NOTES

--- a/docset/windows/adfs/Set-AdfsApplicationPermission.md
+++ b/docset/windows/adfs/Set-AdfsApplicationPermission.md
@@ -235,6 +235,14 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### System.String
+
+String objects are received by the *AddScope*, *Description*, *RemoveScope*, *ScopeNames*, *TargetClientRoleIdentifier*, *TargetIdentifier*, and *TargetServerRoleIdentifier* parameters.
+
+### Microsoft.IdentityServer.Management.Resources.OAuthPermission
+
+OAuthPermission objects are received by the *InputObject* parameter.
+
 ## OUTPUTS
 
 ## NOTES


### PR DESCRIPTION
This PR improves the descriptions for the Inputs and Outputs section of the following `AdfsApplicationPermission` cmdlets:

- Get-AdfsApplicationPermission
- Grant-AdfsApplicationPermission
- Revoke-AdfsApplicationPermission
- Set-AdfsApplicationPermission