### PR TITLE
escape html-tag-like content to make content show on published pages

### DIFF
--- a/docset/windows/addsadministration/New-ADComputer.md
+++ b/docset/windows/addsadministration/New-ADComputer.md
@@ -867,7 +867,7 @@ Accept wildcard characters: False
 Specifies the service principal names for the account.
 This parameter sets the **ServicePrincipalNames** property of the account.
 The LDAP display name (**ldapDisplayName**) for this property is servicePrincipalName.
-To enter multiple values, use the following syntax: <value1>,<value2>,...<valueX>. If the values contain spaces or otherwise require quotation marks, use the following syntax: "<value1>","<value2>",..."<valueX>"."
+To enter multiple values, use the following syntax: `<value1>,<value2>,...<valueX>`. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"<value1>","<value2>",..."<valueX>"`."
 
 ```yaml
 Type: String[]

--- a/docset/windows/addsadministration/New-ADUser.md
+++ b/docset/windows/addsadministration/New-ADUser.md
@@ -1178,7 +1178,7 @@ Accept wildcard characters: False
 Specifies the service principal names for the account.
 This parameter sets the **ServicePrincipalNames** property of the account.
 The LDAP display name (**ldapDisplayName**) for this property is servicePrincipalName.
-To enter multiple values, use the following syntax: <value1>,<value2>,...<valueX>. If the values contain spaces or otherwise require quotation marks, use the following syntax: "<value1>","<value2>",..."<valueX>"."
+To enter multiple values, use the following syntax: `<value1>,<value2>,...<valueX>`. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"<value1>","<value2>",..."<valueX>"`."
 
 ```yaml
 Type: String[]

--- a/docset/winserver2012-ps/activedirectory/New-ADComputer.md
+++ b/docset/winserver2012-ps/activedirectory/New-ADComputer.md
@@ -1013,7 +1013,7 @@ Accept wildcard characters: False
 Specifies the service principal names for the account.
 This parameter sets the ServicePrincipalNames property of the account.
 The LDAP display name (ldapDisplayName) for this property is servicePrincipalName.
-To enter multiple values, use the following syntax: <value1>,<value2>,...<valueX>. If the values contain spaces or otherwise require quotation marks, use the following syntax: "<value1>","<value2>",..."<valueX>"."
+To enter multiple values, use the following syntax: `<value1>,<value2>,...<valueX>`. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"<value1>","<value2>",..."<valueX>"`."
 
 ```yaml
 Type: String[]

--- a/docset/winserver2012-ps/activedirectory/New-ADUser.md
+++ b/docset/winserver2012-ps/activedirectory/New-ADUser.md
@@ -1405,7 +1405,7 @@ Accept wildcard characters: False
 Specifies the service principal names for the account.
 This parameter sets the ServicePrincipalNames property of the account.
 The LDAP display name (ldapDisplayName) for this property is servicePrincipalName.
-To enter multiple values, use the following syntax: <value1>,<value2>,...<valueX>. If the values contain spaces or otherwise require quotation marks, use the following syntax: "<value1>","<value2>",..."<valueX>"."
+To enter multiple values, use the following syntax: `<value1>,<value2>,...<valueX>`. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"<value1>","<value2>",..."<valueX>"`."
 
 ```yaml
 Type: String[]

--- a/docset/winserver2012r2-ps/addsadministration/New-ADComputer.md
+++ b/docset/winserver2012r2-ps/addsadministration/New-ADComputer.md
@@ -866,7 +866,7 @@ Accept wildcard characters: False
 Specifies the service principal names for the account.
 This parameter sets the **ServicePrincipalNames** property of the account.
 The LDAP display name (**ldapDisplayName**) for this property is servicePrincipalName.
-To enter multiple values, use the following syntax: <value1>,<value2>,...<valueX>. If the values contain spaces or otherwise require quotation marks, use the following syntax: "<value1>","<value2>",..."<valueX>"."
+To enter multiple values, use the following syntax: `<value1>,<value2>,...<valueX>`. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"<value1>","<value2>",..."<valueX>"`."
 
 ```yaml
 Type: String[]

--- a/docset/winserver2012r2-ps/addsadministration/New-ADUser.md
+++ b/docset/winserver2012r2-ps/addsadministration/New-ADUser.md
@@ -1182,7 +1182,7 @@ Accept wildcard characters: False
 Specifies the service principal names for the account.
 This parameter sets the **ServicePrincipalNames** property of the account.
 The LDAP display name (**ldapDisplayName**) for this property is servicePrincipalName.
-To enter multiple values, use the following syntax: <value1>,<value2>,...<valueX>. If the values contain spaces or otherwise require quotation marks, use the following syntax: "<value1>","<value2>",..."<valueX>"."
+To enter multiple values, use the following syntax: `<value1>,<value2>,...<valueX>`. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"<value1>","<value2>",..."<valueX>"`."
 
 ```yaml
 Type: String[]


### PR DESCRIPTION
Please escape html-tag-like content with backtick <code>`</code>, otherwise, the content cannot be shown correctly on published pages.
![image](https://user-images.githubusercontent.com/25164547/92872278-6cdd2680-f438-11ea-832d-48d393a934ab.png)
