### PR TITLE
Configuration Manager rebranding

### DIFF
--- a/docset/mdop/mbam/disable-mbamcmintegration.md
+++ b/docset/mdop/mbam/disable-mbamcmintegration.md
@@ -22,7 +22,7 @@ ms.reviewer:
 # Disable-MbamCMIntegration
 
 ## SYNOPSIS
-Disables the MBAM System Center Configuration Manager Integration feature.
+Disables the MBAM Microsoft Endpoint Configuration Manager Integration feature.
 
 ## SYNTAX
 
@@ -31,11 +31,11 @@ Disable-MbamCMIntegration [-Force] [-RemoveComplianceData] [-WhatIf] [-Confirm] 
 ```
 
 ## DESCRIPTION
-The **Disable-MbamCMIntegration** cmdlet disables the Microsoft BitLocker Administration and Monitoring (MBAM) System Center Configuration Manager Integration feature.
+The **Disable-MbamCMIntegration** cmdlet disables the Microsoft BitLocker Administration and Monitoring (MBAM) Microsoft Endpoint Configuration Manager Integration feature.
 
 ## EXAMPLES
 
-### Example 1: Disable the System Center Configuration Manager Integration feature
+### Example 1: Disable the Microsoft Endpoint Configuration Manager Integration feature
 ```
 PS C:\> Disable-MbamCMIntegration
 Are you sure you want to perform this action?
@@ -43,7 +43,7 @@ Performing operation "Disable MBAM CM Integration feature"
 [Y] Yes  [N] No  [S] Suspend  [?] Help (default is "Y"):
 ```
 
-This command disables the MBAM System Center Configuration Manager Integration feature after you confirm the operation.
+This command disables the MBAM Microsoft Endpoint Configuration Manager Integration feature after you confirm the operation.
 
 ## PARAMETERS
 

--- a/docset/mdop/mbam/enable-mbamcmintegration.md
+++ b/docset/mdop/mbam/enable-mbamcmintegration.md
@@ -22,7 +22,7 @@ ms.reviewer:
 # Enable-MbamCMIntegration
 
 ## SYNOPSIS
-Enables the MBAM System Center Configuration Manager Integration feature.
+Enables the MBAM Microsoft Endpoint Configuration Manager Integration feature.
 
 ## SYNTAX
 
@@ -41,7 +41,7 @@ Enable-MbamCMIntegration [-SkipValidation] [-SsrsServer <String>] [-SsrsInstance
 ```
 
 ## DESCRIPTION
-The **Enable-MbamCMIntegration** cmdlet enables the Microsoft BitLocker Administration and Monitoring (MBAM) System Center Configuration Manager Integration feature.
+The **Enable-MbamCMIntegration** cmdlet enables the Microsoft BitLocker Administration and Monitoring (MBAM) Microsoft Endpoint Configuration Manager Integration feature.
 This feature integrates Configuration Manager with MBAM, and moves the compliance and reporting infrastructure into the Configuration Manager environment.
 
 ## EXAMPLES
@@ -51,7 +51,7 @@ This feature integrates Configuration Manager with MBAM, and moves the complianc
 PS C:\> Enable-MbamCMIntegration
 ```
 
-This command enables the MBAM System Center Configuration Manager Integration feature on the local Configuration Manager server.
+This command enables the MBAM Microsoft Endpoint Configuration Manager Integration feature on the local Configuration Manager server.
 The MBAM reports are deployed on the default SQL Server Reporting Services instance, MSSQLSERVER.
 
 ## PARAMETERS
@@ -166,7 +166,7 @@ Accept wildcard characters: False
 ### -SsrsInstance
 Specifies the SQL Server Reporting Services instance.
 This instance hosts the Configuration Manager reports.
-This parameter is ignored if the server has System Center 2012Configuration Manager installed.
+This parameter is ignored if the server has Configuration Manager installed.
 
 ```yaml
 Type: String

