### PR TITLE
Adfs Module: Improve Inputs and Outputs for the AdfsCertificateAuthority Cmdlets

### DIFF
--- a/docset/windows/adfs/Disable-AdfsCertificateAuthority.md
+++ b/docset/windows/adfs/Disable-AdfsCertificateAuthority.md
@@ -91,6 +91,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
+### Microsoft.IdentityServer.Management.Resources.AdfsCertificateAuthority
+
+Returns the disabled AdfsCertificatAuthority object when the *PassThru* parameter is specified. By default, this cmdlet does not generate any output.
+
 ## NOTES
 
 ## RELATED LINKS

--- a/docset/windows/adfs/Get-AdfsCertificateAuthority.md
+++ b/docset/windows/adfs/Get-AdfsCertificateAuthority.md
@@ -44,6 +44,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
+### Microsoft.IdentityServer.Management.Resources.AdfsCertificateAuthority
+
+Returns an AdfsCertificateAuthority object that represents the certificate authority of the Federation Service.
+
 ## NOTES
 
 ## RELATED LINKS

--- a/docset/windows/adfs/Set-AdfsCertificateAuthority.md
+++ b/docset/windows/adfs/Set-AdfsCertificateAuthority.md
@@ -262,6 +262,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
+### Microsoft.IdentityServer.Management.Resources.AdfsCertificateAuthority
+
+Returns the updated AdfsCertificateAuthority object when the *PassThru* parameter is specified. By default, this cmdlet does not generate any output.
+
 ## NOTES
 
 ## RELATED LINKS


### PR DESCRIPTION
This PR improves the descriptions for the Inputs and Outputs section of the following AdfsCertificateAuthority cmdlets:

- Disable-AdfsCertificateAuthority
- Get-AdfsCertificateAuthority
- Set-AdfsCertificateAuthority