### PR TITLE
Update set systemlocale docs

### DIFF
--- a/docset/windows/international/Set-WinSystemLocale.md
+++ b/docset/windows/international/Set-WinSystemLocale.md
@@ -78,7 +78,7 @@ For more information about the CultureInfo object, see [CultureInfo Class](https
 ## NOTES
 Please note that the System Locale setting on the computer is primarily used for legacy code page selection and font fallback. This setting is primarily used by applications that do not support Unicode. It should not be viewed from the sense of a traditional locale or culture info, and should not be confused with the user locale (Regional Format) setting.
 
-When changing the System Locale setting it is highly recommended to also change the Windows Display Language or UI language setting for the computer so that it matches the System Locale. In some cases, the UI language may depend on the code page and/or the font in order to render properly. Failure to do so can result in configurations where non-Unicode applications don't work as intended.
+When changing the System Locale setting it is highly recommended to also change the Windows Display Language or UI language setting for the computer so that it matches the System Locale. In some cases, the UI language may depend on the code page and/or the font to render properly. Failure to do so can result in configurations where non-Unicode applications don't work as intended.
 
 ## RELATED LINKS
 

--- a/docset/windows/international/Set-WinSystemLocale.md
+++ b/docset/windows/international/Set-WinSystemLocale.md
@@ -76,7 +76,9 @@ For more information about the CultureInfo object, see [CultureInfo Class](https
 ## OUTPUTS
 
 ## NOTES
-Please note that the system locale is primarily used for legacy codepage selection and font fallback. If the system locale is changed, it is highly recommended that the Windows Display Language is changed as well to match the locale, since the UI language may depend on the codepage and font to render properly. Failure to do so could result in configurations where the settings don't work as intended.
+Please note that the System Locale setting on the computer is primarily used for legacy code page selection and font fallback. This setting is primarily used by applications that do not support Unicode. It should not be viewed from the sense of a traditional locale or culture info, and should not be confused with the user locale (Regional Format) setting.
+
+When changing the System Locale setting it is highly recommended to also change the Windows Display Language or UI language setting for the computer so that it matches the System Locale. In some cases, the UI language may depend on the code page and/or the font in order to render properly. Failure to do so can result in configurations where non-Unicode applications don't work as intended.
 
 ## RELATED LINKS
 

--- a/docset/windows/international/Set-WinSystemLocale.md
+++ b/docset/windows/international/Set-WinSystemLocale.md
@@ -76,6 +76,8 @@ For more information about the CultureInfo object, see [CultureInfo Class](https
 ## OUTPUTS
 
 ## NOTES
+Please note that the system locale is primarily used for legacy codepage selection and font fallback. If the system locale is changed,
+it is highly recommended that the Windows Display Language is changed as well to match the locale, since the UI language may depend on the codepage and font to render properly. Failure to do so could result in configurations where the settings don't work as intended.
 
 ## RELATED LINKS
 

--- a/docset/windows/international/Set-WinSystemLocale.md
+++ b/docset/windows/international/Set-WinSystemLocale.md
@@ -76,8 +76,7 @@ For more information about the CultureInfo object, see [CultureInfo Class](https
 ## OUTPUTS
 
 ## NOTES
-Please note that the system locale is primarily used for legacy codepage selection and font fallback. If the system locale is changed,
-it is highly recommended that the Windows Display Language is changed as well to match the locale, since the UI language may depend on the codepage and font to render properly. Failure to do so could result in configurations where the settings don't work as intended.
+Please note that the system locale is primarily used for legacy codepage selection and font fallback. If the system locale is changed, it is highly recommended that the Windows Display Language is changed as well to match the locale, since the UI language may depend on the codepage and font to render properly. Failure to do so could result in configurations where the settings don't work as intended.
 
 ## RELATED LINKS
 

--- a/docset/winserver2012-ps/internationalcmdlets/Set-WinSystemLocale.md
+++ b/docset/winserver2012-ps/internationalcmdlets/Set-WinSystemLocale.md
@@ -70,6 +70,9 @@ For more information about the CultureInfo object, see [CultureInfo Class](https
 ## OUTPUTS
 
 ## NOTES
+Please note that the System Locale setting on the computer is primarily used for legacy code page selection and font fallback. This setting is primarily used by applications that do not support Unicode. It should not be viewed from the sense of a traditional locale or culture info, and should not be confused with the user locale (Regional Format) setting.
+
+When changing the System Locale setting it is highly recommended to also change the Windows Display Language or UI language setting for the computer so that it matches the System Locale. In some cases, the UI language may depend on the code page and/or the font to render properly. Failure to do so can result in configurations where non-Unicode applications don't work as intended.
 
 ## RELATED LINKS
 

--- a/docset/winserver2012r2-ps/international/Set-WinSystemLocale.md
+++ b/docset/winserver2012r2-ps/international/Set-WinSystemLocale.md
@@ -71,6 +71,9 @@ For more information about the CultureInfo object, see CultureInfo Classhttp://g
 ## OUTPUTS
 
 ## NOTES
+Please note that the System Locale setting on the computer is primarily used for legacy code page selection and font fallback. This setting is primarily used by applications that do not support Unicode. It should not be viewed from the sense of a traditional locale or culture info, and should not be confused with the user locale (Regional Format) setting.
+
+When changing the System Locale setting it is highly recommended to also change the Windows Display Language or UI language setting for the computer so that it matches the System Locale. In some cases, the UI language may depend on the code page and/or the font to render properly. Failure to do so can result in configurations where non-Unicode applications don't work as intended.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
The Set-WinSystemLocale powershell cmdlet allows to change the system locale, but this doesn't mean that the Windows Display Language needs to be changed as well, which can cause problems and configurations where font fallback doesn't work or the UI is not rendered properly. 

For this reason, I am adding a note on the documentation for people who might need this knowledge or are having problems resulting from this scenarios.