### PR TITLE
Adfs Module: Improve Inputs and Outputs for the AdfsDeviceRegistrationUpnSuffix Cmdlets

### DIFF
--- a/docset/windows/adfs/Add-AdfsDeviceRegistrationUpnSuffix.md
+++ b/docset/windows/adfs/Add-AdfsDeviceRegistrationUpnSuffix.md
@@ -104,7 +104,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-String objects are received by the UpnSuffix parameter.
+String objects are received by the *UpnSuffix* parameter.
 
 ## OUTPUTS
 

--- a/docset/windows/adfs/Add-AdfsDeviceRegistrationUpnSuffix.md
+++ b/docset/windows/adfs/Add-AdfsDeviceRegistrationUpnSuffix.md
@@ -102,7 +102,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### string
+### System.String
+
+String objects are received by the UpnSuffix parameter.
 
 ## OUTPUTS
 

--- a/docset/windows/adfs/Get-AdfsDeviceRegistrationUpnSuffix.md
+++ b/docset/windows/adfs/Get-AdfsDeviceRegistrationUpnSuffix.md
@@ -58,7 +58,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.IdentityServer.Management.Commands.GetAdfsDeviceRegistrationUpnSuffix+DrsBinding
 
-Returns one or more DrsBinding objects that represent the deevice registration service UPN suffix resources for the Federation Service.
+Returns one or more DrsBinding objects that represent the device registration service UPN suffix resources for the Federation Service.
 
 ## NOTES
 
@@ -69,4 +69,3 @@ Returns one or more DrsBinding objects that represent the deevice registration s
 [Remove-AdfsDeviceRegistrationUpnSuffix](./Remove-AdfsDeviceRegistrationUpnSuffix.md)
 
 [Set-AdfsDeviceRegistrationUpnSuffix](./Set-AdfsDeviceRegistrationUpnSuffix.md)
-

--- a/docset/windows/adfs/Get-AdfsDeviceRegistrationUpnSuffix.md
+++ b/docset/windows/adfs/Get-AdfsDeviceRegistrationUpnSuffix.md
@@ -56,15 +56,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### DrsBinding
-- Upn: **string**
-- SslPort: **ushort**
-- IsSetAsSslBinding: **bool**
-- IsCustom: **bool**
-- Upn: **string**
-- SslPort: **ushort**
-- IsSetAsSslBinding: **bool**
-- IsCustom: **bool**
+### Microsoft.IdentityServer.Management.Commands.GetAdfsDeviceRegistrationUpnSuffix+DrsBinding
+
+Returns one or more DrsBinding objects that represent the deevice registration service UPN suffix resources for the Federation Service.
 
 ## NOTES
 

--- a/docset/windows/adfs/Remove-AdfsDeviceRegistrationUpnSuffix.md
+++ b/docset/windows/adfs/Remove-AdfsDeviceRegistrationUpnSuffix.md
@@ -114,7 +114,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### string
+### System.String
+
+String objects are received by the *UpnSuffix* parameter.
 
 ## OUTPUTS
 

--- a/docset/windows/adfs/Set-AdfsDeviceRegistrationUpnSuffix.md
+++ b/docset/windows/adfs/Set-AdfsDeviceRegistrationUpnSuffix.md
@@ -107,7 +107,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### switch
+### System.Management.Automation.SwitchParameter
+
+SwitchParameter objects are received by the *Force* parameter.
 
 ## OUTPUTS
 


### PR DESCRIPTION
This PR improves the descriptions for the Inputs and Outputs section of the following AdfsDeviceRegistrationUpnSuffix cmdlets:

- Add-AdfsDeviceRegistrationUpnSuffix
- Get-AdfsDeviceRegistrationUpnSuffix
- Remove-AdfsDeviceRegistrationUpnSuffix
- Set-AdfsDeviceRegistrationUpnSuffix