### PR TITLE
Error in example 2 of Get-PrintJob.md

### DIFF
--- a/docset/windows/printmanagement/Get-PrintJob.md
+++ b/docset/windows/printmanagement/Get-PrintJob.md
@@ -58,7 +58,7 @@ This command retrieves a list of print jobs on the printer named PrinterName.
 ### Example 2: Get a list of print jobs using a printer object
 ```
 PS C:\> $Printer = Get-Printer -Name "PrinterName:"
-PS C:\> Get-PrintJob -InputObject $Printer
+PS C:\> Get-PrintJob -PrinterObject $Printer
 ```
 
 The first command gets a printer named PrinterName: by using the Get-Printer cmdlet.


### PR DESCRIPTION
Example 2 incorrectly references `-InputObject` which is not a valid parameter, the correct parameter is `-PrinterObject`