### PR TITLE
Updates to prioritize MSIX

### DIFF
--- a/docset/windows/appx/Add-AppxPackage.md
+++ b/docset/windows/appx/Add-AppxPackage.md
@@ -78,7 +78,7 @@ Add-AppxPackage [-RegisterByFamilyName] -MainPackage <String> [-DependencyPackag
 
 ## DESCRIPTION
 The **Add-AppxPackage** cmdlet adds a signed app package to a user account.
-An app package has an .appx file name extension.
+An app package has an .msix or .appx file name extension.
 Use the *DependencyPath* parameter to add all other packages that are required for the installation of the app package.
 
 You can use the *Register* parameter to install from a folder of unpackaged files during development of Windows® Store apps.
@@ -89,7 +89,7 @@ To update an already installed package, the new package must have the same packa
 
 ### Example 1: Add an app package
 ```
-PS C:\> Add-AppxPackage -Path "C:\Users\user1\Desktop\MyApp.appx" -DependencyPath "C:\Users\user1\Desktop\winjs.appx"
+PS C:\> Add-AppxPackage -Path "C:\Users\user1\Desktop\MyApp.msix" -DependencyPath "C:\Users\user1\Desktop\winjs.msix"
 ```
 
 This command adds an app package that the package contains.
@@ -105,16 +105,16 @@ You can use *DisableDevelopmentMode* to register an application that is staged b
 
 ### Example 3: Add an app along with its optional packages
 ```
-PS C:\> Add-AppxPackage -Path "C:\Users\user1\Desktop\MyApp.appxbundle" -ExternalPackages "C:\Users\user1\Desktop\optionalpackage1.appx","C:\Users\user1\Desktop\optionalpackage2.appxbundle"
+PS C:\> Add-AppxPackage -Path "C:\Users\user1\Desktop\MyApp.msixbundle" -ExternalPackages "C:\Users\user1\Desktop\optionalpackage1.msix","C:\Users\user1\Desktop\optionalpackage2.msixbundle"
 
-PS C:\> Add-AppxPackage -Path "C:\Users\user1\Desktop\MyApp.appxbundle" -OptionalPackages "29270sandstorm.OptionalPackage1_gah1vdar1nn7a"
+PS C:\> Add-AppxPackage -Path "C:\Users\user1\Desktop\MyApp.msixbundle" -OptionalPackages "29270sandstorm.OptionalPackage1_gah1vdar1nn7a"
 ```
 
 This command adds an app package along with its optional packages. It is an atomic operation which means that if the app or its optional packages fail to install, the deployment operation will be aborted
 
 ### Example 4: Install only the required section of a streaming app
 ```
-PS C:\> Add-AppxPackage -Path "C:\Users\user1\Desktop\MyApp.appxbundle" -RequiredContentGroupOnly
+PS C:\> Add-AppxPackage -Path "C:\Users\user1\Desktop\MyApp.msixbundle" -RequiredContentGroupOnly
 ```
 
 This command adds an app package but only installs the required section of a streaming app. Calling this command again without the RequiredContentGroupOnly flag proceeds to install the rest of the application in the order defined by the AppxContentGroupMap.xml
@@ -138,7 +138,7 @@ Accept wildcard characters: False
 
 ### -DependencyPath
 Specifies an array of file paths of dependency packages that  are required for the installation of the app package.
-The app package has an .appx or .appxbundle file name extension. You can specify the paths to more than one dependency package.
+The app package has an .msix, .appx, .msixbundle, or .appxbundle file name extension. You can specify the paths to more than one dependency package.
 If a package is already installed for a user, you can skip adding it to the DependencyPath.
 
 ```yaml
@@ -267,7 +267,7 @@ Accept wildcard characters: False
 
 ### -Path
 Specifies the file path of the app package.
-An app package has an .appx or .appxbundle file name extension.
+An app package has an .msix, .appx, .msixbundle, or .appxbundle file name extension.
 
 ```yaml
 Type: String

--- a/docset/windows/appx/Appx.md
+++ b/docset/windows/appx/Appx.md
@@ -20,7 +20,7 @@ ms.assetid: 1848DCF8-9EA3-4E54-9DFC-C40A6CC14BB6
 
 # Appx Module
 ## Description
-The Windows PowerShell cmdlets for AppX are designed to streamline the administration of AppX package management.
+The Windows PowerShell cmdlets for AppX are designed to streamline the administration of MSIX or AppX package management.
 
 ## Appx Cmdlets
 ### [Add-AppxPackage](Add-AppxPackage.md)

--- a/docset/windows/appx/Get-AppxLastError.md
+++ b/docset/windows/appx/Get-AppxLastError.md
@@ -32,7 +32,7 @@ Get-AppxLastError [<CommonParameters>]
 
 ## DESCRIPTION
 The **Get-AppxLastError** cmdlet gets the last error reported in the app package installation logs for the current Windows PowerShell® session.
-An app package has an .appx file name extension.
+An app package has an .msix or .appx file name extension.
 
 ## EXAMPLES
 

--- a/docset/windows/appx/Get-AppxLog.md
+++ b/docset/windows/appx/Get-AppxLog.md
@@ -38,7 +38,7 @@ Get-AppxLog [-ActivityId <String>] [<CommonParameters>]
 
 ## DESCRIPTION
 The **Get-AppxLog** cmdlet gets the app package installation log created during the deployment of an app package.
-An app package has an .appx file name extension.
+An app package has an .msix or .appx file name extension.
 The log contains errors, warnings, and additional information about the processes initiated by cmdlets in the Appx Windows PowerShell® module.
 
 When Add-AppxPackage or Remove-AppxPackage report a failure, they return the **ActivityID** to use with **Get-AppxLog**.

--- a/docset/windows/appx/Get-AppxPackage.md
+++ b/docset/windows/appx/Get-AppxPackage.md
@@ -33,7 +33,7 @@ Get-AppxPackage [-AllUsers] [-PackageTypeFilter <PackageTypes>] [[-Name] <String
 
 ## DESCRIPTION
 The **Get-AppxPackage** cmdlet gets a list of the app packages that are installed in a user profile.
-An app package has an .appx file name extension.
+An app package has an .msix or .appx file name extension.
 To get the list of packages for a user profile other than the profile for the current user, you must run this command by using administrator permissions.
 
 ## EXAMPLES

--- a/docset/windows/appx/Get-AppxPackageManifest.md
+++ b/docset/windows/appx/Get-AppxPackageManifest.md
@@ -32,7 +32,7 @@ Get-AppxPackageManifest [-Package] <String> [[-User] <String>] [<CommonParameter
 
 ## DESCRIPTION
 The **Get-AppxPackageManifest** cmdlet gets the manifest of an app package.
-An app package has an .appx file name extension.
+An app package has an .msix or .appx file name extension.
 The manifest is an .xml document that contains information about the package, like the package ID.
 
 ## EXAMPLES

--- a/docset/windows/appx/Remove-AppxPackage.md
+++ b/docset/windows/appx/Remove-AppxPackage.md
@@ -43,7 +43,7 @@ Remove-AppxPackage [-Package] <String> -User <String> [-Confirm] [-WhatIf] [<Com
 ```
 ## DESCRIPTION
 The **Remove-AppxPackage** cmdlet removes an app package from a user account.
-An app package has an .appx file name extension.
+An app package has an .msix or .appx file name extension.
 
 ## EXAMPLES
 


### PR DESCRIPTION
MSIX is our primary app packaging format and we want to reflect that in our relevant documentation. Updating descriptions and examples to primarily be MSIX, without removing the AppX mentions.