### PR TITLE
Update Get-TlsCipherSuite.md

### DIFF
--- a/docset/winserver2016-ps/tls/Get-TlsCipherSuite.md
+++ b/docset/winserver2016-ps/tls/Get-TlsCipherSuite.md
@@ -11,7 +11,7 @@ title: Get-TlsCipherSuite
 # Get-TlsCipherSuite
 
 ## SYNOPSIS
-Gets the list of cipher suites for TLS for a computer.
+Gets the TLS cipher suites for a computer.
 
 ## SYNTAX
 
@@ -20,7 +20,7 @@ Get-TlsCipherSuite [[-Name] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-TlsCipherSuite** cmdlet gets the ordered list of cipher suites for a computer that Transport Layer Security (TLS) can use.
+The **Get-TlsCipherSuite** cmdlet gets an ordered collection of cipher suites for a computer that Transport Layer Security (TLS) can use.
 
 For more information about the TLS cipher suites, see the documentation for the Enable-TlsCipherSuite cmdlet or type `Get-Help Enable-TlsCipherSuite`.
 
@@ -99,7 +99,8 @@ Name                  : TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 Protocols             : {771, 65277}
 ```
 
-This command gets all the cipher suites that have names that contain the string AES.
+This command gets all the cipher suites that have names that contain the string `AES`.
+Note that the name match is case sensitive and this command returns no output for the name `aes`.
 The output includes a field for the TLS/SSL protocols supported by the cipher. See [Cipher Suites in TLS/SSL (Schannel SSP)](https://docs.microsoft.com/windows/desktop/secauthn/cipher-suites-in-schannel) for more information.
 
 
@@ -108,6 +109,7 @@ The output includes a field for the TLS/SSL protocols supported by the cipher. S
 ### -Name
 Specifies the name of the TLS cipher suite to get.
 The cmdlet gets cipher suites that match the string that this cmdlet specifies, so you can specify a partial name.
+Note that the name match is case sensitive and this command returns no output for the name `aes`.
 
 ```yaml
 Type: String

--- a/docset/winserver2016-ps/tls/Get-TlsCipherSuite.md
+++ b/docset/winserver2016-ps/tls/Get-TlsCipherSuite.md
@@ -101,7 +101,8 @@ Protocols             : {771, 65277}
 
 This command gets all the cipher suites that have names that contain the string `AES`.
 Note that the name match is case sensitive and this command returns no output for the name `aes`.
-The output includes a field for the TLS/SSL protocols supported by the cipher. See [Cipher Suites in TLS/SSL (Schannel SSP)](https://docs.microsoft.com/windows/desktop/secauthn/cipher-suites-in-schannel) for more information.
+The output includes a field for the TLS/SSL protocols supported by the cipher. 
+See [Cipher Suites in TLS/SSL (Schannel SSP)](/windows/desktop/secauthn/cipher-suites-in-schannel) for more information.
 
 
 ## PARAMETERS

--- a/docset/winserver2019-ps/tls/Get-TlsCipherSuite.md
+++ b/docset/winserver2019-ps/tls/Get-TlsCipherSuite.md
@@ -101,7 +101,7 @@ Protocols             : {771, 65277}
 
 This command gets all the cipher suites that have names that contain the string `AES`.
 Note that the name match is case sensitive and this command returns no output for the name `aes`.
-The output includes a field for the TLS/SSL protocols supported by the cipher. See [Cipher Suites in TLS/SSL (Schannel SSP)](https://docs.microsoft.com/windows/desktop/secauthn/cipher-suites-in-schannel) for more information.
+The output includes a field for the TLS/SSL protocols supported by the cipher. See [Cipher Suites in TLS/SSL (Schannel SSP)](/windows/desktop/secauthn/cipher-suites-in-schannel) for more information.
 
 
 ## PARAMETERS
@@ -137,4 +137,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Disable-TlsCipherSuite](./Disable-TlsCipherSuite.md)
 
 [Enable-TlsCipherSuite](./Enable-TlsCipherSuite.md)
-

--- a/docset/winserver2019-ps/tls/Get-TlsCipherSuite.md
+++ b/docset/winserver2019-ps/tls/Get-TlsCipherSuite.md
@@ -11,7 +11,7 @@ title: Get-TlsCipherSuite
 # Get-TlsCipherSuite
 
 ## SYNOPSIS
-Gets the cipher suites for TLS for a computer.
+Gets the TLS cipher suites for a computer.
 
 ## SYNTAX
 
@@ -20,7 +20,7 @@ Get-TlsCipherSuite [[-Name] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-TlsCipherSuite** cmdlet gets the ordered list of cipher suites for a computer that Transport Layer Security (TLS) can use.
+The **Get-TlsCipherSuite** cmdlet gets an ordered collection of cipher suites for a computer that Transport Layer Security (TLS) can use.
 
 For more information about the TLS cipher suites, see the documentation for the Enable-TlsCipherSuite cmdlet or type `Get-Help Enable-TlsCipherSuite`.
 

--- a/docset/winserver2019-ps/tls/Get-TlsCipherSuite.md
+++ b/docset/winserver2019-ps/tls/Get-TlsCipherSuite.md
@@ -11,7 +11,7 @@ title: Get-TlsCipherSuite
 # Get-TlsCipherSuite
 
 ## SYNOPSIS
-Gets the list of cipher suites for TLS for a computer.
+Gets the cipher suites for TLS for a computer.
 
 ## SYNTAX
 
@@ -99,7 +99,8 @@ Name                  : TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 Protocols             : {771, 65277}
 ```
 
-This command gets all the cipher suites that have names that contain the string AES.
+This command gets all the cipher suites that have names that contain the string `AES`.
+Note that the name match is case sensitive and this command returns no output for the name `aes`.
 The output includes a field for the TLS/SSL protocols supported by the cipher. See [Cipher Suites in TLS/SSL (Schannel SSP)](https://docs.microsoft.com/windows/desktop/secauthn/cipher-suites-in-schannel) for more information.
 
 
@@ -107,7 +108,8 @@ The output includes a field for the TLS/SSL protocols supported by the cipher. S
 
 ### -Name
 Specifies the name of the TLS cipher suite to get.
-The cmdlet gets cipher suites that match the string that this cmdlet specifies, so you can specify a partial name.
+The cmdlet gets cipher suites that match the string that this parameter specifies, so you can specify a partial name.
+The name match is case sensitive.
 
 ```yaml
 Type: String

--- a/docset/winserver2022-ps/tls/Get-TlsCipherSuite.md
+++ b/docset/winserver2022-ps/tls/Get-TlsCipherSuite.md
@@ -11,7 +11,7 @@ title: Get-TlsCipherSuite
 # Get-TlsCipherSuite
 
 ## SYNOPSIS
-2022 
+Gets the TLS cipher suites for a computer.
 
 ## SYNTAX
 
@@ -138,4 +138,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Disable-TlsCipherSuite](./Disable-TlsCipherSuite.md)
 
 [Enable-TlsCipherSuite](./Enable-TlsCipherSuite.md)
-

--- a/docset/winserver2022-ps/tls/Get-TlsCipherSuite.md
+++ b/docset/winserver2022-ps/tls/Get-TlsCipherSuite.md
@@ -11,7 +11,7 @@ title: Get-TlsCipherSuite
 # Get-TlsCipherSuite
 
 ## SYNOPSIS
-Gets the list of cipher suites for TLS for a computer.
+2022 
 
 ## SYNTAX
 
@@ -20,7 +20,7 @@ Get-TlsCipherSuite [[-Name] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-TlsCipherSuite** cmdlet gets the ordered list of cipher suites for a computer that Transport Layer Security (TLS) can use.
+The **Get-TlsCipherSuite** cmdlet gets an ordered collection of cipher suites for a computer that Transport Layer Security (TLS) can use.
 
 For more information about the TLS cipher suites, see the documentation for the Enable-TlsCipherSuite cmdlet or type `Get-Help Enable-TlsCipherSuite`.
 
@@ -99,7 +99,8 @@ Name                  : TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 Protocols             : {771, 65277}
 ```
 
-This command gets all the cipher suites that have names that contain the string AES.
+This command gets all the cipher suites that have names that contain the string `AES`.
+Note that the name match is case sensitive and this command returns no output for the name `aes`.
 The output includes a field for the TLS/SSL protocols supported by the cipher. See [Cipher Suites in TLS/SSL (Schannel SSP)](https://docs.microsoft.com/windows/desktop/secauthn/cipher-suites-in-schannel) for more information.
 
 
@@ -108,6 +109,7 @@ The output includes a field for the TLS/SSL protocols supported by the cipher. S
 ### -Name
 Specifies the name of the TLS cipher suite to get.
 The cmdlet gets cipher suites that match the string that this cmdlet specifies, so you can specify a partial name.
+The name match is case sensitive.
 
 ```yaml
 Type: String

--- a/docset/winserver2022-ps/tls/Get-TlsCipherSuite.md
+++ b/docset/winserver2022-ps/tls/Get-TlsCipherSuite.md
@@ -101,7 +101,8 @@ Protocols             : {771, 65277}
 
 This command gets all the cipher suites that have names that contain the string `AES`.
 Note that the name match is case sensitive and this command returns no output for the name `aes`.
-The output includes a field for the TLS/SSL protocols supported by the cipher. See [Cipher Suites in TLS/SSL (Schannel SSP)](https://docs.microsoft.com/windows/desktop/secauthn/cipher-suites-in-schannel) for more information.
+The output includes a field for the TLS/SSL protocols supported by the cipher. 
+See [Cipher Suites in TLS/SSL (Schannel SSP)](/windows/desktop/secauthn/cipher-suites-in-schannel) for more information.
 
 
 ## PARAMETERS


### PR DESCRIPTION
Updated the language in the synopsis.

Updated the cmdlet's Name parameter description and noted that the comparison is case sensitive.

Noted that `-Name AES` is not the same as `-Name aes` are different.