### PR TITLE
Get-MsmqQueue doesn't work for remote queues, incorrect usage of -Recoverable

### DIFF
--- a/docset/winserver2012-ps/msmq/Send-MsmqQueue.md
+++ b/docset/winserver2012-ps/msmq/Send-MsmqQueue.md
@@ -38,12 +38,12 @@ It returns a **System.Messaging.Message** object that represents the message sen
 
 ## EXAMPLES
 
-### Example 1: Send a test message to a discovered local queue
+### Example 1: Send a test message to a local queue
 ```
 PS C:\>Get-MsmqQueue -Name "order_queue" | Send-MsmqQueue -Recoverable -Label "From Windows PowerShell"
 ```
 
-This command sends a non-transactional recoverable (durable) test message to the local queue named "order_queue" with a label named "From Windows PowerShell".
+This command sends a non-transactional recoverable test message to the local queue named "order_queue" with a label named "From Windows PowerShell". Recoverable messages are written to disk and resilient to system crashes for guaranteed delivery.
 
 ### Example 2: Send a test message to a remote queue with a label
 ```
@@ -285,4 +285,3 @@ Accept wildcard characters: False
 [Remove-MsmqQueue](./Remove-MsmqQueue.md)
 
 [Set-MsmqQueue](./Set-MsmqQueue.md)
-

--- a/docset/winserver2012-ps/msmq/Send-MsmqQueue.md
+++ b/docset/winserver2012-ps/msmq/Send-MsmqQueue.md
@@ -38,19 +38,19 @@ It returns a **System.Messaging.Message** object that represents the message sen
 
 ## EXAMPLES
 
-### Example 1: Send a test message to a queue
+### Example 1: Send a test message to a discovered local queue
 ```
-PS C:\>Get-MsmqQueue -Name "a04bm10\private$\order_queue" | Send-MsmqQueue -Recoverable -Transactional -AdminQueuePath ".\private$\admin_queue"
-```
-
-This command sends a recoverable and transactional test message to the queue named a04bm10\private$\order_queue.
-
-### Example 2: Send a test message to a queue with a label
-```
-PS C:\>Get-MsmqQueue -Name "FormatName:DIRECT=TCP:10.199.37.61\order_queue"| Send-MsmqQueue -Transactional -Label "From Windows PowerShell"
+PS C:\>Get-MsmqQueue -Name "order_queue" | Send-MsmqQueue -Recoverable -Label "From Windows PowerShell"
 ```
 
-This command sends a transactional test message to the queue named FormatName:DIRECT=TCP:10.199.37.61\order_queue with the label named From Windows PowerShell.
+This command sends a non-transactional recoverable (durable) test message to the local queue named "order_queue" with a label named "From Windows PowerShell".
+
+### Example 2: Send a test message to a remote queue with a label
+```
+PS C:\>Send-MsmqQueue -Name "FormatName:DIRECT=TCP:10.199.37.61\order_queue" -Transactional -Label "From Windows PowerShell"
+```
+
+This command sends a transactional test message to the remote queue named "FormatName:DIRECT=TCP:10.199.37.61\order_queue" with a label named "From Windows PowerShell".
 
 ## PARAMETERS
 


### PR DESCRIPTION
I could not get *any* output on `Get-MsmqQueue -Name` except for local queues that can be filtered. `Get-MsmqQueue` doesn't work for remote queues.

Also, the sample shows incorrect usage of `-Recoverable`. Transactional messages are by design recoverable as the recoverable flag only affects non-transactional messages. Using -Recoverable on non-transactional messages ensure they are written to disk.

