### PR TITLE
Add DataCenterBridging reference to NetLldpModule overview

### DIFF
--- a/docset/windows/netldpagent/NetLldpAgent.md
+++ b/docset/windows/netldpagent/NetLldpAgent.md
@@ -21,7 +21,7 @@ ms.assetid: 29C55F63-4B4F-4E08-919C-E23079F69F7C
 
 # NetLldpAgent Module
 ## Description
-This reference provides cmdlet descriptions and syntax for the following Network Logical Link Discovery Protocol (LLDP) Agent cmdlets:
+This reference provides cmdlet descriptions and syntax for the Network Logical Link Discovery Protocol (LLDP) Agent. Use of the NetLldpAgent module requires the [DataCenterBridging](https://docs.microsoft.com/en-us/windows-server/networking/technologies/dcb/dcb-install) feature to be installed. The following cmdlets are covered by this reference:
 
 ## NetLldpAgent Cmdlets
 ### [Disable-NetLldpAgent](./Disable-NetLldpAgent.md)

--- a/docset/windows/netldpagent/NetLldpAgent.md
+++ b/docset/windows/netldpagent/NetLldpAgent.md
@@ -21,7 +21,7 @@ ms.assetid: 29C55F63-4B4F-4E08-919C-E23079F69F7C
 
 # NetLldpAgent Module
 ## Description
-This reference provides cmdlet descriptions and syntax for the Network Logical Link Discovery Protocol (LLDP) Agent. Use of the NetLldpAgent module requires the [DataCenterBridging](https://docs.microsoft.com/en-us/windows-server/networking/technologies/dcb/dcb-install) feature to be installed. The following cmdlets are covered by this reference:
+This reference provides cmdlet descriptions and syntax for the Network Logical Link Discovery Protocol (LLDP) Agent. Use of the NetLldpAgent module requires the [DataCenterBridging](https://docs.microsoft.com/windows-server/networking/technologies/dcb/dcb-install) feature to be installed. The following cmdlets are covered by this reference:
 
 ## NetLldpAgent Cmdlets
 ### [Disable-NetLldpAgent](./Disable-NetLldpAgent.md)


### PR DESCRIPTION
Added note about DataCenterBridging being a prerequisite for usage of the NetLldpAgent module, due to several forum posts about how to enable the module, as well as claiming the module is missing. This should clarify how to get access to and use the module.