### PR TITLE
SoftwareInventoryLogging PowerShell reference update

### DIFF
--- a/docset/winserver2022-ps/softwareinventorylogging/Get-SilComputer.md
+++ b/docset/winserver2022-ps/softwareinventorylogging/Get-SilComputer.md
@@ -119,7 +119,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
+[Get-SilComputerIdentity](./Get-SilComputerIdentity.md)
+
 [Get-SilData](./Get-SilData.md)
 
 [SIL_Cmdlets](./softwareinventorylogging.md)
-

--- a/docset/winserver2022-ps/softwareinventorylogging/Get-SilComputerIdentity.md
+++ b/docset/winserver2022-ps/softwareinventorylogging/Get-SilComputerIdentity.md
@@ -1,14 +1,17 @@
 ---
+description: The Get-SilComputerIdentity cmdlet gets IDs that identify a Windows installation, or operating system environment.
 external help file: MsftSil_ComputerIdentity.cdxml-help.xml
 Module Name: SoftwareInventoryLogging
-online version:
+ms.date: 10/06/2021
+online version: https://docs.microsoft.com/powershell/module/softwareinventorylogging/get-silcomputeridentity?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
+title: Get-SilComputerIdentity
 ---
 
 # Get-SilComputerIdentity
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Gets IDs that identify a Windows installation.
 
 ## SYNTAX
 
