### PR TITLE
Update New-VM.md

### DIFF
--- a/docset/windows/hyper-v/New-VM.md
+++ b/docset/windows/hyper-v/New-VM.md
@@ -21,11 +21,13 @@ ms.assetid: 99205277-D2BB-4879-ABC2-9FD1CA5BD2A5
 # New-VM
 
 ## SYNOPSIS
+
 Creates a new virtual machine.
 
 ## SYNTAX
 
 ### No VHD (Default)
+
 ```
 New-VM [[-Name] <String>] [[-MemoryStartupBytes] <Int64>] [-BootDevice <BootDevice>] [-NoVHD]
  [-SwitchName <String>] [-Path <String>] [-Version <Version>] [-Prerelease] [-Experimental]
@@ -34,6 +36,7 @@ New-VM [[-Name] <String>] [[-MemoryStartupBytes] <Int64>] [-BootDevice <BootDevi
 ```
 
 ### New VHD
+
 ```
 New-VM [[-Name] <String>] [[-MemoryStartupBytes] <Int64>] [-BootDevice <BootDevice>] [-SwitchName <String>]
  -NewVHDPath <String> -NewVHDSizeBytes <UInt64> [-Path <String>] [-Version <Version>] [-Prerelease]
@@ -42,6 +45,7 @@ New-VM [[-Name] <String>] [[-MemoryStartupBytes] <Int64>] [-BootDevice <BootDevi
 ```
 
 ### Existing VHD
+
 ```
 New-VM [[-Name] <String>] [[-MemoryStartupBytes] <Int64>] [-BootDevice <BootDevice>] [-SwitchName <String>]
  -VHDPath <String> [-Path <String>] [-Version <Version>] [-Prerelease] [-Experimental] [[-Generation] <Int16>]
@@ -50,26 +54,30 @@ New-VM [[-Name] <String>] [[-MemoryStartupBytes] <Int64>] [-BootDevice <BootDevi
 ```
 
 ## DESCRIPTION
+
 The **New-VM** cmdlet creates a new virtual machine.
 
 ## EXAMPLES
 
 ### Example 1
-```
-PS C:\> New-VM -Name "new 1" -MemoryStartupBytes 512MB
+
+```powershell
+New-VM -Name "new 1" -MemoryStartupBytes 512MB
 ```
 
 This example creates a new virtual machine named new 1 that has 512 MB of memory.
 
 ### Example 2
-```
-PS C:\> New-VM -Name "new 2" -MemoryStartupBytes 1GB -NewVHDPath d:\vhd\base.vhdx
+
+```powershell
+New-VM -Name "new 2" -MemoryStartupBytes 1GB -NewVHDPath d:\vhd\base.vhdx -NewVHDSizeBytes 30GB
 ```
 
 This example creates a virtual machine named new 2 that has 1 GB of memory and that is connected to a new 40 GB virtual hard disk that uses the VHDX format.
 
 ### Example 3
-```
+
+```powershell
 PS C:\> New-VM -Name "new 3" -MemoryStartupBytes 1GB -VHDPath d:\vhd\BaseImage.vhdx
 ```
 
@@ -78,12 +86,13 @@ This example creates a virtual machine named new 3 that has 1 GB of memory and c
 ## PARAMETERS
 
 ### -AsJob
+
 Runs the cmdlet as a background job.
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -93,6 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### -BootDevice
+
 Specifies the device to use as the boot device for the new virtual machine.
 Allowed values are **CD**, **Floppy**, **LegacyNetworkAdapter**, **IDE**, NetworkAdapter, and VHD.
 
@@ -107,7 +117,7 @@ If you specify them on a Generation 1 virtual machine, then they are interpreted
 ```yaml
 Type: BootDevice
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: Floppy, CD, IDE, LegacyNetworkAdapter, NetworkAdapter, VHD
 
 Required: False
