### PR TITLE
Update New-Partition.md

### DIFF
--- a/docset/windows/storage/New-Partition.md
+++ b/docset/windows/storage/New-Partition.md
@@ -28,28 +28,28 @@ Creates a new partition on an existing Disk object.
 ### ByNumber (Default)
 ```
 New-Partition [-DiskNumber] <UInt32[]> [-Size <UInt64>] [-UseMaximumSize] [-Offset <UInt64>]
- [-Alignment <UInt32>] [-AssignDriveLetter] [-MbrType <MbrType>] [-GptType <String>]
+ [-Alignment <UInt32>] [-DriveLetter <Char>] [-AssignDriveLetter] [-MbrType <MbrType>] [-GptType <String>]
  [-IsHidden] [-IsActive] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
 ```
 
 ### ByUniqueId
 ```
 New-Partition -DiskId <String[]> [-Size <UInt64>] [-UseMaximumSize] [-Offset <UInt64>] [-Alignment <UInt32>]
- [-DriveLetter <Char>] [-MbrType <MbrType>] [-GptType <String>] [-IsHidden] [-IsActive]
+ [-DriveLetter <Char>] [-AssignDriveLetter] [-MbrType <MbrType>] [-GptType <String>] [-IsHidden] [-IsActive]
  [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
 ```
 
 ### ByPath
 ```
 New-Partition -DiskPath <String[]> [-Size <UInt64>] [-UseMaximumSize] [-Offset <UInt64>] [-Alignment <UInt32>]
- [-DriveLetter <Char>] [-MbrType <MbrType>] [-GptType <String>] [-IsHidden] [-IsActive]
+ [-DriveLetter <Char>] [-AssignDriveLetter] [-MbrType <MbrType>] [-GptType <String>] [-IsHidden] [-IsActive]
  [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
 ```
 
 ### InputObject (cdxml)
 ```
 New-Partition -InputObject <CimInstance[]> [-Size <UInt64>] [-UseMaximumSize] [-Offset <UInt64>]
- [-Alignment <UInt32>] [-AssignDriveLetter] [-MbrType <MbrType>] [-GptType <String>]
+ [-Alignment <UInt32>] [-DriveLetter <Char>] [-AssignDriveLetter] [-MbrType <MbrType>] [-GptType <String>]
  [-IsHidden] [-IsActive] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
 ```
 


### PR DESCRIPTION
All versions of the New-Partition command allow specifying either [-DriveLetter <Char>] or [-AssignDriveLetter] as indicated by "Get-Help 'New-Partition'" as well as the first bullet point under "Notes" on this page.