### PR TITLE
Update Set-NetIPv*Protocol NeighborCacheLimit description to be more accurate

### DIFF
--- a/docset/winserver2012r2-ps/nettcpip/Set-NetIPv4Protocol.md
+++ b/docset/winserver2012r2-ps/nettcpip/Set-NetIPv4Protocol.md
@@ -43,7 +43,7 @@ This command enables the DHCP Media Sense event log.
 PS C:\>Set-NetIPv4Protocol -NeighborCacheLimitEntries 1000
 ```
 
-This command increases the size of the cache of on-link neighbors on the subnet to 1,000.
+This command increases the size of the cache of on-link neighbors on the subnet that are no longer referenced to 1,000.
 The default value is 256.
 
 ## PARAMETERS
@@ -330,7 +330,7 @@ Accept wildcard characters: False
 ```
 
 ### -NeighborCacheLimitEntries
-Specifies the maximum number of neighbor cache entries.
+Specifies the maximum number of entries in the neighbor cache, which consists of all dynamic neighbors no longer referenced.
 The cmdlet modifies the value for this setting. 
 
 The default value is 256.

--- a/docset/winserver2012r2-ps/nettcpip/Set-NetIPv6Protocol.md
+++ b/docset/winserver2012r2-ps/nettcpip/Set-NetIPv6Protocol.md
@@ -45,7 +45,7 @@ This command enables the DHCP Media Sense event log.
 PS C:\>Set-NetIPv6Protocol -NeighborCacheLimitEntries 1000
 ```
 
-This command increases the size of the cache of on-link neighbors on the subnet to 1,000.
+This command increases the size of the cache of on-link neighbors on the subnet that are no longer referenced to 1,000.
 The default value is 256.
 
 ## PARAMETERS
@@ -398,7 +398,7 @@ Accept wildcard characters: False
 ```
 
 ### -NeighborCacheLimitEntries
-Specifies the maximum number of neighbor cache entries.
+Specifies the maximum number of entries in the neighbor cache, which consists of all dynamic neighbors no longer referenced.
 The cmdlet modifies the value for this setting. 
 
 The default value is 256.

--- a/docset/winserver2016-ps/nettcpip/Set-NetIPv4Protocol.md
+++ b/docset/winserver2016-ps/nettcpip/Set-NetIPv4Protocol.md
@@ -44,7 +44,7 @@ This command enables the DHCP Media Sense event log.
 PS C:\>Set-NetIPv4Protocol -NeighborCacheLimitEntries 1000
 ```
 
-This command increases the size of the cache of on-link neighbors on the subnet to 1,000.
+This command increases the size of the cache of on-link neighbors on the subnet that are no longer referenced to 1,000.
 The default value is 256.
 
 ## PARAMETERS
@@ -349,7 +349,7 @@ Accept wildcard characters: False
 ```
 
 ### -NeighborCacheLimitEntries
-Specifies the maximum number of neighbor cache entries.
+Specifies the maximum number of entries in the neighbor cache, which consists of all dynamic neighbors no longer referenced.
 The cmdlet modifies the value for this setting. 
 
 The default value is 256.

--- a/docset/winserver2016-ps/nettcpip/Set-NetIPv6Protocol.md
+++ b/docset/winserver2016-ps/nettcpip/Set-NetIPv6Protocol.md
@@ -47,7 +47,7 @@ This command enables the DHCP Media Sense event log.
 PS C:\>Set-NetIPv6Protocol -NeighborCacheLimitEntries 1000
 ```
 
-This command increases the size of the cache of on-link neighbors on the subnet to 1,000.
+This command increases the size of the cache of on-link neighbors on the subnet that are no longer referenced to 1,000.
 The default value is 256.
 
 ## PARAMETERS
@@ -396,7 +396,7 @@ Accept wildcard characters: False
 ```
 
 ### -NeighborCacheLimitEntries
-Specifies the maximum number of neighbor cache entries.
+Specifies the maximum number of entries in the neighbor cache, which consists of all dynamic neighbors no longer referenced.
 The cmdlet modifies the value for this setting. 
 
 The default value is 256.

