### PR TITLE
Final cleanup of metadata

### DIFF
--- a/docset/docfx.json
+++ b/docset/docfx.json
@@ -99,6 +99,7 @@
         ],
         "winserver2022-ps/**/*.md": [
           "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/56754133-c3c3-4a9f-af19-71bdbe19fccf"
         ],
         "winserver2019-ps/**/*.md": [
           "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",

--- a/docset/docfx.json
+++ b/docset/docfx.json
@@ -97,11 +97,23 @@
           "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",
           "https://authoring-docs-microsoft.poolparty.biz/devrel/211bc889-ad71-4c77-b1cd-8ea0d02263f9"
         ],
+        "mdop/**/*.yml": [
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/211bc889-ad71-4c77-b1cd-8ea0d02263f9"
+        ],
         "winserver2022-ps/**/*.md": [
           "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",
           "https://authoring-docs-microsoft.poolparty.biz/devrel/56754133-c3c3-4a9f-af19-71bdbe19fccf"
         ],
+        "winserver2022-ps/**/*.yml": [
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/56754133-c3c3-4a9f-af19-71bdbe19fccf"
+        ],
         "winserver2019-ps/**/*.md": [
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/46091ca5-09b4-466c-9539-c4f93b01a036"
+        ],
+        "winserver2019-ps/**/*.yml": [
           "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",
           "https://authoring-docs-microsoft.poolparty.biz/devrel/46091ca5-09b4-466c-9539-c4f93b01a036"
         ],
@@ -110,11 +122,24 @@
           "https://authoring-docs-microsoft.poolparty.biz/devrel/ba9cbf34-2075-4eb6-8fe8-8a65dc77b667",
           "https://authoring-docs-microsoft.poolparty.biz/devrel/bcbcbad5-4208-4783-8035-8481272c98b8"
         ],
+        "winserver2016-ps/**/*.yml": [
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/ba9cbf34-2075-4eb6-8fe8-8a65dc77b667",
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/bcbcbad5-4208-4783-8035-8481272c98b8"
+        ],
         "winserver2012-ps/**/*.md": [
           "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",
           "https://authoring-docs-microsoft.poolparty.biz/devrel/e27ad519-5489-476b-be3f-292774021345"
         ],
+        "winserver2012-ps/**/*.yml": [
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/e27ad519-5489-476b-be3f-292774021345"
+        ],
         "winserver2012r2-ps/**/*.md": [
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",
+          "https://authoring-docs-microsoft.poolparty.biz/devrel/e27ad519-5489-476b-be3f-292774021345"
+        ],
+        "winserver2012r2-ps/**/*.yml": [
           "https://authoring-docs-microsoft.poolparty.biz/devrel/56936876-97d9-45cc-ad1b-9d63320447c8",
           "https://authoring-docs-microsoft.poolparty.biz/devrel/e27ad519-5489-476b-be3f-292774021345"
         ]

--- a/docset/docs-conceptual/mdop/get-started.md
+++ b/docset/docs-conceptual/mdop/get-started.md
@@ -1,15 +1,8 @@
 ---
-ms.technology: 
-author: Kateyanne
-ms.author: v-kaunu
-ms.reviewer:
 description: Use this topic to help manage MDOP technologies with Windows PowerShell.
-keywords: powershell, cmdlet
 ms.date: 12/05/2016
 ms.devlang: powershell
-ms.topic: reference
 title: Microsoft Desktop Optimization Pack Automation with Windows PowerShell
-manager: dansimp
 ---
 
 # Microsoft Desktop Optimization Pack

--- a/docset/docs-conceptual/mdop/get-started.md
+++ b/docset/docs-conceptual/mdop/get-started.md
@@ -7,11 +7,18 @@ title: Microsoft Desktop Optimization Pack Automation with Windows PowerShell
 
 # Microsoft Desktop Optimization Pack
 
-This topic lists the Windows PowerShell modules included with Microsoft Desktop Optimization Pack (MDOP). The modules in the list support automating features of those components and provide links to the cmdlet references for each module. These modules enable you to use cmdlets to administer, maintain, configure, and develop new features for MDOP.
+This topic lists the Windows PowerShell modules included with Microsoft Desktop Optimization Pack
+(MDOP). The modules in the list support automating features of those components and provide links to
+the cmdlet references for each module. These modules enable you to use cmdlets to administer,
+maintain, configure, and develop new features for MDOP.
 
