### PR TITLE
Missing ManagementPointNetworkType param

### DIFF
--- a/docset/winserver2019-ps/failoverclusters/New-Cluster.md
+++ b/docset/winserver2019-ps/failoverclusters/New-Cluster.md
@@ -18,7 +18,7 @@ Creates a new failover cluster.
 ```
 New-Cluster [-Name] <String> [-Node <StringCollection>] [-StaticAddress <StringCollection>]
  [-IgnoreNetwork <StringCollection>] [-NoStorage] [-S2D] [-AdministrativeAccessPoint <AdminAccessPoint>]
- [-Force] [-ManagementPointNetworkType {Automatic | Singleton | Distributed}] [<CommonParameters>]
+ [-Force] [-ManagementPointNetworkType <AdminAccessPointResType>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -173,7 +173,7 @@ Specifies the network configuration used to determine IP address settings.
 
 The acceptable values for this parameter are:
 
-- Automatic: Automatically detects the appropriate setting. If SQL Server is running in Azure, uses `Distributed`. If SQL Server is running on-premises, uses `Singleton`. (Default Setting)
+- Automatic: Automatically detects the appropriate setting. If SQL Server is running in Azure, uses `Distributed`. If SQL Server is running on-premises, uses `Singleton`. (Default setting)
 - Singleton: The traditional method of DHCP or static IP address.
 - Distributed: Uses a Distributed Network Name by using Node IP addresses.
 

--- a/docset/winserver2019-ps/failoverclusters/New-Cluster.md
+++ b/docset/winserver2019-ps/failoverclusters/New-Cluster.md
@@ -175,7 +175,7 @@ The acceptable values for this parameter are:
 
 - Automatic: Automatically detects the appropriate setting. If SQL Server is running in Azure, uses `Distributed`. If SQL Server is running on-premises, uses `Singleton`. (Default Setting)
 - Singleton: The traditional method of DHCP or static IP address.
-- Distributed: Use a Distributed Network Name by using Node IP addresses.
+- Distributed: Uses a Distributed Network Name by using Node IP addresses.
 
 ```yaml
 Type: AdminAccessPointResType

--- a/docset/winserver2019-ps/failoverclusters/New-Cluster.md
+++ b/docset/winserver2019-ps/failoverclusters/New-Cluster.md
@@ -18,7 +18,7 @@ Creates a new failover cluster.
 ```
 New-Cluster [-Name] <String> [-Node <StringCollection>] [-StaticAddress <StringCollection>]
  [-IgnoreNetwork <StringCollection>] [-NoStorage] [-S2D] [-AdministrativeAccessPoint <AdminAccessPoint>]
- [-Force] [<CommonParameters>]
+ [-Force] [-ManagementPointNetworkType {Automatic | Singleton | Distributed}] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -158,6 +158,29 @@ Networks with DHCP enabled are always included, but other networks need a static
 
 ```yaml
 Type: StringCollection
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ManagementPointNetworkType
+Specifies the network configuration used to determine IP address settings.
+
+The acceptable values for this parameter are:
+
+```yaml
+Singleton: Uses the traditional method of DHCP or static IP address.
+Distributed: Use a Distributed Network Name by using Node IP addresses.
+Automatic: Uses detection to determine the appropriate setting. If SQL Server is running in Azure, uses Distributed. If SQL Server is running on-premises, uses Singleton (default setting).
+```
+
+```yaml
+Type: AdminAccessPointResType
 Parameter Sets: (All)
 Aliases: 
 

--- a/docset/winserver2019-ps/failoverclusters/New-Cluster.md
+++ b/docset/winserver2019-ps/failoverclusters/New-Cluster.md
@@ -173,11 +173,9 @@ Specifies the network configuration used to determine IP address settings.
 
 The acceptable values for this parameter are:
 
-```yaml
-Singleton: Uses the traditional method of DHCP or static IP address.
-Distributed: Use a Distributed Network Name by using Node IP addresses.
-Automatic: Uses detection to determine the appropriate setting. If SQL Server is running in Azure, uses Distributed. If SQL Server is running on-premises, uses Singleton (default setting).
-```
+- Automatic: Automatically detects the appropriate setting. If SQL Server is running in Azure, uses `Distributed`. If SQL Server is running on-premises, uses `Singleton`. (Default Setting)
+- Singleton: The traditional method of DHCP or static IP address.
+- Distributed: Use a Distributed Network Name by using Node IP addresses.
 
 ```yaml
 Type: AdminAccessPointResType
@@ -186,7 +184,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: Automatic
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
Adding in documentation around the ManagementPointNetworkType parameter for this command.  