### PR TITLE
Adfs Module: Improve Inputs and Outputs for the AdfsScopeDescription Cmdlets

### DIFF
--- a/docset/windows/adfs/Add-AdfsScopeDescription.md
+++ b/docset/windows/adfs/Add-AdfsScopeDescription.md
@@ -120,7 +120,15 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### System.String
+
+String objects are received by the *Description* and *Name* parameters.
+
 ## OUTPUTS
+
+### Microsoft.IdentityServer.Management.Resources.OAuthScopeDescription
+
+Returns the new OAuthScopeDescription object when the *PassThru* parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
 

--- a/docset/windows/adfs/Get-AdfsScopeDescription.md
+++ b/docset/windows/adfs/Get-AdfsScopeDescription.md
@@ -57,7 +57,15 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### System.String
+
+String objects are received by the *Name* parameter.
+
 ## OUTPUTS
+
+### Microsoft.IdentityServer.Management.Resources.OAuthScopeDescription
+
+Returns one or more OAuthScopeDescription objects that represent the scope descriptions for the Federation Service.
 
 ## NOTES
 

--- a/docset/windows/adfs/Remove-AdfsScopeDescription.md
+++ b/docset/windows/adfs/Remove-AdfsScopeDescription.md
@@ -109,6 +109,14 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### Microsoft.IdentityServer.Management.Resources.OAuthScopeDescription
+
+OAuthScopeDescription objects are received by the *InputObject* parameter.
+
+### System.String
+
+String objects are received by the *TargetName* parameter.
+
 ## OUTPUTS
 
 ## NOTES

--- a/docset/windows/adfs/Set-AdfsScopeDescription.md
+++ b/docset/windows/adfs/Set-AdfsScopeDescription.md
@@ -131,6 +131,14 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### Microsoft.IdentityServer.Management.Resources.OAuthScopeDescription
+
+OAuthScopeDescription objects are received by the *InputObject* parameter.
+
+### System.String
+
+String objects are received by the *TargetName* parameter.
+
 ## OUTPUTS
 
 ## NOTES


### PR DESCRIPTION
This PR improves the descriptions for the Inputs and Outputs section of the following AdfsScopeDescription cmdlets:

- Get-AdfsScopeDescription
- Set-AdfsScopeDescription
- Add-AdfsScopeDescription
- Remove-AdfsScopeDescription