-## MDOP Automation with Windows Powershell
+## MDOP Automation with Windows PowerShell
 
-The table below shows the latest published version of the Help for each module. The Help is available in docs.microsoft.com through the links below, or as Updateable Help files. Updateable Help was introduced with Windows PowerShell 3.0 and enables you to have the latest Help topics available locally on your computer by using the Update-Help cmdlet. For more information, see [about_Updatable_Help](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_updatable_help).
+The table below shows the latest published version of the Help for each module. The Help is
+available in docs.microsoft.com through the links below, or as Updateable Help files. Updateable
+Help was introduced with Windows PowerShell 3.0 and enables you to have the latest Help topics
+available locally on your computer by using the Update-Help cmdlet. For more information, see
+[about_Updatable_Help](/powershell/module/microsoft.powershell.core/about/about_updatable_help).
 
 | Product | Latest product version |
 | - | - |

--- a/docset/docs-conceptual/winserver2012-ps/get-started.md
+++ b/docset/docs-conceptual/winserver2012-ps/get-started.md
@@ -6,11 +6,21 @@ title: Windows 8 and Windows Server 2012
 
 # Windows Server 2012 and Windows 8
 
-This topic lists the Windows PowerShell modules included with Windows Server 2012 and Windows 8. The Windows PowerShell modules in the list support automating the features of those operating systems and provide links to the cmdlet references for each module. These modules enable you to use Windows PowerShell to administer, maintain, configure, and develop new features for Windows Server 2012 and Windows 8.
+This topic lists the Windows PowerShell modules included with Windows Server 2012 and Windows 8. The
+Windows PowerShell modules in the list support automating the features of those operating systems
+and provide links to the cmdlet references for each module. These modules enable you to use Windows
+PowerShell to administer, maintain, configure, and develop new features for Windows Server 2012 and
+Windows 8.
 
-For information about the core features common to all versions of Windows PowerShell, see [Windows PowerShell Core](/powershell/scripting).
+For information about the core features common to all versions of Windows PowerShell, see
+[Windows PowerShell Core](/powershell/scripting).
 
-The table below also shows the latest published version of the Help for each module. The Help is available through the links below, or as Updatable Help files. Updatable Help was introduced with Windows PowerShell 3.0 and enables you to have the latest Help topics available locally on your computer. See [about_Updatable_Help](/powershell/module/microsoft.powershell.core/about/about_updatable_help) for more information.
+The table below also shows the latest published version of the Help for each module. The Help is
+available through the links below, or as Updatable Help files. Updatable Help was introduced with
+Windows PowerShell 3.0 and enables you to have the latest Help topics available locally on your
+computer. See
+[about_Updatable_Help](/powershell/module/microsoft.powershell.core/about/about_updatable_help) for
+more information.
 
 ## Windows PowerShell features
 
@@ -92,7 +102,5 @@ The table below also shows the latest published version of the Help for each mod
 | WindowsErrorReporting | [Windows Error Reporting Cmdlets](/powershell/module/windowserrorreporting) |
 | WindowsServerBackup | [Windows Server Backup Cmdlets](/powershell/module/windowsserverbackup) |
 | WSSCmdlets | [Windows Server Backup Cmdlets](/powershell/module/wsscmdlets) |
-<!-- | BitsTransfer | [BITS Cmdlets]("https://technet.microsoft.com/library/jj590836(v=wps.620).aspx") | -->
-<!-- | PowerShellWebAccess | [Windows PowerShell Web Access Cmdlets]("https://technet.microsoft.com/library/jj592887(v=wps.620).aspx") | -->
 
 You can also find these modules by searching the [PowerShell Module Browser](/powershell/module/).

--- a/docset/docs-conceptual/winserver2012-ps/get-started.md
+++ b/docset/docs-conceptual/winserver2012-ps/get-started.md
@@ -1,10 +1,7 @@
 ---
