### PR TITLE
-ScanAvgCPULoadFactor

### DIFF
--- a/docset/windows/defender/Set-MpPreference.md
+++ b/docset/windows/defender/Set-MpPreference.md
@@ -752,6 +752,8 @@ The acceptable values for this parameter are: integers from 5 through 100, and t
 Windows Defender does not exceed the percentage of CPU usage that you specify.
 The default value is 50.
 
+Note: This is not a hard limit but rather a guidance for the scanning engine to not exceed this maximum on average.
+
 ```yaml
 Type: Byte
 Parameter Sets: (All)


### PR DESCRIPTION
Is it a hard limit or not. this document doesn't say if it is or it isn't but this doc say it's not a hard limit so have edited this one. Need someone to confirm which is true: https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-antivirus/configure-advanced-scan-types-microsoft-defender-antivirus