### PR TITLE
Corrected faulty example on doc for Enable-PnpDevice

### DIFF
--- a/docset/windows/pnpdevice/Enable-PnpDevice.md
+++ b/docset/windows/pnpdevice/Enable-PnpDevice.md
@@ -52,7 +52,7 @@ This command enables the device that has the specified instance ID.
 
 ### Example 2: Enable all disabled devices
 ```
-PS C:\>Get-PnpDevice | Where-Object {$_.Problem -match 22} | Enable-PnpDevice
+PS C:\>Get-PnpDevice | Where-Object {$_.Problem -eq 22} | Enable-PnpDevice
 ```
 
 This command gets all the PnP devices by using the **Get-PnpDevice** cmdlet, and then passes them to the **Where-Object** cmdlet by using the pipeline operator.


### PR DESCRIPTION
The command which uses -match to validate the error code does not work as intended. Changing it to -eq solved the error.