-title: Windows 8 and Windows Server 2012
 description: Use this topic to help manage Windows 8 and Windows Server 2012 technologies with Windows PowerShell.
-manager: dansimp
 ms.date: 03/29/2021
-ms.author: v-kaunu
-author: Kateyanne
+title: Windows 8 and Windows Server 2012
 ---
 
 # Windows Server 2012 and Windows 8

--- a/docset/docs-conceptual/winserver2012r2-ps/get-started.md
+++ b/docset/docs-conceptual/winserver2012r2-ps/get-started.md
@@ -6,9 +6,18 @@ title: Windows 8.1 and Windows Server 2012 R2
 
 # Windows Server 2012 R2 and Windows 8.1
 
-This topic lists the Windows PowerShellÂ&reg; modules included with Windows Server 2012 R2 and Windows 8.1. The Windows PowerShell modules in the list support automating the features of those operating systems and provide links to the cmdlet references for each module. These modules enable you to use Windows PowerShell to administer, maintain, configure, and develop new features for and Windows Server 2012 R2.
+This topic lists the Windows PowerShellÂ&reg; modules included with Windows Server 2012 R2 and
+Windows 8.1. The Windows PowerShell modules in the list support automating the features of those
+operating systems and provide links to the cmdlet references for each module. These modules enable
+you to use Windows PowerShell to administer, maintain, configure, and develop new features for and
+Windows Server 2012 R2.
 
-The table below also shows the latest published version of the Help for each module. The Help is available in the TechNet Library through the links below, or as Updatable Help files. Updatable Help was introduced with Windows PowerShell 3.0 and enables you to have the latest Help topics available locally on your computer. See [about\_Updatable\_Help](/powershell/module/microsoft.powershell.core/about/about_updatable_help) for more information.
+The table below also shows the latest published version of the Help for each module. The Help is
+available in the TechNet Library through the links below, or as Updatable Help files. Updatable Help
+was introduced with Windows PowerShell 3.0 and enables you to have the latest Help topics available
+locally on your computer. See
+[about_Updatable_Help](/powershell/module/microsoft.powershell.core/about/about_updatable_help)
+for more information.
 
 ## Windows and Windows Server Automation with Windows PowerShell
 

--- a/docset/docs-conceptual/winserver2012r2-ps/get-started.md
+++ b/docset/docs-conceptual/winserver2012r2-ps/get-started.md
@@ -1,10 +1,7 @@
 ---
-title: Windows 8.1 and Windows Server 2012 R2
 description: Use this topic to help manage Windows 8.1 and Windows Server 21012 R2 technologies with Windows PowerShell.
-manager: dansimp
 ms.date: 03/29/2021
-ms.author: v-kaunu
-author: Kateyanne
+title: Windows 8.1 and Windows Server 2012 R2
 ---
 
 # Windows Server 2012 R2 and Windows 8.1

--- a/docset/docs-conceptual/winserver2016-ps/get-started.md
+++ b/docset/docs-conceptual/winserver2016-ps/get-started.md
@@ -1,14 +1,7 @@
 ---
-ms.mktglfcycl: manage
-ms.sitesec: library
-ms.author: v-kaunu
-title: Windows Server 2016
-ms.reviewer:
 description: Use this topic to help manage Windows Server technologies with Windows PowerShell on Windows Server 2016.
-author: Kateyanne
-ms.assetid: f16d306b-a30a-45b3-a585-c450ad7ba93b
-manager: dansimp
 ms.date: 09/26/2017
+title: Windows Server 2016
 ---
 
 

--- a/docset/docs-conceptual/winserver2019-ps/get-started.md
+++ b/docset/docs-conceptual/winserver2019-ps/get-started.md
@@ -1,11 +1,7 @@
 ---
-ms.author: jgerend
-title: Windows 10 and Windows Server 2019
-ms.reviewer:
 description: Use this topic to help manage Windows 10 and Windows Server 2019 technologies with Windows PowerShell.
-author: JasonGerend
-manager: dansimp
 ms.date: 03/29/2021
+title: Windows 10 and Windows Server 2019
 ---
 
 # Windows 10 and Windows Server 2019

