### PR TITLE
Update Remove-ADGroupMember.md

### DIFF
--- a/docset/windows/addsadministration/Remove-ADGroupMember.md
+++ b/docset/windows/addsadministration/Remove-ADGroupMember.md
@@ -1,7 +1,7 @@
 ---
 ms.mktglfcycl: manage
 ms.sitesec: library
-ms.author: v-anbarr
+ms.author: v-kaunu
 author: andreabarr
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: Microsoft.ActiveDirectory.Management.dll-Help.xml
@@ -9,7 +9,7 @@ keywords: powershell, cmdlet
 manager: jasgro
 ms.date: 12/27/2016
 ms.prod: w10
-ms.technology: powershell-windows
+ms.technology: 
 ms.topic: reference
 online version: 
 schema: 2.0.0

--- a/docset/windows/addsadministration/Remove-ADGroupMember.md
+++ b/docset/windows/addsadministration/Remove-ADGroupMember.md
@@ -27,7 +27,7 @@ Removes one or more members from an Active Directory group.
 
 ```
 Remove-ADGroupMember [-WhatIf] [-Confirm] [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADGroup> [-Members] <ADPrincipal[]> [-Partition <String>] [-PassThru] [-Server <String>]
+ [-Identity] <ADGroup> [-Members] <ADPrincipal[]> [-Partition <String>] [-PassThru] [-Server <String>] [-DisablePermissiveModify]
  [<CommonParameters>]
 ```
 
@@ -303,6 +303,25 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisablePermissiveModify
+Group membership updates use permissive modify by default. This suppresses an error when removing a member that is not member of the group.
+When this parameter is used, an error “The specified account name is not a member of the group” is returned.
+
+This parameter is available in Windows Server 2019 with the September 2020 Updates.
+
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
As a result of windows bug "24359250: [RS1] Using Permissive Modify causes extra event 5136 to be written for Group membership changes" a new parameter was added to this cmdlet. It already appears in the online help in Powershell ISE.