### PR TITLE
Update Grant-SmbShareAccess.md

### DIFF
--- a/docset/winserver2019-ps/smbshare/Grant-SmbShareAccess.md
+++ b/docset/winserver2019-ps/smbshare/Grant-SmbShareAccess.md
@@ -74,7 +74,7 @@ The acceptable values for this parameter are: Full, Change, or Read.
 Type: ShareAccessRight
 Parameter Sets: (All)
 Aliases:
-Accepted values: Full, Change, Read, Custom
+Accepted values: Full, Change, Read
 
 Required: False
 Position: Named


### PR DESCRIPTION
removed Custom from the accepted values as the acceptable values for this parameter are: Full, Change, or Read.