--- a/docset/docs-conceptual/winserver2019-ps/get-started.md
+++ b/docset/docs-conceptual/winserver2019-ps/get-started.md
@@ -6,9 +6,17 @@ title: Windows 10 and Windows Server 2019
 
 # Windows 10 and Windows Server 2019
 
-This topic lists the Windows PowerShell modules included with Windows Server 2019 and Windows 10. The Windows PowerShell modules in the list support automating the features of those versions of the Windows operating system and provide links to the cmdlet references for each module. These modules enable you to use Windows PowerShell to administer, maintain, configure, and develop new features for Windows Server 2019 and Windows 10.
+This topic lists the Windows PowerShell modules included with Windows Server 2019 and Windows 10.
+The Windows PowerShell modules in the list support automating the features of those versions of the
+Windows operating system and provide links to the cmdlet references for each module. These modules
+enable you to use Windows PowerShell to administer, maintain, configure, and develop new features
+for Windows Server 2019 and Windows 10.
 
-The table below also shows the latest published version of the Help for each module. The Help is available through the links below, or as Updatable Help files. Updatable Help was introduced with Windows PowerShell 3.0 and enables you to have the latest Help topics available locally on your computer. For more information, see [about_Updatable_Help](/powershell/module/microsoft.powershell.core/about/about_updatable_help).
+The table below also shows the latest published version of the Help for each module. The Help is
+available through the links below, or as Updatable Help files. Updatable Help was introduced with
+Windows PowerShell 3.0 and enables you to have the latest Help topics available locally on your
+computer. For more information, see
+[about_Updatable_Help](/powershell/module/microsoft.powershell.core/about/about_updatable_help).
 
 | Module name | Title and link to Web version |
 | - | - |

--- a/docset/docs-conceptual/winserver2022-ps/get-started.md
+++ b/docset/docs-conceptual/winserver2022-ps/get-started.md
@@ -1,11 +1,7 @@
 ---
-ms.author: jgerend
-title: Windows 10 and Windows Server 2019
-ms.reviewer:
 description: Use this topic to help manage Windows 10 and Windows Server 2022 technologies with Windows PowerShell.
-author: JasonGerend
-manager: dansimp
 ms.date: 03/29/2021
+title: Windows 10 and Windows Server 2019
 ---
 
 # Windows 10 and Windows Server 2022

--- a/docset/docs-conceptual/winserver2022-ps/get-started.md
+++ b/docset/docs-conceptual/winserver2022-ps/get-started.md
@@ -16,7 +16,7 @@ The table below also shows the latest published version of the Help for each mod
 available through the links below, or as Updatable Help files. Updatable Help was introduced with
 Windows PowerShell 3.0 and enables you to have the latest Help topics available locally on your
 computer. For more information, see
-[about_Updatable_Help](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_updatable_help).
+[about_Updatable_Help](/powershell/module/microsoft.powershell.core/about/about_updatable_help).
 
 | Module name | Title and link to Web version |
 | - | - |

--- a/docset/mapping/cabgenConfig.json
+++ b/docset/mapping/cabgenConfig.json
@@ -24,19 +24,6 @@
                     "docset/winserver2016-ps/Microsoft.Windows.ServerManager.Migration",
                     "docset/winserver2016-ps/windowsdiagnosticdata"
                 ]
-            },
-            "winserver2012r2-ps": {
-                "exclude": [
-                    "docset/winserver2012r2-ps/hpc",
-                    "docset/winserver2012r2-ps/hyper-v",
-                    "docset/winserver2012r2-ps/servermigrationcmdlets"
-                ]
-            },
-            "winserver2012-ps": {
-                "exclude": [
-                    "docset/winserver2012-ps/hyper-v",
-                    "docset/winserver2012-ps/servermigrationcmdlets"
-                ]
             }
         }
     ]


### PR DESCRIPTION
- clean up metadata in conceptual docs
  - fix absolute URL paths
- Add product taxonomy URI  for Server 2022
  - Add taxonomy mappings for yml files
- remove 2012 and 210r2 from cabgen build as temporary fix
  - will restore when DevRel engineering fixes the timeout issue