@@ -17,21 +20,36 @@ Get-SilComputerIdentity [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+The **Get-SilComputerIdentity** cmdlet gets IDs that identify a Windows installation, or operating system environment.
+This cmdlet gets information for both physical and virtual servers.
 
 ## EXAMPLES
 
-### Example 1
+### Example 1: Get IDs for a virtual machine
 ```powershell
-PS C:\> {{ Add example code here }}
+Get-SilComputerIdentity
 ```
 
-{{ Add example description here }}
+```output
+ID                 : 961FF8A1-8549-4BEC-8DF6-3B3E32C26FFA
+UUID               : B49ACB4C-7D9C-4806-9917-AE750BB3DA84
+VMGUID             : E84CCCBD-0D0F-486B-A424-9780C7CF92E4
+Name               : Server08Guest.TSQA.Contoso.com
+HypervisorHostName : Server08.TSQA.Contoso.com
+```
+
+This command gets the IDs for a virtual machine that runs on Hyper-V.
 
 ## PARAMETERS
 
 ### -AsJob
-{{ Fill AsJob Description }}
+Runs the cmdlet as a background job.
+Use this parameter to run commands that take a long time to complete. 
+ The cmdlet immediately returns an object that represents the job and then displays the command prompt.
+You can continue to work in the session while the job completes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+ For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
 ```yaml
 Type: SwitchParameter
@@ -46,7 +64,9 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-{{ Fill CimSession Description }}
+Runs the cmdlet in a remote session or on a remote computer.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+The default is the current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -61,7 +81,9 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-{{ Fill ThrottleLimit Description }}
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
+If this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
+The throttle limit applies only to the current cmdlet, not to the session or to the computer.
 
 ```yaml
 Type: Int32
@@ -76,7 +98,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -91,3 +113,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[Get-SilComputer](./Get-SilComputer.md)

--- a/docset/winserver2022-ps/softwareinventorylogging/Get-SilComputerIdentity.md
+++ b/docset/winserver2022-ps/softwareinventorylogging/Get-SilComputerIdentity.md
@@ -1,0 +1,93 @@
+---
+external help file: MsftSil_ComputerIdentity.cdxml-help.xml
+Module Name: SoftwareInventoryLogging
+online version:
+schema: 2.0.0
+---
+
+# Get-SilComputerIdentity
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Get-SilComputerIdentity [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AsJob
+{{ Fill AsJob Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CimSession
+{{ Fill CimSession Description }}
+
+```yaml
+Type: CimSession[]
+Parameter Sets: (All)
+Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ThrottleLimit
+{{ Fill ThrottleLimit Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### Microsoft.Management.Infrastructure.CimInstance
+
+### Microsoft.Management.Infrastructure.CimInstance#root\InventoryLogging\MsftSil_ComputerIdentity
+
+## NOTES
+
+## RELATED LINKS

--- a/docset/winserver2022-ps/softwareinventorylogging/Get-SilLogging.md
+++ b/docset/winserver2022-ps/softwareinventorylogging/Get-SilLogging.md
@@ -1,6 +1,6 @@
 ---
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
-external help file: MsftSil_ManagementTasks-help.xml
+external help file: MsftSil_ManagementTasks.psm1-help.xml
 Module Name: SoftwareInventoryLogging
 ms.date: 01/24/2017
 online version: https://docs.microsoft.com/powershell/module/softwareinventorylogging/get-sillogging?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
@@ -63,9 +63,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### None
+
 ## OUTPUTS
 
-### System.Management.Automation.PSCustomObject
+### System.Object
 
 ## NOTES
 

--- a/docset/winserver2022-ps/softwareinventorylogging/Set-SilLogging.md
+++ b/docset/winserver2022-ps/softwareinventorylogging/Set-SilLogging.md
@@ -1,6 +1,6 @@
 ---
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
-external help file: MsftSil_ManagementTasks-help.xml
+external help file: MsftSil_ManagementTasks.psm1-help.xml
 Module Name: SoftwareInventoryLogging
 ms.date: 01/24/2017
 online version: https://docs.microsoft.com/powershell/module/softwareinventorylogging/set-sillogging?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
@@ -172,9 +172,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### None
+
 ## OUTPUTS
 
-### Microsoft.Management.Infrastructure.CimMethodResult#msftsil_managementtasks#SetLoggingState
+### System.Object
 
 ## NOTES
 

--- a/docset/winserver2022-ps/softwareinventorylogging/SoftwareInventoryLogging.md
+++ b/docset/winserver2022-ps/softwareinventorylogging/SoftwareInventoryLogging.md
@@ -17,7 +17,10 @@ This reference provides cmdlet descriptions and syntax for all Software Inventor
 ### [Get-SilComputer](./Get-SilComputer.md)
 Displays the point in time values for specific server and operating system-related data.
 
-### [Get-SilData](./Get-SilData.md)
+### [Get-SilComputerIdentity](Get-SilComputerIdentity.md)
+{{ Fill in the Synopsis }}
+
+### [Get-SilData](Get-SilData.md)
 Displays a point in time collection of all Software Inventory Logging data.
 
 ### [Get-SilLogging](./Get-SilLogging.md)

--- a/docset/winserver2022-ps/softwareinventorylogging/SoftwareInventoryLogging.md
+++ b/docset/winserver2022-ps/softwareinventorylogging/SoftwareInventoryLogging.md
@@ -18,7 +18,7 @@ This reference provides cmdlet descriptions and syntax for all Software Inventor
 Displays the point in time values for specific server and operating system-related data.
 
 ### [Get-SilComputerIdentity](Get-SilComputerIdentity.md)
-{{ Fill in the Synopsis }}
+Gets IDs that identify a Windows installation.
 
 ### [Get-SilData](Get-SilData.md)
 Displays a point in time collection of all Software Inventory Logging data.

--- a/docset/winserver2022-ps/softwareinventorylogging/Start-SilLogging.md
+++ b/docset/winserver2022-ps/softwareinventorylogging/Start-SilLogging.md
@@ -1,6 +1,6 @@
 ---
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
-external help file: MsftSil_ManagementTasks-help.xml
+external help file: MsftSil_ManagementTasks.psm1-help.xml
 Module Name: SoftwareInventoryLogging
 ms.date: 01/24/2017
 online version: https://docs.microsoft.com/powershell/module/softwareinventorylogging/start-sillogging?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
@@ -88,7 +88,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### None
+
 ## OUTPUTS
+
+### System.Object
 
 ## NOTES
 

--- a/docset/winserver2022-ps/softwareinventorylogging/Stop-SilLogging.md
+++ b/docset/winserver2022-ps/softwareinventorylogging/Stop-SilLogging.md
@@ -1,6 +1,6 @@
 ---
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
-external help file: MsftSil_ManagementTasks-help.xml
+external help file: MsftSil_ManagementTasks.psm1-help.xml
 Module Name: SoftwareInventoryLogging
 ms.date: 01/24/2017
 online version: https://docs.microsoft.com/powershell/module/softwareinventorylogging/stop-sillogging?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
@@ -88,7 +88,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### None
+
 ## OUTPUTS
+
+### System.Object
 
 ## NOTES
 


### PR DESCRIPTION
[1882155](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1882155)

One new cmdlet, PlatyPS changes to 3 others.

The new cmdlet turned out to be not new, but undocumented in intervening versions. Not clear on all the history, but the product team said it should be documented. I moved the old text into the current file, so it matches PlatyPS.