### PR TITLE
WIP: VpnClient PowerShell reference update

### DIFF
--- a/docset/winserver2022-ps/vpnclient/New-EapConfiguration.md
+++ b/docset/winserver2022-ps/vpnclient/New-EapConfiguration.md
@@ -23,9 +23,9 @@ New-EapConfiguration [-UseWinlogonCredential] [-CimSession <CimSession[]>] [-Thr
 
 ### EapTtlsAuth
 ```
-New-EapConfiguration [-UseWinlogonCredential] [-Ttls] [-TunneledNonEapAuthMethod <String>]
- [[-TunneledEapAuthMethod] <XmlDocument>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+New-EapConfiguration [-UseWinlogonCredential] [-Ttls] [-TunnledNonEapAuthMethod <String>]
+ [-TunnledEapAuthMethod <XmlDocument>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ### EapTlsAuth
@@ -36,7 +36,7 @@ New-EapConfiguration [-Tls] [-UserCertificate] [-VerifyServerIdentity] [-CimSess
 
 ### PeapAuth
 ```
-New-EapConfiguration [-VerifyServerIdentity] [[-TunneledEapAuthMethod] <XmlDocument>] [-Peap] [-EnableNap]
+New-EapConfiguration [-VerifyServerIdentity] [-TunnledEapAuthMethod <XmlDocument>] [-Peap] [-EnableNap]
  [-FastReconnect <Boolean>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
@@ -89,14 +89,14 @@ The configuration object is stored in the variable named $A.
 
 ### Example 5: Create a TTLS EAP configuration object with MSCHAPv2 as the client authentication method
 ```
-PS C:\> $A = New-EapConfiguration -Ttls -TunneledNonEapAuthMethod "MSChapv2" -UseWinlogonCredential
+PS C:\> $A = New-EapConfiguration -Ttls -TunnledNonEapAuthMethod "MSChapv2" -UseWinlogonCredential
 ```
 
 This command creates a new EAP configuration object and stores it in the variable named $A.
 The EAP configuration object is customized by specifying the following parameters: 
 
 - The *Ttls* parameter, which indicates that this configuration object uses TTLS as the authentication method
-- The *TunneledNonEapAuthMethod* parameter with the MSChapv2 value, which specifies that MSCHAPv2 is used as the specific client authentication method
+- The *TunnledNonEapAuthMethod* parameter with the MSChapv2 value, which specifies that MSCHAPv2 is used as the specific client authentication method
 - The *UseWinlogonCredential* parameter, which indicates that Windows logon credentials are used automatically when connecting with the VPN connection profile that uses this EAP configuration object.
 
 ### Example 6: Create an EAP configuration object and use it as input
@@ -104,8 +104,8 @@ The EAP configuration object is customized by specifying the following parameter
 This command creates an EAP configuration object configured to use an EAP-TLS authentication method and to verify the server identity. The configuration object is stored in a variable named $B.
 PS C:\>$B = New-EapConfiguration -Tls -VerifyServerIdentity
 
-This command creates an EAP configuration object configured to use the TTLS authentication method, and specifies the *TunneledEapAuthMethod* parameter to use the EapConfigXmlStream created by the first EAP configuration object as the tunnel EAP authentication method.
-PS C:\>$A = New-EapConfiguration -Ttls -TunneledEapAuthMethod $B.EapConfigXmlStream
+This command creates an EAP configuration object configured to use the TTLS authentication method, and specifies the *TunnledEapAuthMethod* parameter to use the EapConfigXmlStream created by the first EAP configuration object as the tunnel EAP authentication method.
+PS C:\>$A = New-EapConfiguration -Ttls -TunnledEapAuthMethod $B.EapConfigXmlStream
 ```
 
 This set of commands creates an EAP configuration object customized with a TTLS authentication method which uses EAP-TLS as the tunneled client authentication method.
@@ -123,8 +123,8 @@ The configuration object is stored in a variable named $A.
 This command creates the EAP configuration object and stores it in the variable named $B. The EAP configuration object is customized to use the TLS authentication method by the *Tls* parameter, and configured to verify the identity of the server by the *VerifyServerIdentity* parameter.This command implicitly configures a smart card to be used for authentication.
 PS C:\>$B = New-EapConfiguration -Tls -VerifyServerIdentity
 
-This command uses the *EapConfigXmlStream* method of the EAP configuration object created in the previous command to specify the value for the *TunneledEapAuthMethod* parameter. This command also specifies that PEAP is the authentication method, as specified by the *Peap* parameter; that NAP is enabled for PEAP, as specified by the *EnableNap* parameter; and that *FastReconnect* is enabled, as specified by the *FastReconnect* parameter. 
-PS C:\>$a = New-EapConfiguration -Peap -EnableNap -FastReconnect $True -VerifyServerIdentity -TunneledEapAuthMethod $b.EapConfigXmlStream
+This command uses the *EapConfigXmlStream* method of the EAP configuration object created in the previous command to specify the value for the *TunnledEapAuthMethod* parameter. This command also specifies that PEAP is the authentication method, as specified by the *Peap* parameter; that NAP is enabled for PEAP, as specified by the *EnableNap* parameter; and that *FastReconnect* is enabled, as specified by the *FastReconnect* parameter. 
+PS C:\>$a = New-EapConfiguration -Peap -EnableNap -FastReconnect $True -VerifyServerIdentity -TunnledEapAuthMethod $b.EapConfigXmlStream
 ```
 
 This set of commands creates an EAP configuration object customized with the TLS authentication method, and then uses its EapConfigXmlStream object as the tunneled authentication method.
@@ -271,7 +271,7 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -TunneledEapAuthMethod
+### -TunnledEapAuthMethod
 Specifies the configuration XML for tunneled EAP, EAP-TTLS, or PEAP authentication.
 
 ```yaml
@@ -280,7 +280,7 @@ Parameter Sets: EapTtlsAuth
 Aliases: TunneledEapAuthMethod
 
 Required: False
-Position: 3
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -292,13 +292,13 @@ Parameter Sets: PeapAuth
 Aliases: TunneledEapAuthMethod
 
 Required: False
-Position: 3
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -TunneledNonEapAuthMethod
+### -TunnledNonEapAuthMethod
 Specifies the simple EAP-TTLS client authentication methods.
 The acceptable values for this parameter are:
 
@@ -310,7 +310,7 @@ The acceptable values for this parameter are:
 ```yaml
 Type: String
 Parameter Sets: EapTtlsAuth
-Aliases: TunneledNonEapAuthMethod
+Aliases: TunnledNonEapAuthMethod
 Accepted values: Pap, Chap, MSChap, MSChapv2
 
 Required: False


### PR DESCRIPTION
[1869910](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1869910)

I think this may be a false positive:

This appears in the current documentation: **TunneledNonEapAuthMethod**
This is the generated version: **TunnledEapAuthMethod**

"TunneledNonEapAuthMethod" is an alias of "TunnledEapAuthMethod".