### PR TITLE
Update the maximum size of the cluster log to 2048 MB

### DIFF
--- a/docset/windows/failoverclusters/Set-ClusterLog.md
+++ b/docset/windows/failoverclusters/Set-ClusterLog.md
@@ -117,7 +117,7 @@ Accept wildcard characters: False
 
 ### -Size
 Specifies the log size to set for the cluster.
-The acceptable values for this parameter are:`8` MB to `1024` MB.
+The acceptable values for this parameter are:`8` MB to `2048` MB.
 
 ```yaml
 Type: Int32

--- a/docset/windows/failoverclusters/Set-ClusterLog.md
+++ b/docset/windows/failoverclusters/Set-ClusterLog.md
@@ -48,13 +48,13 @@ This example sets the cluster log to a detail level of 1.
 
 ### Example 2
 ```
-PS C:\> Set-ClusterLog -Size 1024
+PS C:\> Set-ClusterLog -Size 2048
 Name 
 ---- 
 cluster1
 ```
 
-This example sets the cluster log size to 1024 MB.
+This example sets the cluster log size to 2048 MB.
 
 ## PARAMETERS
 


### PR DESCRIPTION
Windows Server 2019 allows one to set the maximum cluster log size as 2048 MB