### PR TITLE
Update to include -StubPackageOption

### DIFF
--- a/docset/windows/dism/Add-AppxProvisionedPackage.md
+++ b/docset/windows/dism/Add-AppxProvisionedPackage.md
@@ -29,7 +29,7 @@ Adds an app package (.appx) that will install for each new user to a Windows ima
 ```
 Add-AppxProvisionedPackage [-FolderPath <String>] [-PackagePath <String>] [-DependencyPackagePath <String[]>]
  [-LicensePath <String>] [-SkipLicense] [-CustomDataPath <String>] -Path <String> [-WindowsDirectory <String>]
- [-SystemDrive <String>] [-LogPath <String>] [-ScratchDirectory <String>] [-LogLevel <LogLevel>]
+ [-SystemDrive <String>] [-LogPath <String>] [-ScratchDirectory <String>] [-StubPackageOption <StubPackageOption>] [-LogLevel <LogLevel>]
  [<CommonParameters>]
 ```
 
@@ -37,7 +37,7 @@ Add-AppxProvisionedPackage [-FolderPath <String>] [-PackagePath <String>] [-Depe
 ```
 Add-AppxProvisionedPackage [-FolderPath <String>] [-PackagePath <String>] [-DependencyPackagePath <String[]>]
  [-LicensePath <String>] [-SkipLicense] [-CustomDataPath <String>] [-Online] [-WindowsDirectory <String>]
- [-SystemDrive <String>] [-LogPath <String>] [-ScratchDirectory <String>] [-LogLevel <LogLevel>]
+ [-SystemDrive <String>] [-LogPath <String>] [-ScratchDirectory <String>] [-StubPackageOption <StubPackageOption>] [-LogLevel <LogLevel>]
  [<CommonParameters>]
 ```
 
@@ -271,6 +271,20 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+### -StubPackageOption
+Specifies the stub preference of the package. If no stub package option is specified than the provisioned package version is set to the predefined stub preferences. 
+
+```yaml
+Type: StubPackageOption
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: InstallFull, InstallStub
 Accept wildcard characters: False
 ```
 

--- a/docset/windows/dism/Add-AppxProvisionedPackage.md
+++ b/docset/windows/dism/Add-AppxProvisionedPackage.md
@@ -274,7 +274,7 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 ### -StubPackageOption
-Specifies the stub preference of the package. If no stub package option is specified than the provisioned package version is set to the predefined stub preferences. 
+Specifies the stub preference of the package. If no stub package option is specified then the provisioned package version is set to the predefined stub preferences. 
 
 ```yaml
 Type: StubPackageOption
@@ -348,4 +348,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-AppxProvisionedPackage](./Remove-AppxProvisionedPackage.md)
 
 [Set-AppXProvisionedDataFile](./Set-AppXProvisionedDataFile.md)
-


### PR DESCRIPTION
The work to include -StubPackageOption has been completed and documentation needs to be updated. 
/StubPackageOption:installstub sets the provision package to the stub version. Implicitly sets the stub preference to stub.
/StubPackageOption:installfull  sets the provision package to the provision the full version. Implicitly sets the stub preference to full.
If no stub package option is specified than the provisioned package version is set to the predefined stub preferences.