### PR TITLE
Remove deprecated Windows Update cmdlets link

### DIFF
--- a/docset/windows/windowsupdate/Get-WindowsUpdateLog.md
+++ b/docset/windows/windowsupdate/Get-WindowsUpdateLog.md
@@ -222,5 +222,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Windows Update Cmdlets](./windowsupdate.md)
-


### PR DESCRIPTION
The Windows Update cmdlets link was incorrectly in this help file, and should not have been there. This change removes it.