### PR TITLE
Correct -PolicyStore path example

### DIFF
--- a/docset/windows/netsecurity/Set-NetFirewallProfile.md
+++ b/docset/windows/netsecurity/Set-NetFirewallProfile.md
@@ -92,7 +92,7 @@ This example modifies the default inbound action of the domain profile.
 
 ### Example 4
 ```
-PS C:\>$nfProfile = Get-NetFirewallProfile -Name Private -PolicyStore corp.contoso.com/gpo_name
+PS C:\>$nfProfile = Get-NetFirewallProfile -Name Private -PolicyStore corp.contoso.com\gpo_name
 
 
 
@@ -100,7 +100,7 @@ PS C:\>Set-NetFirewallProfile -AllowUnicastResponseToMulticast True -InputObject
 
 
 This cmdlet can be run using only the pipeline.
-PS C:\>Get-NetFirewallProfile -Name Private -PolicyStore corp.contoso.com/gpo_name | Set-NetFirewallProfile -AllowUnicastResponseToMulticast True
+PS C:\>Get-NetFirewallProfile -Name Private -PolicyStore corp.contoso.com\gpo_name | Set-NetFirewallProfile -AllowUnicastResponseToMulticast True
 ```
 
 This example modifies the private profile associated with a GPO.

--- a/docset/windows/netsecurity/Set-NetFirewallProfile.md
+++ b/docset/windows/netsecurity/Set-NetFirewallProfile.md
@@ -93,11 +93,7 @@ This example modifies the default inbound action of the domain profile.
 ### Example 4
 ```
 PS C:\>$nfProfile = Get-NetFirewallProfile -Name Private -PolicyStore corp.contoso.com\gpo_name
-
-
-
 PS C:\>Set-NetFirewallProfile -AllowUnicastResponseToMulticast True -InputObject $nfProfile
-
 
 This cmdlet can be run using only the pipeline.
 PS C:\>Get-NetFirewallProfile -Name Private -PolicyStore corp.contoso.com\gpo_name | Set-NetFirewallProfile -AllowUnicastResponseToMulticast True
@@ -108,11 +104,7 @@ This example modifies the private profile associated with a GPO.
 ### Example 5
 ```
 PS C:\>$nfProfile = Get-NetFirewallRule -DisplayName "Unicast Rule" | Get-NetFirewallProfile
-
-
-
 PS C:\>Set-NetFirewallProfile -AllowUnicastResponseToMulticast True -InputObject $nfProfile
-
 
 This cmdlet can be run using only the pipeline.
 PS C:\>Get-NetFirewallRule -DisplayName "Unicast Rule" | Get-NetFirewallProfile | Set-NetFirewallProfile -AllowUnicastResponseToMulticast True


### PR DESCRIPTION
The example shows forward slashes in the PolicyStore parameter, which does not work in the cmdlet. A backslash is required - this is also shown in the documentation for the parameter itself.