### PR TITLE
Import-PfxCertificate fix powershell examples

### DIFF
--- a/docset/windows/pkiclient/Import-PfxCertificate.md
+++ b/docset/windows/pkiclient/Import-PfxCertificate.md
@@ -42,8 +42,6 @@ Delegation may be required when using this cmdlet with Windows PowerShell® remo
 ```
 PS C:\>$mypwd = Get-Credential -UserName 'Enter password below' -Message 'Enter password below'
 
-
-
 PS C:\>Import-PfxCertificate -FilePath C:\mypfx.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $mypwd.Password
 ```
 
@@ -61,9 +59,7 @@ The **Password** parameter is not required since this PFX file is not password p
 ```
 PS C:\>Set-Location -Path cert:\localMachine\my
 
-
-
-PS C:\>Import-PfxCertificate -FilePath c:\mypfx.pfx
+PS Cert:\localMachine\my>Import-PfxCertificate -FilePath c:\mypfx.pfx
 ```
 
 This example imports the PFX file mypfx.pfx into the My store for the machine account.


### PR DESCRIPTION
Import-PfxCertificate (https://docs.microsoft.com/en-us/powershell/module/pkiclient/import-pfxcertificate)

remove unneeded whitespace
fix path after Set-Location