### PR TITLE
Incorrect Default value listed

### DIFF
--- a/docset/windows/netsecurity/New-NetFirewallRule.md
+++ b/docset/windows/netsecurity/New-NetFirewallRule.md
@@ -238,7 +238,7 @@ Accepted values: Inbound, Outbound
 
 Required: False
 Position: Named
-Default value: None
+Default value: Inbound
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
The description for the -Direction parameter of New-NetFirewallRule describes a default value of Inbound. The table below it lists a default value of None. Updating table with default value of Inbound.