--- a/docset/mdop/mbam/enable-mbamwebapplication.md
+++ b/docset/mdop/mbam/enable-mbamwebapplication.md
@@ -154,8 +154,8 @@ Accept wildcard characters: False
 ```
 
 ### -CMIntegrationMode
-Indicates that all reports, except the Recovery Audit Report, are integrated into Microsoft System Center Configuration Manager.
-If you enable the System Center Configuration Manager Integration feature, specify this parameter.
+Indicates that all reports, except the Recovery Audit Report, are integrated into Microsoft Endpoint Configuration Manager.
+If you enable the Configuration Manager Integration feature, specify this parameter.
 
 ```yaml
 Type: SwitchParameter

--- a/docset/mdop/mbam/get-mbamcmintegration.md
+++ b/docset/mdop/mbam/get-mbamcmintegration.md
@@ -22,7 +22,7 @@ ms.reviewer:
 # Get-MbamCMIntegration
 
 ## SYNOPSIS
-Gets the configuration of the MBAM System Center Configuration Manager Integration feature.
+Gets the configuration of the MBAM Microsoft Endpoint Configuration Manager Integration feature.
 
 ## SYNTAX
 
@@ -31,19 +31,19 @@ Get-MbamCMIntegration [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-MbamCMIntegration** cmdlet gets the configuration of the Microsoft BitLocker Administration and Monitoring (MBAM) System Center Configuration Manager Integration feature.
+The **Get-MbamCMIntegration** cmdlet gets the configuration of the Microsoft BitLocker Administration and Monitoring (MBAM) Microsoft Endpoint Configuration Manager Integration feature.
 
 ## EXAMPLES
 
-### Example 1: Get the configuration of the System Center Configuration Manager Integration feature
+### Example 1: Get the configuration of the Microsoft Endpoint Configuration Manager Integration feature
 ```
 PS C:\> Get-MbamCMIntegration
 Name        : Configuration Manager Integration
 Enabled     : False
-Description : This feature will integrate MBAM with a Microsoft System Center Configuration Manager server.
+Description : This feature will integrate MBAM with a Microsoft Endpoint Configuration Manager server.
 ```
 
-This command gets the configuration of the MBAM System Center Configuration Manager Integration feature in the local server.
+This command gets the configuration of the MBAM Microsoft Endpoint Configuration Manager Integration feature in the local server.
 
 ## PARAMETERS
 

--- a/docset/mdop/mbam/mbam.md
+++ b/docset/mdop/mbam/mbam.md
@@ -27,7 +27,7 @@ The following list contains links to the help topics for the Microsoft BitLocker
 
 ## MBAM Cmdlets
 ### [Disable-MbamCMIntegration](disable-mbamcmintegration.md)
-Disables the MBAM System Center Configuration Manager Integration feature.
+Disables the MBAM Microsoft Endpoint Configuration Manager Integration feature.
 
 ### [Disable-MbamReport](disable-mbamreport.md)
 Disables the Reports feature.
@@ -36,7 +36,7 @@ Disables the Reports feature.
 Disables a web application.
 
 ### [Enable-MbamCMIntegration](enable-mbamcmintegration.md)
-Enables the MBAM System Center Configuration Manager Integration feature.
+Enables the MBAM Microsoft Endpoint Configuration Manager Integration feature.
 
 ### [Enable-MbamDatabase](enable-mbamdatabase.md)
 Enables the Compliance and Audit and Recovery databases.
@@ -51,7 +51,7 @@ Enables a web application.
 Requests an MBAM recovery key.
 
 ### [Get-MbamCMIntegration](get-mbamcmintegration.md)
-Gets the configuration of the MBAM System Center Configuration Manager Integration feature.
+Gets the configuration of the MBAM Microsoft Endpoint Configuration Manager Integration feature.
 
 ### [Get-MbamReport](get-mbamreport.md)
 Gets the configuration of the Reports feature.

--- a/docset/mdop/mbam/test-mbamcmintegration.md
+++ b/docset/mdop/mbam/test-mbamcmintegration.md
@@ -40,7 +40,7 @@ Test-MbamCMIntegration [-Detailed] [-SsrsServer <String>] [-SsrsInstance <String
 ```
 
 ## DESCRIPTION
-The **Test-MbamCMIntegration** cmdlet checks the server prerequisites and validates the parameters for the Microsoft BitLocker Administration and Monitoring (MBAM) System Center Configuration Manager Integration feature.
+The **Test-MbamCMIntegration** cmdlet checks the server prerequisites and validates the parameters for the Microsoft BitLocker Administration and Monitoring (MBAM) Microsoft Endpoint Configuration Manager Integration feature.
 
 ## EXAMPLES
 
@@ -49,7 +49,7 @@ The **Test-MbamCMIntegration** cmdlet checks the server prerequisites and valida
 PS C:\> Test-MbamCMIntegration
 ```
 
-This command tests the prerequisites for enabling the MBAM System Center Configuration Manager Integration on the local Configuration Manager server.
+This command tests the prerequisites for enabling the MBAM Microsoft Endpoint Configuration Manager Integration on the local Configuration Manager server.
 The MBAM reports are deployed on the default SQL Server Reporting Services instance, MSSQLSERVER.
 
 ### Example 2: Check prerequisites to enable integration with detailed output
@@ -59,10 +59,10 @@ PS C:\> Test-MbamCMIntegration -Detailed
 
 ID             Type  Message
 --             ----  -------
-CmInstallation Error This feature can be installed only on a server that is running System Center Configuration Manager.
+CmInstallation Error This feature can be installed only on a server that is running Microsoft Endpoint Configuration Manager.
 ```
 
-This command checks the prerequisites to enable the MBAM System Center Configuration Manager Integration feature on the local Configuration Manager server with detailed output.
+This command checks the prerequisites to enable the MBAM Microsoft Endpoint Configuration Manager Integration feature on the local Configuration Manager server with detailed output.
 
 ## PARAMETERS
 
@@ -160,7 +160,7 @@ Accept wildcard characters: False
 ### -SsrsInstance
 Specifies the SQL Server Reporting Services instance.
 This instance hosts the Configuration Manager reports.
-This parameter is ignored if the server has System Center 2012 Configuration Manager installed.
+This parameter is ignored if the server has Configuration Manager installed.
 
 ```yaml
 Type: String

--- a/docset/mdop/mbam/test-mbamwebapplication.md
+++ b/docset/mdop/mbam/test-mbamwebapplication.md
@@ -154,8 +154,8 @@ Accept wildcard characters: False
 ```
 
 ### -CMIntegrationMode
-Indicates that all reports, except the Recovery Audit Report, are integrated into Microsoft System Center Configuration Manager.
-If you enable the System Center Configuration Manager Integration feature, specify this parameter.
+Indicates that all reports, except the Recovery Audit Report, are integrated into Microsoft Endpoint Configuration Manager.
+If you enable the Configuration Manager Integration feature, specify this parameter.
 
 ```yaml
 Type: SwitchParameter

--- a/docset/windows/appvclient/Disable-Appv.md
+++ b/docset/windows/appvclient/Disable-Appv.md
@@ -31,7 +31,7 @@ Disable-Appv [<CommonParameters>]
 
 ## DESCRIPTION
 The **Disable-Appv** cmdlet disables the Microsoft Application Virtualization (App-V) service on Windows 10 Anniversary Edition computers.
-This cmdlet disables the download of all App-V apps from App-V Server or System Center 2016 Configuration Manager.
+This cmdlet disables the download of all App-V apps from App-V Server or Configuration Manager.
 If this cmdlet succeeds, it returns a message.
 You must restart the computer for the change to take effect.
 

--- a/docset/windows/dism/Add-WindowsCapability.md
+++ b/docset/windows/dism/Add-WindowsCapability.md
@@ -255,7 +255,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-As of Windows 10 version 1709, you cannot use Windows Server Update Services (WSUS) to host Features on Demand (FOD) and language packs for Windows 10 clients. Instead, you can enforce a Group Policy setting that tells the clients to download them directly from Windows Update. You can also host FOD and language packs on a network share, but starting with Windows 10 version 1809, FOD and language packs can only be installed from Windows Update. For more information, see [How to make Features on Demand and language packs available when you're using WSUS/SCCM](https://docs.microsoft.com/windows/deployment/update/fod-and-lang-packs).
+As of Windows 10 version 1709, you cannot use Windows Server Update Services (WSUS) to host Features on Demand (FOD) and language packs for Windows 10 clients. Instead, you can enforce a Group Policy setting that tells the clients to download them directly from Windows Update. You can also host FOD and language packs on a network share, but starting with Windows 10 version 1809, FOD and language packs can only be installed from Windows Update. For more information, see [How to make Features on Demand and language packs available when you're using WSUS/Configuration Manager](https://docs.microsoft.com/windows/deployment/update/fod-and-lang-packs).
 
 ## RELATED LINKS
 

--- a/docset/windows/remoteaccess/Update-DAMgmtServer.md
+++ b/docset/windows/remoteaccess/Update-DAMgmtServer.md
@@ -34,12 +34,12 @@ Update-DAMgmtServer [-PassThru] [-ComputerName <String>] [-CimSession <CimSessio
 The **Update-DAMgmtServer** cmdlet updates the list of Management servers of the DirectAccess (DA) deployment.
 A management server is any server that needs to be accessed in a DA managed-out deployment or during the first tunnel in a DA full deployment, such as update servers, domain controllers and other servers.
 
-Domain controllers and System Center Configuration Manager servers are discovered automatically.
+Domain controllers and Microsoft Endpoint Configuration Manager servers are discovered automatically.
 Manually entered management server names are resolved to IP addresses. 
 
 Management server configuration is applicable globally to the entire DA deployment and therefore is not impacted by multi-site deployments. 
 
-When the cmdlet runs, the list of automatically discovered domain controllers and System Center Configuration Manager servers is updated.
+When the cmdlet runs, the list of automatically discovered domain controllers and Configuration Manager servers is updated.
 Discovered servers are added to the list, and servers that cannot be discovered are removed.
 IP addresses in the list are updated in accordance with server name resolution.
 

--- a/docset/windows/updateservices/Add-WsusDynamicCategory.md
+++ b/docset/windows/updateservices/Add-WsusDynamicCategory.md
@@ -48,7 +48,7 @@ In order to transfer dynamic categories from one update server to another, pass 
 
 This cmdlet is used to add Dynamic Categories to WSUS, based on the type of requirement (computer model, device or application). The definition of Dynamic Categories in a WSUS implementation helps to categorize the applying of updates to the different categories available.
 
-In some cases, you need advanced automation when using Dynamic Categories. If you want to download a specific device driver for a specific group of computers in the physical network, for example, advanced automation is required to use Dynamic Categories. In this case, the use of [System Center Configurations Manager](https://www.microsoft.com/en-us/cloud-platform/system-center-configuration-manager) is needed to configure the [Software Update Point](https://docs.microsoft.com/en-us/sccm/sum/get-started/install-a-software-update-point) feature.
+In some cases, you need advanced automation when using Dynamic Categories. If you want to download a specific device driver for a specific group of computers in the physical network, for example, advanced automation is required to use Dynamic Categories. In this case, the use of [Microsoft Endpoint Configuration Manager](https://docs.microsoft.com/configmgr/) is needed to [install and configure a software update point](https://docs.microsoft.com/configmgr/sum/get-started/install-a-software-update-point) feature.
 
 ## EXAMPLES
 

--- a/docset/winserver2012-ps/remoteaccess/Install-RemoteAccess.md
+++ b/docset/winserver2012-ps/remoteaccess/Install-RemoteAccess.md
@@ -119,7 +119,7 @@ If an appropriate certificate cannot be found, then a self-signed certificate is
 
  ---- If an IPv4 address is detected on the internal interface of the DA server, then the DNS64 or NAT64 configuration is enabled on the DA server which enables DA clients to access corporate network resources that have IPv4 address only by allotting v6 addresses to these hosts. 
 
- ---- This cmdlet also does an auto-discovery of SCCM servers including Domain Controllers and configures them as the Management Servers.
+ ---- This cmdlet also does an auto-discovery of Microsoft Endpoint Configuration Manager servers including Domain Controllers and configures them as the Management Servers.
 
 VPN Installation. 
 

--- a/docset/winserver2012-ps/remoteaccess/Update-DAMgmtServer.md
+++ b/docset/winserver2012-ps/remoteaccess/Update-DAMgmtServer.md
@@ -25,12 +25,12 @@ Update-DAMgmtServer [-AsJob] [-CimSession <CimSession[]>] [-ComputerName <String
 The **Update-DAMgmtServer** cmdlet updates the list of Management servers of the DirectAccess (DA) deployment.
 A management server is any server that needs to be accessed in a DA managed-out deployment or during the first tunnel in a DA full deployment, such as update servers, domain controllers and other servers.
 
-Domain controllers and System Center Configuration Manager servers are discovered automatically.
+Domain controllers and Microsoft Endpoint Configuration Manager servers are discovered automatically.
 Manually entered management server names are resolved to IP addresses. 
 
 Management server configuration is applicable globally to the entire DA deployment and therefore is not impacted by multi-site deployments. 
 
-When the cmdlet runs, the list of automatically discovered domain controllers and System Center Configuration Manager servers is updated.
+When the cmdlet runs, the list of automatically discovered domain controllers and Configuration Manager servers is updated.
 Discovered servers are added to the list, and servers that cannot be discovered are removed.
 IP addresses in the list are updated in accordance with server name resolution.
 

--- a/docset/winserver2012r2-ps/remoteaccess/Install-RemoteAccess.md
+++ b/docset/winserver2012r2-ps/remoteaccess/Install-RemoteAccess.md
@@ -136,7 +136,7 @@ If an appropriate certificate cannot be found, then a self-signed certificate is
                        
  ---- If an IPv4 address is detected on the internal interface of the DA server, then the DNS64 or NAT64 configuration is enabled on the DA server which enables DA clients to access corporate network resources that have IPv4 address only by allotting v6 addresses to these hosts. 
                        
- ---- This cmdlet also does an auto-discovery of SCCM servers including Domain Controllers and configures them as the Management Servers.
+ ---- This cmdlet also does an auto-discovery of Microsoft Endpoint Configuration Manager servers including Domain Controllers and configures them as the Management Servers.
 
 VPN Installation. 
                        

--- a/docset/winserver2012r2-ps/remoteaccess/Update-DAMgmtServer.md
+++ b/docset/winserver2012r2-ps/remoteaccess/Update-DAMgmtServer.md
@@ -32,12 +32,12 @@ Update-DAMgmtServer [-PassThru] [-ComputerName <String>] [-CimSession <CimSessio
 The **Update-DAMgmtServer** cmdlet updates the list of Management servers of the DirectAccess (DA) deployment.
 A management server is any server that needs to be accessed in a DA managed-out deployment or during the first tunnel in a DA full deployment, such as update servers, domain controllers and other servers.
 
-Domain controllers and System Center Configuration Manager servers are discovered automatically.
+Domain controllers and Microsoft Endpoint Configuration Manager servers are discovered automatically.
 Manually entered management server names are resolved to IP addresses. 
 
 Management server configuration is applicable globally to the entire DA deployment and therefore is not impacted by multi-site deployments. 
 
-When the cmdlet runs, the list of automatically discovered domain controllers and System Center Configuration Manager servers is updated.
+When the cmdlet runs, the list of automatically discovered domain controllers and Configuration Manager servers is updated.
 Discovered servers are added to the list, and servers that cannot be discovered are removed.
 IP addresses in the list are updated in accordance with server name resolution.
 


### PR DESCRIPTION
[User Story 1643831](https://mseng.visualstudio.com/TechnicalContent/_workitems/edit/1643831): Content Update: ConfigMgr rebrand

System Center Configuration Manager is now part of Microsoft Endpoint Manager with Intune, Desktop Analytics, Autopilot, and the Device Management Admin Center (DMAC). 

Its full brand name is now **Microsoft Endpoint Configuration Manager**.

This PR addresses the rebranding of all instances of "System Center Configuration Manager" and "SCCM" in this repo.

NOTE: I left 8 instances of "SCCM" where it was being used as a parameter value.