### PR TITLE
Add note about security descriptor

### DIFF
--- a/docset/windows/dism/New-WindowsImage.md
+++ b/docset/windows/dism/New-WindowsImage.md
@@ -55,7 +55,7 @@ This command captures the Drive D image in the WIM file located on d:\ and save 
 Specifies the drive or path to the Windows operating system that is to be captured to an image file.
 
    > [!NOTE]
-   > When the path specified is not the root folder of a drive, the captured image will inherit the parent folder’s security descriptors. If you are capturing an image which was previously applied, apply the original image to the root folder of the drive to ensure that the security descriptors of the new image remain the same.
+   > When the path specified is not the root folder of a drive, the captured image will inherit the parent folder’s security descriptors. If you are capturing an image that was previously applied, apply the original image to the root folder of the drive to ensure that the security descriptors of the new image remain the same.
 
 ```yaml
 Type: String

--- a/docset/windows/dism/New-WindowsImage.md
+++ b/docset/windows/dism/New-WindowsImage.md
@@ -54,7 +54,7 @@ This command captures the Drive D image in the WIM file located on d:\ and save 
 ### -CapturePath
 Specifies the drive or path to the Windows operating system that is to be captured to an image file.
 
-   > [!Note]
+   > [!NOTE]
    > When the path specified is not the root folder of a drive, the captured image will inherit the parent folder’s security descriptors. If you are capturing an image which was previously applied, apply the original image to the root folder of the drive to ensure that the security descriptors of the new image remain the same.
 
 ```yaml
@@ -332,4 +332,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Save-WindowsImage](./Save-WindowsImage.md)
 
 [Split-WindowsImage](./Split-WindowsImage.md)
-

--- a/docset/windows/dism/New-WindowsImage.md
+++ b/docset/windows/dism/New-WindowsImage.md
@@ -54,6 +54,9 @@ This command captures the Drive D image in the WIM file located on d:\ and save 
 ### -CapturePath
 Specifies the drive or path to the Windows operating system that is to be captured to an image file.
 
+   > [!Note]
+   > When the path specified is not the root folder of a drive, the captured image will inherit the parent folder’s security descriptors. If you are capturing an image which was previously applied, apply the original image to the root folder of the drive to ensure that the security descriptors of the new image remain the same.
+
 ```yaml
 Type: String
 Parameter Sets: (All)

--- a/docset/windows/dism/New-WindowsImage.md
+++ b/docset/windows/dism/New-WindowsImage.md
@@ -54,7 +54,7 @@ This command captures the Drive D image in the WIM file located on d:\ and save 
 ### -CapturePath
 Specifies the drive or path to the Windows operating system that is to be captured to an image file.
 
-   > When the path specified is not the root folder of a drive, the captured image will inherit the parent folder’s security descriptors. If you are capturing an image that was previously applied, apply the original image to the root folder of the drive to ensure that the security descriptors of the new image remain the same.
+When the path specified is not the root folder of a drive, the captured image will inherit the parent folder security descriptors. If you are capturing an image that was previously applied, apply the original image to the root folder of the drive to ensure that the security descriptors of the new image remain the same.
 
 ```yaml
 Type: String

--- a/docset/windows/dism/New-WindowsImage.md
+++ b/docset/windows/dism/New-WindowsImage.md
@@ -54,7 +54,6 @@ This command captures the Drive D image in the WIM file located on d:\ and save 
 ### -CapturePath
 Specifies the drive or path to the Windows operating system that is to be captured to an image file.
 
-   > [!NOTE]
    > When the path specified is not the root folder of a drive, the captured image will inherit the parent folder’s security descriptors. If you are capturing an image that was previously applied, apply the original image to the root folder of the drive to ensure that the security descriptors of the new image remain the same.
 
 ```yaml


### PR DESCRIPTION
Add note to let readers know that when the capture path is a subfolder instead of the root folder, the resulting image will inherit security descriptors from the folder.