### PR TITLE
New-VirtualDisk: Corrects IsEnclosureAware's default value

### DIFF
--- a/docset/windows/storage/New-VirtualDisk.md
+++ b/docset/windows/storage/New-VirtualDisk.md
@@ -325,7 +325,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
For `IsEnclosureAware` there actually **is** a default value.