### PR TITLE
Remove Hyper-V from CabGen exclusions

### DIFF
--- a/docset/mapping/cabgenConfig.json
+++ b/docset/mapping/cabgenConfig.json
@@ -3,7 +3,6 @@
         {
             "WindowsServer2022-ps": {
                 "exclude": [
-                    "docset/winserver2022-ps/hyper-v",
                     "docset/winserver2022-ps/Microsoft.DiagnosticDataViewer",
                     "docset/winserver2022-ps/Microsoft.Windows.ServerManager.Migration",
                     "docset/winserver2022-ps/windowsdiagnosticdata"
@@ -11,7 +10,6 @@
             },
             "WindowsServer2019-ps": {
                 "exclude": [
-                    "docset/winserver2019-ps/hyper-v",
                     "docset/winserver2019-ps/Microsoft.DiagnosticDataViewer",
                     "docset/winserver2019-ps/Microsoft.Windows.ServerManager.Migration",
                     "docset/winserver2019-ps/windowsdiagnosticdata"
@@ -19,7 +17,6 @@
             },
             "WindowsServer2016-ps": {
                 "exclude": [
-                    "docset/winserver2016-ps/hyper-v",
                     "docset/winserver2016-ps/Microsoft.DiagnosticDataViewer",
                     "docset/winserver2016-ps/Microsoft.Windows.ServerManager.Migration",
                     "docset/winserver2016-ps/windowsdiagnosticdata"
@@ -28,13 +25,11 @@
             "winserver2012r2-ps": {
                 "exclude": [
                     "docset/winserver2012r2-ps/hpc",
-                    "docset/winserver2012r2-ps/hyper-v",
                     "docset/winserver2012r2-ps/servermigrationcmdlets"
                 ]
             },
             "winserver2012-ps": {
                 "exclude": [
-                    "docset/winserver2012-ps/hyper-v",
                     "docset/winserver2012-ps/servermigrationcmdlets"
                 ]
             }


### PR DESCRIPTION
PlatyPS 0.14.2 includes a bug fix that allows PlatyPS to work with modules that have hyphens in the name.