### PR TITLE
Switch-Certificate examples fixes

### DIFF
--- a/docset/windows/pkiclient/Switch-Certificate.md
+++ b/docset/windows/pkiclient/Switch-Certificate.md
@@ -47,17 +47,11 @@ This example sets the renewal property of the certificate with the thumbprint E4
 ```
 PS C:\>Set-Location -Path cert:\LocalMachine\My
 
+PS cert:\LocalMachine\My>$oldCert = Get-ChildItem -Path E42DBC3B3F2771990A9B3E35D0C3C422779DACD7
 
+PS cert:\LocalMachine\My>$newCert = Get-ChildItem -Path 4A346B4385F139CA843912D358D765AB8DEE9FD4
 
-PS C:\>$oldCert = (Get-ChildItem -Path E42DBC3B3F2771990A9B3E35D0C3C422779DACD7)
-
-
-
-PS C:\>$newCert = (Get-ChildItem -Path 4A346B4385F139CA843912D358D765AB8DEE9FD4)
-
-
-
-PS C:\>Switch-Certificate -OldCert $oldCert -NewCert $newCert -NotifyOnly
+PS cert:\LocalMachine\My>Switch-Certificate -OldCert $oldCert -NewCert $newCert -NotifyOnly
 ```
 
 This example locates two certificates in the machine MY store and assigns them the variables $oldCert and $newCert.


### PR DESCRIPTION
* removed extra white space (lines) which makes the code sample unnecessarily long
* removed redundant parenthesis in variable assignment
* moved location of cli after Set-Location