### PR TITLE
UpdateServices PowerShell reference update

### DIFF
--- a/docset/winserver2022-ps/updateservices/Add-WsusComputer.md
+++ b/docset/winserver2022-ps/updateservices/Add-WsusComputer.md
@@ -110,7 +110,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### None
+### System.Object
 
 ## NOTES
 

--- a/docset/winserver2022-ps/updateservices/Add-WsusDynamicCategory.md
+++ b/docset/winserver2022-ps/updateservices/Add-WsusDynamicCategory.md
@@ -162,11 +162,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### IDynamicCategory
+### Microsoft.UpdateServices.Administration.IDynamicCategory
 
 ## OUTPUTS
 
-### IDynamicCategory
+### System.Object
 
 ## NOTES
 

--- a/docset/winserver2022-ps/updateservices/Approve-WsusUpdate.md
+++ b/docset/winserver2022-ps/updateservices/Approve-WsusUpdate.md
@@ -130,9 +130,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### Microsoft UpdateServices.Commands.WsusUpdate
+### Microsoft.UpdateServices.Commands.WsusUpdate
 
 ## OUTPUTS
+
+### System.Object
 
 ## NOTES
 

--- a/docset/winserver2022-ps/updateservices/Deny-WsusUpdate.md
+++ b/docset/winserver2022-ps/updateservices/Deny-WsusUpdate.md
@@ -94,7 +94,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### None
+### System.Object
 
 ## NOTES
 

--- a/docset/winserver2022-ps/updateservices/Get-WsusClassification.md
+++ b/docset/winserver2022-ps/updateservices/Get-WsusClassification.md
@@ -83,9 +83,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### Microsoft.UpdateServices.Commands.IUpdateServer
+### Microsoft.UpdateServices.Administration.IUpdateServer
 
 ## OUTPUTS
+
+### Microsoft.UpdateServices.Commands.WsusClassification
 
 ## NOTES
 

--- a/docset/winserver2022-ps/updateservices/Get-WsusComputer.md
+++ b/docset/winserver2022-ps/updateservices/Get-WsusComputer.md
@@ -342,11 +342,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### Microsoft.UpdateServices.Commands.IUpdateServer
+### Microsoft.UpdateServices.Administration.IUpdateServer
 
 ## OUTPUTS
 
-### None
+### Microsoft.UpdateServices.Commands.WsusComputer
 
 ## NOTES
 

--- a/docset/winserver2022-ps/updateservices/Get-WsusDynamicCategory.md
+++ b/docset/winserver2022-ps/updateservices/Get-WsusDynamicCategory.md
@@ -128,6 +128,8 @@ Accept wildcard characters: False
 
 ### -First
 
+Specifies the number of dynamic categories to return from the beginning of the results.
+
 ```yaml
 Type: Int64
 Parameter Sets: Filter
@@ -157,6 +159,8 @@ Accept wildcard characters: False
 ```
 
 ### -Skip
+
+Specifies the number of dynamic categories to skip from the beginning of the results.
 
 ```yaml
 Type: Int64

--- a/docset/winserver2022-ps/updateservices/Get-WsusDynamicCategory.md
+++ b/docset/winserver2022-ps/updateservices/Get-WsusDynamicCategory.md
@@ -208,11 +208,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### IUpdateServer
+### Microsoft.UpdateServices.Administration.IUpdateServer
 
 ## OUTPUTS
 
-### IDynamicCategory
+### System.Object
 
 ## NOTES
 

--- a/docset/winserver2022-ps/updateservices/Get-WsusProduct.md
+++ b/docset/winserver2022-ps/updateservices/Get-WsusProduct.md
@@ -111,11 +111,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### Microsoft.UpdateServices.Administration.IUpdateServer
 
 ## OUTPUTS
 
-### None
+### Microsoft.UpdateServices.Commands.WsusProduct
 
 ## NOTES
 

--- a/docset/winserver2022-ps/updateservices/Get-WsusServer.md
+++ b/docset/winserver2022-ps/updateservices/Get-WsusServer.md
@@ -110,11 +110,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### System.String
 
 ## OUTPUTS
 
-### Microsoft.UpdateServices.Commands.IUpdateServer
+### Microsoft.UpdateServices.Administration.IUpdateServer
 
 ## NOTES
 

--- a/docset/winserver2022-ps/updateservices/Get-WsusUpdate.md
+++ b/docset/winserver2022-ps/updateservices/Get-WsusUpdate.md
@@ -186,7 +186,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### Microsoft.UpdateServices.Administration.IUpdateServer
 
 ## OUTPUTS
 

--- a/docset/winserver2022-ps/updateservices/Remove-WsusDynamicCategory.md
+++ b/docset/winserver2022-ps/updateservices/Remove-WsusDynamicCategory.md
@@ -153,11 +153,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### IDynamicCategory
+### None
 
 ## OUTPUTS
 
-### None
+### System.Object
 
 ## NOTES
 

--- a/docset/winserver2022-ps/updateservices/Set-WsusClassification.md
+++ b/docset/winserver2022-ps/updateservices/Set-WsusClassification.md
@@ -111,12 +111,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### Microsoft.UpdateServices.Commands.WsusClassification
 
 ## OUTPUTS
 
-### None
-
+### System.Object 
 ## NOTES
 
 ## RELATED LINKS

--- a/docset/winserver2022-ps/updateservices/Set-WsusDynamicCategory.md
+++ b/docset/winserver2022-ps/updateservices/Set-WsusDynamicCategory.md
@@ -187,11 +187,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### IDynamicCategory
+### Microsoft.UpdateServices.Administration.IDynamicCategory
 
 ## OUTPUTS
 
-### None
+### System.Object
 
 ## NOTES
 

--- a/docset/winserver2022-ps/updateservices/Set-WsusProduct.md
+++ b/docset/winserver2022-ps/updateservices/Set-WsusProduct.md
@@ -106,11 +106,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### Microsoft.UpdateServices.Commands.WsusProduct
 
 ## OUTPUTS
 
-### None
+### System.Object
 
 ## NOTES
 

--- a/docset/winserver2022-ps/updateservices/Set-WsusServerSynchronization.md
+++ b/docset/winserver2022-ps/updateservices/Set-WsusServerSynchronization.md
@@ -189,11 +189,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### Microsoft.UpdateServices.Commands.IUpdateServer
+### Microsoft.UpdateServices.Administration.IUpdateServer
 
 ## OUTPUTS
 
-### None
+### System.Object
 
 ## NOTES
 


### PR DESCRIPTION
[1870784](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1870784)

@PatAltimore These were mostly generated changes (inputs, outputs), but there was a weird gap:

https://docs.microsoft.com/en-us/powershell/module/updateservices/get-wsusdynamiccategory?view=windowsserver2019-ps

Look at **First** and **Skip**.  No descriptions in the current live docs. No "add descriptions" text in the generated text. Also, none of the other cmdlets in this module have those params, so I can't just copy them in.

Should I document these two?