### PR TITLE
Update Export-DnsServerZone.md

### DIFF
--- a/docset/windows/dnsserver/Export-DnsServerZone.md
+++ b/docset/windows/dnsserver/Export-DnsServerZone.md
@@ -119,7 +119,7 @@ Accept wildcard characters: False
 
 ### -FileName
 Specifies a name for the export file.
-You can include a file path.
+You CANNOT include a file path. the file will be exported to the SYSTEM32 DNS Folder
 
 ```yaml
 Type: String


### PR DESCRIPTION
You cannot include a path when using this command, if you include a path in this filename the export will fail. if you only include a file name the file will export to the system32 dns folder with the name you supplied (not you current working directory either).
The help is plain wrong