### PR TITLE
Change Uservoice URL to Feedback Hub

### DIFF
--- a/docset/docfx.json
+++ b/docset/docfx.json
@@ -74,7 +74,7 @@
       "manager": "femila",
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/windows-powershell-docs",
-      "feedback_product_url": "https://windowsserver.uservoice.com/forums/301869-powershell",
+      "feedback_product_url": "https://support.microsoft.com/windows/send-feedback-to-microsoft-with-the-feedback-hub-app-f59187f8-8739-22d6-ba93-f66612949332",
       "contributors_to_exclude": [
         "rjagiewich",
         "traya1",


### PR DESCRIPTION
Uservoice is no longer used by Microsoft. The old URL results in 404 message. All feedback for Windows components should be submitted through the Windows Feedback Hub. This link points to instructions for the Feedback Hub.