@@ -118,6 +128,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
+
 Runs the cmdlet in a remote session or on a remote computer.
 Enter a computer name or a session object, such as the output of a [New-CimSession](http://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](http://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
@@ -125,7 +136,7 @@ The default is the current session on the local computer.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -135,6 +146,7 @@ Accept wildcard characters: False
 ```
 
 ### -ComputerName
+
 Specifies one or more Hyper-V hosts on which the virtual machine is to be created.
 NetBIOS names, IP addresses, and fully qualified domain names are allowable.
 The default is the local computer.
@@ -143,7 +155,7 @@ Use localhost or a dot (.) to specify the local computer explicitly.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -153,6 +165,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -168,13 +181,14 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
+
 Specifies one or more user accounts that have permission to perform this action.
 The default is the current user.
 
 ```yaml
 Type: PSCredential[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -185,11 +199,10 @@ Accept wildcard characters: False
 
 ### -Experimental
 
-
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -200,11 +213,10 @@ Accept wildcard characters: False
 
 ### -Force
 
-
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -214,13 +226,14 @@ Accept wildcard characters: False
 ```
 
 ### -Generation
+
 Specifies the generation, as an integer, for the virtual machine.
 The values that are valid in this version of Windows are 1 and 2.
 
 ```yaml
 Type: Int16
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: 1, 2
 
 Required: False
@@ -231,13 +244,14 @@ Accept wildcard characters: False
 ```
 
 ### -MemoryStartupBytes
+
 Specifies the amount of memory, in bytes, to assign to the virtual machine.
 The default value is 512 MB.
 
 ```yaml
 Type: Int64
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 1
@@ -247,6 +261,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies the name of the new virtual machine.
 The default name is New virtual machine.
 
@@ -263,6 +278,7 @@ Accept wildcard characters: False
 ```
 
 ### -NewVHDPath
+
 Creates a new virtual hard disk with the specified path and connects it to the new virtual machine.
 Absolute paths are allowed.
 If only a file name is specified, the virtual hard disk is created in the default path configured for the host.
@@ -270,7 +286,7 @@ If only a file name is specified, the virtual hard disk is created in the defaul
 ```yaml
 Type: String
 Parameter Sets: New VHD
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -280,12 +296,13 @@ Accept wildcard characters: False
 ```
 
 ### -NewVHDSizeBytes
+
 Specifies the size of the dynamic virtual hard disk that is created and attached to the new virtual machine.
 
 ```yaml
 Type: UInt64
 Parameter Sets: New VHD
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -295,12 +312,13 @@ Accept wildcard characters: False
 ```
 
 ### -NoVHD
+
 Creates a virtual machine without attaching any virtual hard disks.
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: No VHD
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -310,12 +328,13 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies the directory to store the files for the new virtual machine.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -326,11 +345,10 @@ Accept wildcard characters: False
 
 ### -Prerelease
 
-
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -340,13 +358,14 @@ Accept wildcard characters: False
 ```
 
 ### -SwitchName
+
 Specifies the friendly name of the virtual switch if you want to connect the new virtual machine to an existing virtual switch to provide connectivity to a network.
 Hyper-V automatically creates a virtual machine with one virtual network adapter, but connecting it to a virtual switch is optional.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -356,12 +375,13 @@ Accept wildcard characters: False
 ```
 
 ### -VHDPath
+
 Specifies the path to a virtual hard disk file.
 
 ```yaml
 Type: String
 Parameter Sets: Existing VHD
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -372,11 +392,10 @@ Accept wildcard characters: False
 
 ### -Version
 
-
 ```yaml
 Type: Version
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -386,6 +405,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -402,6 +422,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -413,4 +434,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/docset/windows/hyper-v/New-VM.md
+++ b/docset/windows/hyper-v/New-VM.md
@@ -78,7 +78,7 @@ This example creates a virtual machine named new 2 that has 1 GB of memory and t
 ### Example 3
 
 ```powershell
-PS C:\> New-VM -Name "new 3" -MemoryStartupBytes 1GB -VHDPath d:\vhd\BaseImage.vhdx
+New-VM -Name "new 3" -MemoryStartupBytes 1GB -VHDPath d:\vhd\BaseImage.vhdx
 ```
 
 This example creates a virtual machine named new 3 that has 1 GB of memory and connects it to an existing virtual hard disk that uses the VHDX format.
@@ -130,7 +130,7 @@ Accept wildcard characters: False
 ### -CimSession
 
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](http://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](http://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -423,7 +423,7 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 


### PR DESCRIPTION
Added missing switch in example 2, first reported in #1732.
Added line shifts to conform with markdown.
Added PowerShell code snippet markdown and removed command prompt from examples.