--- a/docset/winserver2019-ps/nettcpip/Set-NetIPv4Protocol.md
+++ b/docset/winserver2019-ps/nettcpip/Set-NetIPv4Protocol.md
@@ -44,7 +44,7 @@ This command enables the DHCP Media Sense event log.
 PS C:\>Set-NetIPv4Protocol -NeighborCacheLimitEntries 1000
 ```
 
-This command increases the size of the cache of on-link neighbors on the subnet to 1,000.
+This command increases the size of the cache of on-link neighbors on the subnet that are no longer referenced to 1,000.
 The default value is 256.
 
 ## PARAMETERS
@@ -349,7 +349,7 @@ Accept wildcard characters: False
 ```
 
 ### -NeighborCacheLimitEntries
-Specifies the maximum number of neighbor cache entries.
+Specifies the maximum number of entries in the neighbor cache, which consists of all dynamic neighbors no longer referenced.
 The cmdlet modifies the value for this setting. 
 
 The default value is 256.

--- a/docset/winserver2019-ps/nettcpip/Set-NetIPv6Protocol.md
+++ b/docset/winserver2019-ps/nettcpip/Set-NetIPv6Protocol.md
@@ -47,7 +47,7 @@ This command enables the DHCP Media Sense event log.
 PS C:\>Set-NetIPv6Protocol -NeighborCacheLimitEntries 1000
 ```
 
-This command increases the size of the cache of on-link neighbors on the subnet to 1,000.
+This command increases the size of the cache of on-link neighbors on the subnet that are no longer referenced to 1,000.
 The default value is 256.
 
 ## PARAMETERS
@@ -396,7 +396,7 @@ Accept wildcard characters: False
 ```
 
 ### -NeighborCacheLimitEntries
-Specifies the maximum number of neighbor cache entries.
+Specifies the maximum number of entries in the neighbor cache, which consists of all dynamic neighbors no longer referenced.
 The cmdlet modifies the value for this setting. 
 
 The default value is 256.

--- a/docset/winserver2022-ps/nettcpip/Set-NetIPv4Protocol.md
+++ b/docset/winserver2022-ps/nettcpip/Set-NetIPv4Protocol.md
@@ -45,7 +45,7 @@ This command enables the DHCP Media Sense event log.
 PS C:\>Set-NetIPv4Protocol -NeighborCacheLimitEntries 1000
 ```
 
-This command increases the size of the cache of on-link neighbors on the subnet to 1,000.
+This command increases the size of the cache of on-link neighbors on the subnet that are no longer referenced to 1,000.
 The default value is 256.
 
 ## PARAMETERS
@@ -372,7 +372,7 @@ Accept wildcard characters: False
 ```
 
 ### -NeighborCacheLimitEntries
-Specifies the maximum number of neighbor cache entries.
+Specifies the maximum number of entries in the neighbor cache, which consists of all dynamic neighbors no longer referenced.
 The cmdlet modifies the value for this setting.
 
 The default value is 256.

--- a/docset/winserver2022-ps/nettcpip/Set-NetIPv6Protocol.md
+++ b/docset/winserver2022-ps/nettcpip/Set-NetIPv6Protocol.md
@@ -47,7 +47,7 @@ This command enables the DHCP Media Sense event log.
 PS C:\>Set-NetIPv6Protocol -NeighborCacheLimitEntries 1000
 ```
 
-This command increases the size of the cache of on-link neighbors on the subnet to 1,000.
+This command increases the size of the cache of on-link neighbors on the subnet that are no longer referenced to 1,000.
 The default value is 256.
 
 ## PARAMETERS
@@ -418,7 +418,7 @@ Accept wildcard characters: False
 ```
 
 ### -NeighborCacheLimitEntries
-Specifies the maximum number of neighbor cache entries.
+Specifies the maximum number of entries in the neighbor cache, which consists of all dynamic neighbors no longer referenced.
 The cmdlet modifies the value for this setting.
 
 The default value is 256.


### PR DESCRIPTION
The NeighborCacheLimit parameter to the Set-NetIPv*Protocol cmdlets is misleadingly named.  This PR updates the descriptions for the parameter across all Windows versions in this repo.