### PR TITLE
Overhaul Enable-BitLocker doc page (botched PR)

### DIFF
--- a/docset/winserver2012-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2012-ps/bitlocker/Enable-BitLocker.md
@@ -19,144 +19,147 @@ Enables BitLocker Drive Encryption for a volume.
 ### PasswordProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-PasswordProtector] [[-Password] <SecureString>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -PasswordProtector [-Password] <SecureString>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly][-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryPasswordProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryPasswordProtector]
- [[-RecoveryPassword] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -RecoveryPasswordProtector [[-RecoveryPassword] <String>]
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### StartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyProtector] [-StartupKeyPath] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -StartupKeyProtector [-StartupKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndStartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
- [-TpmAndStartupKeyProtector] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndStartupKeyProtector [-StartupKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinAndStartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
- [-TpmAndPinAndStartupKeyProtector] [[-Pin] <SecureString>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndPinAndStartupKeyProtector -StartupKeyPath <String>
+[-Pin] <SecureString> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+[-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm]
+[<CommonParameters>]
 ```
 
 ### AdAccountOrGroupProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-AdAccountOrGroupProtector] [-Service]
- [-AdAccountOrGroup] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -AdAccountOrGroupProtector [-AdAccountOrGroup] <String>
+[-Service] [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [[-Pin] <SecureString>] [-TpmAndPinProtector]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndPinProtector [-Pin] <SecureString>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-TpmProtector] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmProtector
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryKeyProtector] [-RecoveryKeyPath] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -RecoveryKeyProtector [-RecoveryKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 The **Enable-BitLocker** cmdlet enables BitLocker Drive Encryption for a volume.
 
-When you enable encryption, you must specify a volume and an encryption method for that volume.
-You can specify a volume by drive letter or by specifying a BitLocker volume object.
-For the encryption method, you can choose either Advanced Encryption Standard (AES) algorithms AES-128 or AES-256, or you can use hardware encryption if it is supported by the disk hardware.
+When you enable encryption, you must specify a volume, either by its drive letter or by its
+BitLocker volume object.
 
-You must also establish a key protector.
-BitLocker uses a key protector to encrypt the volume encryption key.
-When a user accesses a BitLocker encrypted drive, such as when starting a computer, BitLocker requests the relevant key protector.
-For example, the user can enter a PIN or provide a USB drive that contains a key.
-BitLocker decrypts the encryption key and uses it to read data from the drive.
-You can use one of the following methods or combinations of methods for a key protector:
+You must also establish a key protector. BitLocker uses a key protector to encrypt the volume
+encryption key. When a user accesses a BitLocker encrypted drive, such as when starting a computer,
+BitLocker requests the relevant key protector. For example, the user can enter a PIN or provide a
+USB drive that contains a key. BitLocker decrypts the encryption key and uses it to read data from
+the drive. You can use one of the following methods or combinations of methods for a key protector:
 
-- Trusted Platform Module (TPM).
-BitLocker uses the computer's TPM to protect the encryption key.
-If you select this key protector, users can access the encrypted drive as long as it is connected to the system board that hosts the TPM and system boot integrity is intact.
-In general, TPM-based protectors can only be associated to an operating system volume.
+- **Trusted Platform Module (TPM):** BitLocker uses the computer's TPM to protect the encryption
+  key. If you select this key protector, users can access the encrypted drive as long as it is
+  connected to the system board that hosts the TPM and system boot integrity is intact. In general,
+  TPM-based protectors can only be associated to an operating system volume.
 
-- TPM and Personal Identification Number (PIN).
-BitLocker uses a combination of the TPM and a user-supplied PIN.
-A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers.
+- **TPM and Personal Identification Number (PIN):** BitLocker uses a combination of the TPM and a
+  user-supplied PIN. A PIN is four to twenty digits or, if you allow enhanced PINs, is four to
+  twenty letters, symbols, spaces, or numbers.
 
-- TPM, PIN, and startup key.
-BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key.
+- **TPM, PIN, and startup key:** BitLocker uses a combination of the TPM, a user-supplied PIN, and
+  input from of a USB memory device that contains an external key.
 
-- TPM and startup key.
-BitLocker uses a combination of the TPM and input from of a USB memory device.
+- **TPM and startup key:** BitLocker uses a combination of the TPM and a USB flash drive that
+  contains the external key.
 
-- Startup key.
-BitLocker uses input from of a USB memory device that contains the external key.
+- **Startup key:** BitLocker uses a USB flash drive that contains the external key.
 
-- Password.
-BitLocker uses a password.
+- **Password:** BitLocker uses a password.
 
-- Recovery key.
-BitLocker uses a recovery key stored as a specified file.
+- **Recovery key:** BitLocker uses a recovery key stored as a specified file.
 
-- Recovery password.
-BitLocker uses a recovery password.
+- **Recovery password:** BitLocker uses a recovery password.
 
-- Active Directory Domain Services (AD DS) account.
-BitLocker uses domain authentication.
+- **Active Directory Domain Services (AD DS) account:** BitLocker uses domain authentication.
 
-You can specify only one of these methods or combinations when you enable encryption, but you can use the **Add-BitLockerKeyProtector** cmdlet to add other protectors.
+You can specify only one of these methods or combinations when you enable encryption, but you can
+use the **Add-BitLockerKeyProtector** cmdlet to add other protectors.
 
-For a password or PIN key protector, specify a secure string.
-You can use the **ConvertTo-SecureString** cmdlet to create a secure string.
-You can use secure strings in a script and still maintain confidentiality of passwords.
+For a password or PIN key protector, specify a secure string. You can use the
+**ConvertTo-SecureString** cmdlet to create a secure string. You can use secure strings in a script
+and still maintain confidentiality of passwords.
 
-This cmdlet returns a BitLocker volume object.
-If you choose recovery password as your key protector but do not specify a 48-digit recovery password, this cmdlet creates a random 48-digit recovery password.
-The cmdlet stores the password as the **RecoveryPassword** field of the **KeyProtector** attribute of the BitLocker volume object.
+You may optionally select an encryption method. By default, BitLocker uses AES-128 but you can opt
+AES-256 for stronger security. You may request hardware encryption but Microsoft strongly advices
+against it. For further guidance, see the "[ADV180028 Security Advisory][1]".
 
-If you use startup key or recovery key as part of your key protector, provide a path to store the key.
-This cmdlet stores the name of the file that contains the key in the **KeyFileName** field of the **KeyProtector** field in the BitLocker volume object.
+This cmdlet returns a BitLocker volume object. If you choose recovery password as your key protector
+but do not specify a 48-digit recovery password, this cmdlet generates a random one for you, and
+stores it in the **RecoveryPassword** field of the **KeyProtector** attribute of the BitLocker
+volume object.
 
-If you use the **Enable-BitLocker** cmdlet on an encrypted volume or on a volume that with encryption in process, it takes no action.
-If you use the cmdlet on a drive that has encryption paused, it resumes encryption on the volume.
+If you use startup key or recovery key as part of your key protector, provide a path to store the
+key. This cmdlet stores the name of the file that contains the key in the **KeyFileName** field of
+the **KeyProtector** field in the BitLocker volume object.
 
-By default, this cmdlet encrypts the entire drive.
-If you use the *UsedSpaceOnly* parameter, it only encrypts the used space in the disk.
-This option can significant reduce encryption time.
+If you use the **Enable-BitLocker** cmdlet on an encrypted volume or on a volume that with
+encryption in process, it takes no action. If you use the cmdlet on a drive that has encryption
+paused, it resumes encryption on the volume.
 
-It is common practice to add a recovery password to an operating system volume by using the **Add-BitLockerKeyProtector** cmdlet, and then save the recovery password by using the **Backup-BitLockerKeyProtector** cmdlet, and then enable BitLocker for the drive.
-This procedure ensures that you have a recovery option.
+By default, this cmdlet encrypts the entire drive. If you use the *UsedSpaceOnly* parameter, it only
+encrypts the used space on the disk. This option can significant reduce encryption time.
 
-For an overview of BitLocker, see [BitLocker Drive Encryption Overview](https://technet.microsoft.com/en-us/library/cc732774.aspx) on TechNet.
+It is common practice to add a recovery password for an operating system volume using the
+**Add-BitLockerKeyProtector** cmdlet, save the recovery password using the
+**Backup-BitLockerKeyProtector** cmdlet, and then enable BitLocker on that volume. This procedure
+ensures that you have a recovery option.
+
+For an overview of BitLocker, see "[BitLocker Drive Encryption Overview][2]" on Microsoft Docs.
 
 ## EXAMPLES
 
@@ -587,24 +590,22 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### BitLockerVolume[],String[]
+`BitLockerVolume[]`, `String[]`
 
 ## OUTPUTS
 
-### BitLockerVolume[]
+`BitLockerVolume[]`
 
 ## NOTES
 
 ## RELATED LINKS
 
-[Disable-BitLocker](./Disable-BitLocker.md)
+- [Disable-BitLocker](./Disable-BitLocker.md)
+- [Get-BitLockerVolume](./Get-BitLockerVolume.md)
+- [Lock-BitLocker](./Lock-BitLocker.md)
+- [Resume-BitLocker](./Resume-BitLocker.md)
+- [Suspend-BitLocker](./Suspend-BitLocker.md)
+- [Unlock-BitLocker](./Unlock-BitLocker.md)
 
-[Get-BitLockerVolume](./Get-BitLockerVolume.md)
-
-[Lock-BitLocker](./Lock-BitLocker.md)
-
-[Resume-BitLocker](./Resume-BitLocker.md)
-
-[Suspend-BitLocker](./Suspend-BitLocker.md)
-
-[Unlock-BitLocker](./Unlock-BitLocker.md)
+[1]: https://msrc.microsoft.com/update-guide/en-us/vulnerability/ADV180028
+[2]: https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc732774(v=ws.11)

--- a/docset/winserver2012-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2012-ps/bitlocker/Enable-BitLocker.md
@@ -590,11 +590,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-`BitLockerVolume[]`, `String[]`
+### BitLockerVolume[], String[]
 
 ## OUTPUTS
 
-`BitLockerVolume[]`
+### BitLockerVolume[]
 
 ## NOTES
 

--- a/docset/winserver2012-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2012-ps/bitlocker/Enable-BitLocker.md
@@ -135,8 +135,8 @@ For a password or PIN key protector, specify a secure string. You can use the
 and still maintain confidentiality of passwords.
 
 You may optionally select an encryption method. By default, BitLocker uses AES-128 but you can opt
-AES-256 for stronger security. You may request hardware encryption but Microsoft strongly advices
-against it. For further guidance, see the "[ADV180028 Security Advisory][1]".
+AES-256 for stronger security. (Diffuser is not supported.) You may request hardware encryption but
+Microsoft strongly advices against it. For further guidance, see the "[ADV180028 Security Advisory][1]".
 
 This cmdlet returns a BitLocker volume object. If you choose recovery password as your key protector
 but do not specify a 48-digit recovery password, this cmdlet generates a random one for you, and

--- a/docset/winserver2012-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2012-ps/bitlocker/Enable-BitLocker.md
@@ -1,104 +1,136 @@
 ---
-external help file: Bitlocker_Cmdlets.xml
+description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
+external help file: BitLocker-help.xml
 Module Name: BitLocker
+ms.date: 12/14/2021
 online version: https://docs.microsoft.com/powershell/module/bitlocker/enable-bitlocker?view=windowsserver2012-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
+title: Enable-BitLocker
 ---
 
 # Enable-BitLocker
 
 ## SYNOPSIS
-Enables encryption for a BitLocker volume.
+
+Enables BitLocker Drive Encryption for a volume.
 
 ## SYNTAX
 
-### UNNAMED_PARAMETER_SET_1
-```
-Enable-BitLocker [-AdAccountOrGroup] <String> [-Service] [-AdAccountOrGroupProtector] [-Confirm] [-WhatIf]
+### PasswordProtector
+
+```PowerShell
+Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+ [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-PasswordProtector] [[-Password] <SecureString>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### UNNAMED_PARAMETER_SET_2
-```
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod] [-HardwareEncryption] [-SkipHardwareTest]
- [-UsedSpaceOnly] [-Confirm] [-WhatIf]
+### RecoveryPasswordProtector
+
+```PowerShell
+Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+ [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryPasswordProtector]
+ [[-RecoveryPassword] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### UNNAMED_PARAMETER_SET_3
-```
-Enable-BitLocker [[-Password] <SecureString>] [-PasswordProtector] [-Confirm] [-WhatIf]
+### StartupKeyProtector
+
+```PowerShell
+Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+ [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyProtector] [-StartupKeyPath] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### UNNAMED_PARAMETER_SET_4
-```
-Enable-BitLocker [[-Pin] <SecureString>] [-TpmAndPinProtector] [-Confirm] [-WhatIf]
+### TpmAndStartupKeyProtector
+
+```PowerShell
+Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+ [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
+ [-TpmAndStartupKeyProtector] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### UNNAMED_PARAMETER_SET_5
-```
-Enable-BitLocker [-StartupKeyPath] <String> [[-Pin] <SecureString>] [-TpmAndPinAndStartupKeyProtector]
- [-Confirm] [-WhatIf]
+### TpmAndPinAndStartupKeyProtector
+
+```PowerShell
+Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+ [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
+ [-TpmAndPinAndStartupKeyProtector] [[-Pin] <SecureString>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### UNNAMED_PARAMETER_SET_6
-```
-Enable-BitLocker [-RecoveryKeyPath] <String> [-RecoveryKeyProtector] [-Confirm] [-WhatIf]
+### AdAccountOrGroupProtector
+
+```PowerShell
+Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+ [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-AdAccountOrGroupProtector] [-Service]
+ [-AdAccountOrGroup] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### UNNAMED_PARAMETER_SET_7
-```
-Enable-BitLocker [[-RecoveryPassword] <String>] [-RecoveryPasswordProtector] [-Confirm] [-WhatIf]
+### TpmAndPinProtector
+
+```PowerShell
+Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+ [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [[-Pin] <SecureString>] [-TpmAndPinProtector]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### UNNAMED_PARAMETER_SET_8
-```
-Enable-BitLocker [-StartupKeyPath] <String> [-StartupKeyProtector] [-Confirm] [-WhatIf]
+### TpmProtector
+
+```PowerShell
+Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+ [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-TpmProtector] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
-### UNNAMED_PARAMETER_SET_9
-```
-Enable-BitLocker [-StartupKeyPath] <String> [-TpmAndStartupKeyProtector] [-Confirm] [-WhatIf]
-```
+### RecoveryKeyProtector
 
-### UNNAMED_PARAMETER_SET_10
-```
-Enable-BitLocker [-TpmProtector] [-Confirm] [-WhatIf]
+```PowerShell
+Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+ [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryKeyProtector] [-RecoveryKeyPath] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 The **Enable-BitLocker** cmdlet enables BitLocker Drive Encryption for a volume.
 
 When you enable encryption, you must specify a volume and an encryption method for that volume.
 You can specify a volume by drive letter or by specifying a BitLocker volume object.
-For the encryption method, you can choose either Advanced Encryption Standard (AES) algorithms AES-128 or AES-256, or you can use hardware encryption, if it is supported by the disk hardware.
+For the encryption method, you can choose either Advanced Encryption Standard (AES) algorithms AES-128 or AES-256, or you can use hardware encryption if it is supported by the disk hardware.
 
 You must also establish a key protector.
 BitLocker uses a key protector to encrypt the volume encryption key.
 When a user accesses a BitLocker encrypted drive, such as when starting a computer, BitLocker requests the relevant key protector.
 For example, the user can enter a PIN or provide a USB drive that contains a key.
 BitLocker decrypts the encryption key and uses it to read data from the drive.
-You can use one of the following methods or combinations of methods for a key protector: 
+You can use one of the following methods or combinations of methods for a key protector:
 
 - Trusted Platform Module (TPM).
 BitLocker uses the computer's TPM to protect the encryption key.
 If you select this key protector, users can access the encrypted drive as long as it is connected to the system board that hosts the TPM and system boot integrity is intact.
-In general, TPM-based protectors can only be associated to an operating system volume. 
+In general, TPM-based protectors can only be associated to an operating system volume.
+
 - TPM and Personal Identification Number (PIN).
 BitLocker uses a combination of the TPM and a user-supplied PIN.
-A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers. 
+A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers.
+
 - TPM, PIN, and startup key.
-BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key. 
+BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key.
+
 - TPM and startup key.
-BitLocker uses a combination of the TPM and input from of a USB memory device. 
+BitLocker uses a combination of the TPM and input from of a USB memory device.
+
 - Startup key.
-BitLocker uses input from of a USB memory device that contains the external key. 
+BitLocker uses input from of a USB memory device that contains the external key.
+
 - Password.
-BitLocker uses a password. 
+BitLocker uses a password.
+
 - Recovery key.
-BitLocker uses a recovery key stored as a specified file. 
+BitLocker uses a recovery key stored as a specified file.
+
 - Recovery password.
-BitLocker uses a recovery password. 
-- Active Directory Domain Services (AD DS).
-account.
+BitLocker uses a recovery password.
+
+- Active Directory Domain Services (AD DS) account.
 BitLocker uses domain authentication.
 
 You can specify only one of these methods or combinations when you enable encryption, but you can use the **Add-BitLockerKeyProtector** cmdlet to add other protectors.
@@ -108,29 +140,31 @@ You can use the **ConvertTo-SecureString** cmdlet to create a secure string.
 You can use secure strings in a script and still maintain confidentiality of passwords.
 
 This cmdlet returns a BitLocker volume object.
-If you choose recovery password as your key protector but do not specify a 48-digit recovery password, this cmdlet creates a random 48-bit recovery password.
+If you choose recovery password as your key protector but do not specify a 48-digit recovery password, this cmdlet creates a random 48-digit recovery password.
 The cmdlet stores the password as the **RecoveryPassword** field of the **KeyProtector** attribute of the BitLocker volume object.
 
 If you use startup key or recovery key as part of your key protector, provide a path to store the key.
 This cmdlet stores the name of the file that contains the key in the **KeyFileName** field of the **KeyProtector** field in the BitLocker volume object.
 
-If you use the Enable-BitLocker cmdlet on an encrypted volume or on a volume that with encryption in process, it takes no action.
+If you use the **Enable-BitLocker** cmdlet on an encrypted volume or on a volume that with encryption in process, it takes no action.
 If you use the cmdlet on a drive that has encryption paused, it resumes encryption on the volume.
 
 By default, this cmdlet encrypts the entire drive.
-If you use the **UsedSpaceOnly** parameter, it only encrypts the used space in the disk.
+If you use the *UsedSpaceOnly* parameter, it only encrypts the used space in the disk.
 This option can significant reduce encryption time.
 
-It is common practice to add a recovery password to an operating system volume by using the Add-BitLockerKeyProtector cmdlet, and then save the recovery password by using the Backup-BitLockerKeyProtector cmdlet, and then enable BitLocker for the drive.
+It is common practice to add a recovery password to an operating system volume by using the **Add-BitLockerKeyProtector** cmdlet, and then save the recovery password by using the **Backup-BitLockerKeyProtector** cmdlet, and then enable BitLocker for the drive.
 This procedure ensures that you have a recovery option.
 
-For an overview of BitLocker, see BitLocker Drive Encryption Overviewhttp://technet.microsoft.com/en-us/library/cc732774.aspx (http://technet.microsoft.com/en-us/library/cc732774.aspx) on TechNet.
+For an overview of BitLocker, see [BitLocker Drive Encryption Overview](https://technet.microsoft.com/en-us/library/cc732774.aspx) on TechNet.
 
 ## EXAMPLES
 
 ### Example 1: Enable BitLocker
-```
-PS C:\> $SecureString = ConvertTo-SecureString "1234" -AsPlainText -Force PS C:\>Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes256 -UsedSpaceOnly -Pin $SecureString -TPMandPinProtector
+
+```PowerShell
+$SecureString = ConvertTo-SecureString "1234" -AsPlainText -Force
+Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes256 -UsedSpaceOnly -Pin $SecureString -TPMandPinProtector
 ```
 
 This example enables BitLocker for a specified drive using the TPM and a PIN for key protector.
@@ -144,51 +178,71 @@ The command also specifies that this volume uses a combination of the TPM and th
 The command also specifies to encrypt the used space data on the disk, instead of the entire volume.
 When the system writes data to the volume in the future, that data is encrypted.
 
-### Example 2: Enable BitLocker with a specified recovery key
-```
-PS C:\>Get-BitLockerVolume | Enable-BitLocker -EncryptionMethod Aes128 -RecoveryKeyPath "E:\Recovery\" -RecoveryKeyProtector
+### Example 2: Enable BitLocker with a recovery key
+
+```PowerShell
+Get-BitLockerVolume | Enable-BitLocker -EncryptionMethod Aes128 -RecoveryKeyPath "E:\Recovery\" -RecoveryKeyProtector
 ```
 
-This command gets all the BitLocker volumes for the current computer and passes pipes them to the Enable-BitLocker cmdlet by using the pipe operator.
+This command gets all the BitLocker volumes for the current computer and passes pipes them to the **Enable-BitLocker** cmdlet by using the pipe operator.
 This cmdlet specifies an encryption algorithm for the volume or volumes.
 This cmdlet specifies a path to a folder where the randomly generated recovery key will be stored and indicates that these volumes use a recovery key as a key protector.
 
 ### Example 3: Enable BitLocker with a specified user account
-```
-PS C:\>Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes128 -AdAccountOrGroup "Western\SarahJones" -AdAccountOrGroupProtector
+
+```PowerShell
+Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes128 -AdAccountOrGroup "Western\SarahJones" -AdAccountOrGroupProtector
 ```
 
-This command encrypts the BitLocker volume specified by the **MountPoint** parameter, and uses the AES 128 encryption method.
+This command encrypts the BitLocker volume specified by the *MountPoint* parameter, and uses the AES 128 encryption method.
 The command also specifies an account and specifies that BitLocker uses user credentials as a key protector.
 When a user accesses this volume, BitLocker prompts for credentials for the user account Western\SarahJones.
 
 ## PARAMETERS
 
 ### -AdAccountOrGroup
-Specifies an account using the format **Domain\User**.
+
+Specifies an account using the format Domain\User.
 This cmdlet adds the account you specify as a key protector for the volume encryption key.
 
 ```yaml
 Type: String
-Parameter Sets: UNNAMED_PARAMETER_SET_1
+Parameter Sets: AdAccountOrGroupProtector
 Aliases: sid
 
 Required: True
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -AdAccountOrGroupProtector
+
 Indicates that BitLocker uses an AD DS account as a protector for the volume encryption key.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_1
+Parameter Sets: AdAccountOrGroupProtector
 Aliases: sidp
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
 Position: Named
 Default value: False
 Accept pipeline input: False
@@ -196,18 +250,14 @@ Accept wildcard characters: False
 ```
 
 ### -EncryptionMethod
-Specifies an encryption method for the encrypted drive.
-The acceptable values for this parameter are:
 
-- Aes128. 
-- Aes256. 
-- Hardware.
+Specifies an encryption method for the encrypted drive.
 
 ```yaml
-Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_2
+Type: BitLockerVolumeEncryptionMethodOnEnable
+Parameter Sets: (All)
 Aliases: 
-Accepted values: Aes128, Aes256, Hardware
+Accepted values: Aes128, Aes256
 
 Required: False
 Position: Named
@@ -217,308 +267,312 @@ Accept wildcard characters: False
 ```
 
 ### -HardwareEncryption
+
 Indicates that the volume uses hardware encryption.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_2
+Parameter Sets: (All)
 Aliases: 
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -MountPoint
+
 Specifies an array of drive letters or BitLocker volume objects.
 This cmdlet enables protection for the volumes specified.
-To obtain a BitLocker volume object, use the Get-BitLockerVolume cmdlet.
+To obtain a BitLocker volume object, use the **Get-BitLockerVolume** cmdlet.
 
 ```yaml
 Type: String[]
-Parameter Sets: UNNAMED_PARAMETER_SET_2
+Parameter Sets: (All)
 Aliases: 
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
-Accept pipeline input: True (ByValue, ByPropertyName)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
 ### -Password
+
 Specifies a secure string object that contains a password.
 The password specified acts as a protector for the volume encryption key.
 
 ```yaml
 Type: SecureString
-Parameter Sets: UNNAMED_PARAMETER_SET_3
+Parameter Sets: PasswordProtector
 Aliases: pw
 
 Required: False
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -PasswordProtector
+
 Indicates that BitLocker uses a password as a protector for the volume encryption key.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_3
+Parameter Sets: PasswordProtector
 Aliases: pwp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Pin
+
 Specifies a secure string object that contains a PIN.
 BitLocker uses the PIN specified, with other data, as a protector for the volume encryption key.
 
 ```yaml
 Type: SecureString
-Parameter Sets: UNNAMED_PARAMETER_SET_4, UNNAMED_PARAMETER_SET_5
+Parameter Sets: TpmAndPinAndStartupKeyProtector, TpmAndPinProtector
 Aliases: p
 
 Required: False
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -RecoveryKeyPath
+
 Specifies a path to a folder.
 This cmdlet adds a randomly generated recovery key as a protector for the volume encryption key and stores it in the specified path.
 
 ```yaml
 Type: String
-Parameter Sets: UNNAMED_PARAMETER_SET_6
+Parameter Sets: RecoveryKeyProtector
 Aliases: rk
 
 Required: True
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -RecoveryKeyProtector
+
 Indicates that BitLocker uses a recovery key as a protector for the volume encryption key.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_6
+Parameter Sets: RecoveryKeyProtector
 Aliases: rkp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -RecoveryPassword
+
 Specifies a recovery password.
-If you do not specify this parameter, but you do include the **RecoveryPasswordProtector** parameter, the cmdlet creates a random password.
-You can enter a 48 digit password.
+If you do not specify this parameter, but you do include the *RecoveryPasswordProtector* parameter, the cmdlet creates a random password.
+You can enter a 48-digit password.
 The password specified or created acts as a protector for the volume encryption key.
 
 ```yaml
 Type: String
-Parameter Sets: UNNAMED_PARAMETER_SET_7
+Parameter Sets: RecoveryPasswordProtector
 Aliases: rp
 
 Required: False
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -RecoveryPasswordProtector
+
 Indicates that BitLocker uses a recovery password as a protector for the volume encryption key.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_7
+Parameter Sets: RecoveryPasswordProtector
 Aliases: rpp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Service
+
 Indicates that the system account for this computer unlocks the encrypted volume.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_1
+Parameter Sets: AdAccountOrGroupProtector
 Aliases: 
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -SkipHardwareTest
+
 Indicates that BitLocker does not perform a hardware test before it begins encryption.
 BitLocker uses a hardware test as a dry run to make sure that all the key protectors are correctly set up and that the computer can start without issues.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_2
+Parameter Sets: (All)
 Aliases: s
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -StartupKeyPath
+
 Specifies a path to a startup key.
 The key stored in the specified path acts as a protector for the volume encryption key.
 
 ```yaml
 Type: String
-Parameter Sets: UNNAMED_PARAMETER_SET_5, UNNAMED_PARAMETER_SET_8, UNNAMED_PARAMETER_SET_9
+Parameter Sets: StartupKeyProtector, TpmAndStartupKeyProtector, TpmAndPinAndStartupKeyProtector
 Aliases: sk
 
 Required: True
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -StartupKeyProtector
+
 Indicates that BitLocker uses a startup key as a protector for the volume encryption key.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_8
+Parameter Sets: StartupKeyProtector
 Aliases: skp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -TpmAndPinAndStartupKeyProtector
+
 Indicates that BitLocker uses a combination of the TPM, a PIN, and a startup key as a protector for the volume encryption key.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_5
+Parameter Sets: TpmAndPinAndStartupKeyProtector
 Aliases: tpskp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -TpmAndPinProtector
+
 Indicates that BitLocker uses a combination of the TPM and a PIN as a protector for the volume encryption key.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_4
+Parameter Sets: TpmAndPinProtector
 Aliases: tpp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -TpmAndStartupKeyProtector
+
 Indicates that BitLocker uses a combination of the TPM and a startup key as a protector for the volume encryption key.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_9
+Parameter Sets: TpmAndStartupKeyProtector
 Aliases: tskp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -TpmProtector
+
 Indicates that BitLocker uses the TPM as a protector for the volume encryption key.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_10
+Parameter Sets: TpmProtector
 Aliases: tpmp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -UsedSpaceOnly
+
 Indicates that BitLocker does not encrypt disk space which contains unused data.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_2
+Parameter Sets: (All)
 Aliases: qe
 
 Required: False
 Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: 
-
-Required: False
-Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases: wi
 
 Required: False
 Position: Named
@@ -526,6 +580,10 @@ Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -541,6 +599,8 @@ Accept wildcard characters: False
 
 [Disable-BitLocker](./Disable-BitLocker.md)
 
+[Get-BitLockerVolume](./Get-BitLockerVolume.md)
+
 [Lock-BitLocker](./Lock-BitLocker.md)
 
 [Resume-BitLocker](./Resume-BitLocker.md)
@@ -548,6 +608,3 @@ Accept wildcard characters: False
 [Suspend-BitLocker](./Suspend-BitLocker.md)
 
 [Unlock-BitLocker](./Unlock-BitLocker.md)
-
-[Get-BitLockerVolume](./Get-BitLockerVolume.md)
-

--- a/docset/winserver2012r2-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2012r2-ps/bitlocker/Enable-BitLocker.md
@@ -19,144 +19,147 @@ Enables BitLocker Drive Encryption for a volume.
 ### PasswordProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-PasswordProtector] [[-Password] <SecureString>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -PasswordProtector [-Password] <SecureString>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly][-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryPasswordProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryPasswordProtector]
- [[-RecoveryPassword] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -RecoveryPasswordProtector [[-RecoveryPassword] <String>]
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### StartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyProtector] [-StartupKeyPath] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -StartupKeyProtector [-StartupKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndStartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
- [-TpmAndStartupKeyProtector] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndStartupKeyProtector [-StartupKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinAndStartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
- [-TpmAndPinAndStartupKeyProtector] [[-Pin] <SecureString>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndPinAndStartupKeyProtector -StartupKeyPath <String>
+[-Pin] <SecureString> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+[-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm]
+[<CommonParameters>]
 ```
 
 ### AdAccountOrGroupProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-AdAccountOrGroupProtector] [-Service]
- [-AdAccountOrGroup] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -AdAccountOrGroupProtector [-AdAccountOrGroup] <String>
+[-Service] [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [[-Pin] <SecureString>] [-TpmAndPinProtector]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndPinProtector [-Pin] <SecureString>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-TpmProtector] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmProtector
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryKeyProtector] [-RecoveryKeyPath] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -RecoveryKeyProtector [-RecoveryKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 The **Enable-BitLocker** cmdlet enables BitLocker Drive Encryption for a volume.
 
-When you enable encryption, you must specify a volume and an encryption method for that volume.
-You can specify a volume by drive letter or by specifying a BitLocker volume object.
-For the encryption method, you can choose either Advanced Encryption Standard (AES) algorithms AES-128 or AES-256, or you can use hardware encryption if it is supported by the disk hardware.
+When you enable encryption, you must specify a volume, either by its drive letter or by its
+BitLocker volume object.
 
-You must also establish a key protector.
-BitLocker uses a key protector to encrypt the volume encryption key.
-When a user accesses a BitLocker encrypted drive, such as when starting a computer, BitLocker requests the relevant key protector.
-For example, the user can enter a PIN or provide a USB drive that contains a key.
-BitLocker decrypts the encryption key and uses it to read data from the drive.
-You can use one of the following methods or combinations of methods for a key protector:
+You must also establish a key protector. BitLocker uses a key protector to encrypt the volume
+encryption key. When a user accesses a BitLocker encrypted drive, such as when starting a computer,
+BitLocker requests the relevant key protector. For example, the user can enter a PIN or provide a
+USB drive that contains a key. BitLocker decrypts the encryption key and uses it to read data from
+the drive. You can use one of the following methods or combinations of methods for a key protector:
 
-- Trusted Platform Module (TPM).
-BitLocker uses the computer's TPM to protect the encryption key.
-If you select this key protector, users can access the encrypted drive as long as it is connected to the system board that hosts the TPM and system boot integrity is intact.
-In general, TPM-based protectors can only be associated to an operating system volume.
+- **Trusted Platform Module (TPM):** BitLocker uses the computer's TPM to protect the encryption
+  key. If you select this key protector, users can access the encrypted drive as long as it is
+  connected to the system board that hosts the TPM and system boot integrity is intact. In general,
+  TPM-based protectors can only be associated to an operating system volume.
 
-- TPM and Personal Identification Number (PIN).
-BitLocker uses a combination of the TPM and a user-supplied PIN.
-A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers.
+- **TPM and Personal Identification Number (PIN):** BitLocker uses a combination of the TPM and a
+  user-supplied PIN. A PIN is four to twenty digits or, if you allow enhanced PINs, is four to
+  twenty letters, symbols, spaces, or numbers.
 
-- TPM, PIN, and startup key.
-BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key.
+- **TPM, PIN, and startup key:** BitLocker uses a combination of the TPM, a user-supplied PIN, and
+  input from of a USB memory device that contains an external key.
 
-- TPM and startup key.
-BitLocker uses a combination of the TPM and input from of a USB memory device.
+- **TPM and startup key:** BitLocker uses a combination of the TPM and a USB flash drive that
+  contains the external key.
 
-- Startup key.
-BitLocker uses input from of a USB memory device that contains the external key.
+- **Startup key:** BitLocker uses a USB flash drive that contains the external key.
 
-- Password.
-BitLocker uses a password.
+- **Password:** BitLocker uses a password.
 
-- Recovery key.
-BitLocker uses a recovery key stored as a specified file.
+- **Recovery key:** BitLocker uses a recovery key stored as a specified file.
 
-- Recovery password.
-BitLocker uses a recovery password.
+- **Recovery password:** BitLocker uses a recovery password.
 
-- Active Directory Domain Services (AD DS) account.
-BitLocker uses domain authentication.
+- **Active Directory Domain Services (AD DS) account:** BitLocker uses domain authentication.
 
-You can specify only one of these methods or combinations when you enable encryption, but you can use the **Add-BitLockerKeyProtector** cmdlet to add other protectors.
+You can specify only one of these methods or combinations when you enable encryption, but you can
+use the **Add-BitLockerKeyProtector** cmdlet to add other protectors.
 
-For a password or PIN key protector, specify a secure string.
-You can use the **ConvertTo-SecureString** cmdlet to create a secure string.
-You can use secure strings in a script and still maintain confidentiality of passwords.
+For a password or PIN key protector, specify a secure string. You can use the
+**ConvertTo-SecureString** cmdlet to create a secure string. You can use secure strings in a script
+and still maintain confidentiality of passwords.
 
-This cmdlet returns a BitLocker volume object.
-If you choose recovery password as your key protector but do not specify a 48-digit recovery password, this cmdlet creates a random 48-digit recovery password.
-The cmdlet stores the password as the **RecoveryPassword** field of the **KeyProtector** attribute of the BitLocker volume object.
+You may optionally select an encryption method. By default, BitLocker uses AES-128 but you can opt
+AES-256 for stronger security. You may request hardware encryption but Microsoft strongly advices
+against it. For further guidance, see the "[ADV180028 Security Advisory][1]".
 
-If you use startup key or recovery key as part of your key protector, provide a path to store the key.
-This cmdlet stores the name of the file that contains the key in the **KeyFileName** field of the **KeyProtector** field in the BitLocker volume object.
+This cmdlet returns a BitLocker volume object. If you choose recovery password as your key protector
+but do not specify a 48-digit recovery password, this cmdlet generates a random one for you, and
+stores it in the **RecoveryPassword** field of the **KeyProtector** attribute of the BitLocker
+volume object.
 
-If you use the **Enable-BitLocker** cmdlet on an encrypted volume or on a volume that with encryption in process, it takes no action.
-If you use the cmdlet on a drive that has encryption paused, it resumes encryption on the volume.
+If you use startup key or recovery key as part of your key protector, provide a path to store the
+key. This cmdlet stores the name of the file that contains the key in the **KeyFileName** field of
+the **KeyProtector** field in the BitLocker volume object.
 
-By default, this cmdlet encrypts the entire drive.
-If you use the *UsedSpaceOnly* parameter, it only encrypts the used space in the disk.
-This option can significant reduce encryption time.
+If you use the **Enable-BitLocker** cmdlet on an encrypted volume or on a volume that with
+encryption in process, it takes no action. If you use the cmdlet on a drive that has encryption
+paused, it resumes encryption on the volume.
 
-It is common practice to add a recovery password to an operating system volume by using the **Add-BitLockerKeyProtector** cmdlet, and then save the recovery password by using the **Backup-BitLockerKeyProtector** cmdlet, and then enable BitLocker for the drive.
-This procedure ensures that you have a recovery option.
+By default, this cmdlet encrypts the entire drive. If you use the *UsedSpaceOnly* parameter, it only
+encrypts the used space on the disk. This option can significant reduce encryption time.
 
-For an overview of BitLocker, see [BitLocker Drive Encryption Overview](https://technet.microsoft.com/en-us/library/cc732774.aspx) on TechNet.
+It is common practice to add a recovery password for an operating system volume using the
+**Add-BitLockerKeyProtector** cmdlet, save the recovery password using the
+**Backup-BitLockerKeyProtector** cmdlet, and then enable BitLocker on that volume. This procedure
+ensures that you have a recovery option.
+
+For an overview of BitLocker, see "[BitLocker Drive Encryption Overview][2]" on Microsoft Docs.
 
 ## EXAMPLES
 
@@ -587,24 +590,22 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### BitLockerVolume[],String[]
+`BitLockerVolume[]`, `String[]`
 
 ## OUTPUTS
 
-### BitLockerVolume[]
+`BitLockerVolume[]`
 
 ## NOTES
 
 ## RELATED LINKS
 
-[Disable-BitLocker](./Disable-BitLocker.md)
+- [Disable-BitLocker](./Disable-BitLocker.md)
+- [Get-BitLockerVolume](./Get-BitLockerVolume.md)
+- [Lock-BitLocker](./Lock-BitLocker.md)
+- [Resume-BitLocker](./Resume-BitLocker.md)
+- [Suspend-BitLocker](./Suspend-BitLocker.md)
+- [Unlock-BitLocker](./Unlock-BitLocker.md)
 
-[Get-BitLockerVolume](./Get-BitLockerVolume.md)
-
-[Lock-BitLocker](./Lock-BitLocker.md)
-
-[Resume-BitLocker](./Resume-BitLocker.md)
-
-[Suspend-BitLocker](./Suspend-BitLocker.md)
-
-[Unlock-BitLocker](./Unlock-BitLocker.md)
+[1]: https://msrc.microsoft.com/update-guide/en-us/vulnerability/ADV180028
+[2]: https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc732774(v=ws.11)

--- a/docset/winserver2012r2-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2012r2-ps/bitlocker/Enable-BitLocker.md
@@ -590,11 +590,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-`BitLockerVolume[]`, `String[]`
+### BitLockerVolume[], String[]
 
 ## OUTPUTS
 
-`BitLockerVolume[]`
+### BitLockerVolume[]
 
 ## NOTES
 

--- a/docset/winserver2012r2-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2012r2-ps/bitlocker/Enable-BitLocker.md
@@ -1,7 +1,8 @@
 ---
+description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: BitLocker-help.xml
 Module Name: BitLocker
-ms.date: 10/29/2017
+ms.date: 12/14/2021
 online version: https://docs.microsoft.com/powershell/module/bitlocker/enable-bitlocker?view=windowsserver2012r2-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enable-BitLocker
@@ -10,117 +11,126 @@ title: Enable-BitLocker
 # Enable-BitLocker
 
 ## SYNOPSIS
-Enables encryption for a BitLocker volume.
+
+Enables BitLocker Drive Encryption for a volume.
 
 ## SYNTAX
 
 ### PasswordProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-PasswordProtector] [[-Password] <SecureString>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryPasswordProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryPasswordProtector]
  [[-RecoveryPassword] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### StartupKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyProtector] [-StartupKeyPath] <String>
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndStartupKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
  [-TpmAndStartupKeyProtector] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinAndStartupKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
  [-TpmAndPinAndStartupKeyProtector] [[-Pin] <SecureString>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### AdAccountOrGroupProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-AdAccountOrGroupProtector] [-Service]
  [-AdAccountOrGroup] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [[-Pin] <SecureString>] [-TpmAndPinProtector]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-TpmProtector] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### RecoveryKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryKeyProtector] [-RecoveryKeyPath] <String>
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 The **Enable-BitLocker** cmdlet enables BitLocker Drive Encryption for a volume.
 
 When you enable encryption, you must specify a volume and an encryption method for that volume.
 You can specify a volume by drive letter or by specifying a BitLocker volume object.
-For the encryption method, you can choose either Advanced Encryption Standard (AES) algorithms AES-128 or AES-256, or you can use hardware encryption, if it is supported by the disk hardware.
+For the encryption method, you can choose either Advanced Encryption Standard (AES) algorithms AES-128 or AES-256, or you can use hardware encryption if it is supported by the disk hardware.
 
 You must also establish a key protector.
 BitLocker uses a key protector to encrypt the volume encryption key.
 When a user accesses a BitLocker encrypted drive, such as when starting a computer, BitLocker requests the relevant key protector.
 For example, the user can enter a PIN or provide a USB drive that contains a key.
 BitLocker decrypts the encryption key and uses it to read data from the drive.
-You can use one of the following methods or combinations of methods for a key protector: 
+You can use one of the following methods or combinations of methods for a key protector:
 
-
-- Trusted Platform Module (TPM) .
+- Trusted Platform Module (TPM).
 BitLocker uses the computer's TPM to protect the encryption key.
 If you select this key protector, users can access the encrypted drive as long as it is connected to the system board that hosts the TPM and system boot integrity is intact.
-In general, TPM-based protectors can only be associated to an operating system volume. 
+In general, TPM-based protectors can only be associated to an operating system volume.
 
-- TPM and Personal Identification Number (PIN) .
+- TPM and Personal Identification Number (PIN).
 BitLocker uses a combination of the TPM and a user-supplied PIN.
-A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers. 
+A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers.
 
 - TPM, PIN, and startup key.
-BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key. 
+BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key.
 
 - TPM and startup key.
-BitLocker uses a combination of the TPM and input from of a USB memory device. 
+BitLocker uses a combination of the TPM and input from of a USB memory device.
 
 - Startup key.
-BitLocker uses input from of a USB memory device that contains the external key. 
+BitLocker uses input from of a USB memory device that contains the external key.
 
 - Password.
-BitLocker uses a password. 
+BitLocker uses a password.
 
 - Recovery key.
-BitLocker uses a recovery key stored as a specified file. 
+BitLocker uses a recovery key stored as a specified file.
 
 - Recovery password.
-BitLocker uses a recovery password. 
+BitLocker uses a recovery password.
 
-- Active Directory Domain Services(AD DS).
-account.
+- Active Directory Domain Services (AD DS) account.
 BitLocker uses domain authentication.
 
 You can specify only one of these methods or combinations when you enable encryption, but you can use the **Add-BitLockerKeyProtector** cmdlet to add other protectors.
@@ -130,30 +140,31 @@ You can use the **ConvertTo-SecureString** cmdlet to create a secure string.
 You can use secure strings in a script and still maintain confidentiality of passwords.
 
 This cmdlet returns a BitLocker volume object.
-If you choose recovery password as your key protector but do not specify a 48-digit recovery password, this cmdlet creates a random 48-bit recovery password.
+If you choose recovery password as your key protector but do not specify a 48-digit recovery password, this cmdlet creates a random 48-digit recovery password.
 The cmdlet stores the password as the **RecoveryPassword** field of the **KeyProtector** attribute of the BitLocker volume object.
 
 If you use startup key or recovery key as part of your key protector, provide a path to store the key.
 This cmdlet stores the name of the file that contains the key in the **KeyFileName** field of the **KeyProtector** field in the BitLocker volume object.
 
-If you use the Enable-BitLocker cmdlet on an encrypted volume or on a volume that with encryption in process, it takes no action.
+If you use the **Enable-BitLocker** cmdlet on an encrypted volume or on a volume that with encryption in process, it takes no action.
 If you use the cmdlet on a drive that has encryption paused, it resumes encryption on the volume.
 
 By default, this cmdlet encrypts the entire drive.
-If you use the **UsedSpaceOnly** parameter, it only encrypts the used space in the disk.
+If you use the *UsedSpaceOnly* parameter, it only encrypts the used space in the disk.
 This option can significant reduce encryption time.
 
-It is common practice to add a recovery password to an operating system volume by using the Add-BitLockerKeyProtector cmdlet, and then save the recovery password by using the Backup-BitLockerKeyProtector cmdlet, and then enable BitLocker for the drive.
+It is common practice to add a recovery password to an operating system volume by using the **Add-BitLockerKeyProtector** cmdlet, and then save the recovery password by using the **Backup-BitLockerKeyProtector** cmdlet, and then enable BitLocker for the drive.
 This procedure ensures that you have a recovery option.
 
-For an overview of BitLocker, see BitLocker Drive Encryption Overviewhttp://technet.microsoft.com/en-us/library/cc732774.aspx (http://technet.microsoft.com/en-us/library/cc732774.aspx) on TechNet.
+For an overview of BitLocker, see [BitLocker Drive Encryption Overview](https://technet.microsoft.com/en-us/library/cc732774.aspx) on TechNet.
 
 ## EXAMPLES
 
 ### Example 1: Enable BitLocker
-```
-PS C:\> $SecureString = ConvertTo-SecureString "1234" -AsPlainText -Force
-PS C:\> Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes256 -UsedSpaceOnly -Pin $SecureString -TPMandPinProtector
+
+```PowerShell
+$SecureString = ConvertTo-SecureString "1234" -AsPlainText -Force
+Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes256 -UsedSpaceOnly -Pin $SecureString -TPMandPinProtector
 ```
 
 This example enables BitLocker for a specified drive using the TPM and a PIN for key protector.
@@ -167,28 +178,31 @@ The command also specifies that this volume uses a combination of the TPM and th
 The command also specifies to encrypt the used space data on the disk, instead of the entire volume.
 When the system writes data to the volume in the future, that data is encrypted.
 
-### Example 2: Enable BitLocker with a specified recovery key
-```
-PS C:\> Get-BitLockerVolume | Enable-BitLocker -EncryptionMethod Aes128 -RecoveryKeyPath "E:\Recovery\" -RecoveryKeyProtector
+### Example 2: Enable BitLocker with a recovery key
+
+```PowerShell
+Get-BitLockerVolume | Enable-BitLocker -EncryptionMethod Aes128 -RecoveryKeyPath "E:\Recovery\" -RecoveryKeyProtector
 ```
 
-This command gets all the BitLocker volumes for the current computer and passes pipes them to the Enable-BitLocker cmdlet by using the pipe operator.
+This command gets all the BitLocker volumes for the current computer and passes pipes them to the **Enable-BitLocker** cmdlet by using the pipe operator.
 This cmdlet specifies an encryption algorithm for the volume or volumes.
 This cmdlet specifies a path to a folder where the randomly generated recovery key will be stored and indicates that these volumes use a recovery key as a key protector.
 
 ### Example 3: Enable BitLocker with a specified user account
-```
-PS C:\> Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes128 -AdAccountOrGroup "Western\SarahJones" -AdAccountOrGroupProtector
+
+```PowerShell
+Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes128 -AdAccountOrGroup "Western\SarahJones" -AdAccountOrGroupProtector
 ```
 
-This command encrypts the BitLocker volume specified by the **MountPoint** parameter, and uses the AES 128 encryption method.
+This command encrypts the BitLocker volume specified by the *MountPoint* parameter, and uses the AES 128 encryption method.
 The command also specifies an account and specifies that BitLocker uses user credentials as a key protector.
 When a user accesses this volume, BitLocker prompts for credentials for the user account Western\SarahJones.
 
 ## PARAMETERS
 
 ### -AdAccountOrGroup
-Specifies an account using the format **Domain\User**.
+
+Specifies an account using the format Domain\User.
 This cmdlet adds the account you specify as a key protector for the volume encryption key.
 
 ```yaml
@@ -204,6 +218,7 @@ Accept wildcard characters: False
 ```
 
 ### -AdAccountOrGroupProtector
+
 Indicates that BitLocker uses an AD DS account as a protector for the volume encryption key.
 
 ```yaml
@@ -213,12 +228,13 @@ Aliases: sidp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -234,19 +250,14 @@ Accept wildcard characters: False
 ```
 
 ### -EncryptionMethod
+
 Specifies an encryption method for the encrypted drive.
-The acceptable values for this parameter are:
-
-
-- Aes128
-
-- Aes256
 
 ```yaml
 Type: BitLockerVolumeEncryptionMethodOnEnable
 Parameter Sets: (All)
 Aliases: 
-Accepted values: Aes128, Aes256, Hardware
+Accepted values: Aes128, Aes256
 
 Required: False
 Position: Named
@@ -256,6 +267,7 @@ Accept wildcard characters: False
 ```
 
 ### -HardwareEncryption
+
 Indicates that the volume uses hardware encryption.
 
 ```yaml
@@ -265,15 +277,16 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -MountPoint
+
 Specifies an array of drive letters or BitLocker volume objects.
 This cmdlet enables protection for the volumes specified.
-To obtain a BitLocker volume object, use the Get-BitLockerVolume cmdlet.
+To obtain a BitLocker volume object, use the **Get-BitLockerVolume** cmdlet.
 
 ```yaml
 Type: String[]
@@ -288,6 +301,7 @@ Accept wildcard characters: False
 ```
 
 ### -Password
+
 Specifies a secure string object that contains a password.
 The password specified acts as a protector for the volume encryption key.
 
@@ -304,6 +318,7 @@ Accept wildcard characters: False
 ```
 
 ### -PasswordProtector
+
 Indicates that BitLocker uses a password as a protector for the volume encryption key.
 
 ```yaml
@@ -313,12 +328,13 @@ Aliases: pwp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Pin
+
 Specifies a secure string object that contains a PIN.
 BitLocker uses the PIN specified, with other data, as a protector for the volume encryption key.
 
@@ -335,6 +351,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryKeyPath
+
 Specifies a path to a folder.
 This cmdlet adds a randomly generated recovery key as a protector for the volume encryption key and stores it in the specified path.
 
@@ -351,6 +368,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryKeyProtector
+
 Indicates that BitLocker uses a recovery key as a protector for the volume encryption key.
 
 ```yaml
@@ -360,15 +378,16 @@ Aliases: rkp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -RecoveryPassword
+
 Specifies a recovery password.
-If you do not specify this parameter, but you do include the **RecoveryPasswordProtector** parameter, the cmdlet creates a random password.
-You can enter a 48 digit password.
+If you do not specify this parameter, but you do include the *RecoveryPasswordProtector* parameter, the cmdlet creates a random password.
+You can enter a 48-digit password.
 The password specified or created acts as a protector for the volume encryption key.
 
 ```yaml
@@ -384,6 +403,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPasswordProtector
+
 Indicates that BitLocker uses a recovery password as a protector for the volume encryption key.
 
 ```yaml
@@ -393,12 +413,13 @@ Aliases: rpp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Service
+
 Indicates that the system account for this computer unlocks the encrypted volume.
 
 ```yaml
@@ -408,12 +429,13 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -SkipHardwareTest
+
 Indicates that BitLocker does not perform a hardware test before it begins encryption.
 BitLocker uses a hardware test as a dry run to make sure that all the key protectors are correctly set up and that the computer can start without issues.
 
@@ -424,12 +446,13 @@ Aliases: s
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -StartupKeyPath
+
 Specifies a path to a startup key.
 The key stored in the specified path acts as a protector for the volume encryption key.
 
@@ -446,6 +469,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartupKeyProtector
+
 Indicates that BitLocker uses a startup key as a protector for the volume encryption key.
 
 ```yaml
@@ -455,12 +479,13 @@ Aliases: skp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -TpmAndPinAndStartupKeyProtector
+
 Indicates that BitLocker uses a combination of the TPM, a PIN, and a startup key as a protector for the volume encryption key.
 
 ```yaml
@@ -470,12 +495,13 @@ Aliases: tpskp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -TpmAndPinProtector
+
 Indicates that BitLocker uses a combination of the TPM and a PIN as a protector for the volume encryption key.
 
 ```yaml
@@ -485,12 +511,13 @@ Aliases: tpp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -TpmAndStartupKeyProtector
+
 Indicates that BitLocker uses a combination of the TPM and a startup key as a protector for the volume encryption key.
 
 ```yaml
@@ -500,12 +527,13 @@ Aliases: tskp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -TpmProtector
+
 Indicates that BitLocker uses the TPM as a protector for the volume encryption key.
 
 ```yaml
@@ -515,12 +543,13 @@ Aliases: tpmp
 
 Required: True
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -UsedSpaceOnly
+
 Indicates that BitLocker does not encrypt disk space which contains unused data.
 
 ```yaml
@@ -530,12 +559,13 @@ Aliases: qe
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -552,7 +582,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -568,6 +599,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Disable-BitLocker](./Disable-BitLocker.md)
 
+[Get-BitLockerVolume](./Get-BitLockerVolume.md)
+
 [Lock-BitLocker](./Lock-BitLocker.md)
 
 [Resume-BitLocker](./Resume-BitLocker.md)
@@ -575,6 +608,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Suspend-BitLocker](./Suspend-BitLocker.md)
 
 [Unlock-BitLocker](./Unlock-BitLocker.md)
-
-[Get-BitLockerVolume](./Get-BitLockerVolume.md)
-

--- a/docset/winserver2016-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2016-ps/bitlocker/Enable-BitLocker.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: BitLocker-help.xml
 Module Name: BitLocker
-ms.date: 12/20/2016
+ms.date: 12/14/2021
 online version: https://docs.microsoft.com/powershell/module/bitlocker/enable-bitlocker?view=windowsserver2016-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enable-BitLocker
@@ -11,74 +11,85 @@ title: Enable-BitLocker
 # Enable-BitLocker
 
 ## SYNOPSIS
+
 Enables BitLocker Drive Encryption for a volume.
 
 ## SYNTAX
 
 ### PasswordProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-PasswordProtector] [[-Password] <SecureString>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryPasswordProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryPasswordProtector]
  [[-RecoveryPassword] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### StartupKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyProtector] [-StartupKeyPath] <String>
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndStartupKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
  [-TpmAndStartupKeyProtector] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinAndStartupKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
  [-TpmAndPinAndStartupKeyProtector] [[-Pin] <SecureString>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### AdAccountOrGroupProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-AdAccountOrGroupProtector] [-Service]
  [-AdAccountOrGroup] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [[-Pin] <SecureString>] [-TpmAndPinProtector]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-TpmProtector] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### RecoveryKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryKeyProtector] [-RecoveryKeyPath] <String>
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 The **Enable-BitLocker** cmdlet enables BitLocker Drive Encryption for a volume.
 
 When you enable encryption, you must specify a volume and an encryption method for that volume.
@@ -90,35 +101,34 @@ BitLocker uses a key protector to encrypt the volume encryption key.
 When a user accesses a BitLocker encrypted drive, such as when starting a computer, BitLocker requests the relevant key protector.
 For example, the user can enter a PIN or provide a USB drive that contains a key.
 BitLocker decrypts the encryption key and uses it to read data from the drive.
-You can use one of the following methods or combinations of methods for a key protector: 
-
+You can use one of the following methods or combinations of methods for a key protector:
 
 - Trusted Platform Module (TPM).
 BitLocker uses the computer's TPM to protect the encryption key.
 If you select this key protector, users can access the encrypted drive as long as it is connected to the system board that hosts the TPM and system boot integrity is intact.
-In general, TPM-based protectors can only be associated to an operating system volume. 
+In general, TPM-based protectors can only be associated to an operating system volume.
 
 - TPM and Personal Identification Number (PIN).
 BitLocker uses a combination of the TPM and a user-supplied PIN.
-A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers. 
+A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers.
 
 - TPM, PIN, and startup key.
-BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key. 
+BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key.
 
 - TPM and startup key.
-BitLocker uses a combination of the TPM and input from of a USB memory device. 
+BitLocker uses a combination of the TPM and input from of a USB memory device.
 
 - Startup key.
-BitLocker uses input from of a USB memory device that contains the external key. 
+BitLocker uses input from of a USB memory device that contains the external key.
 
 - Password.
-BitLocker uses a password. 
+BitLocker uses a password.
 
 - Recovery key.
-BitLocker uses a recovery key stored as a specified file. 
+BitLocker uses a recovery key stored as a specified file.
 
 - Recovery password.
-BitLocker uses a recovery password. 
+BitLocker uses a recovery password.
 
 - Active Directory Domain Services (AD DS) account.
 BitLocker uses domain authentication.
@@ -151,9 +161,10 @@ For an overview of BitLocker, see [BitLocker Drive Encryption Overview](https://
 ## EXAMPLES
 
 ### Example 1: Enable BitLocker
-```
-PS C:\> $SecureString = ConvertTo-SecureString "1234" -AsPlainText -Force
-PS C:\> Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes256 -UsedSpaceOnly -Pin $SecureString -TPMandPinProtector
+
+```PowerShell
+$SecureString = ConvertTo-SecureString "1234" -AsPlainText -Force
+Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes256 -UsedSpaceOnly -Pin $SecureString -TPMandPinProtector
 ```
 
 This example enables BitLocker for a specified drive using the TPM and a PIN for key protector.
@@ -168,8 +179,9 @@ The command also specifies to encrypt the used space data on the disk, instead o
 When the system writes data to the volume in the future, that data is encrypted.
 
 ### Example 2: Enable BitLocker with a recovery key
-```
-PS C:\> Get-BitLockerVolume | Enable-BitLocker -EncryptionMethod Aes128 -RecoveryKeyPath "E:\Recovery\" -RecoveryKeyProtector
+
+```PowerShell
+Get-BitLockerVolume | Enable-BitLocker -EncryptionMethod Aes128 -RecoveryKeyPath "E:\Recovery\" -RecoveryKeyProtector
 ```
 
 This command gets all the BitLocker volumes for the current computer and passes pipes them to the **Enable-BitLocker** cmdlet by using the pipe operator.
@@ -177,8 +189,9 @@ This cmdlet specifies an encryption algorithm for the volume or volumes.
 This cmdlet specifies a path to a folder where the randomly generated recovery key will be stored and indicates that these volumes use a recovery key as a key protector.
 
 ### Example 3: Enable BitLocker with a specified user account
-```
-PS C:\> Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes128 -AdAccountOrGroup "Western\SarahJones" -AdAccountOrGroupProtector
+
+```PowerShell
+Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes128 -AdAccountOrGroup "Western\SarahJones" -AdAccountOrGroupProtector
 ```
 
 This command encrypts the BitLocker volume specified by the *MountPoint* parameter, and uses the AES 128 encryption method.
@@ -188,6 +201,7 @@ When a user accesses this volume, BitLocker prompts for credentials for the user
 ## PARAMETERS
 
 ### -AdAccountOrGroup
+
 Specifies an account using the format Domain\User.
 This cmdlet adds the account you specify as a key protector for the volume encryption key.
 
@@ -204,6 +218,7 @@ Accept wildcard characters: False
 ```
 
 ### -AdAccountOrGroupProtector
+
 Indicates that BitLocker uses an AD DS account as a protector for the volume encryption key.
 
 ```yaml
@@ -219,6 +234,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -234,14 +250,8 @@ Accept wildcard characters: False
 ```
 
 ### -EncryptionMethod
+
 Specifies an encryption method for the encrypted drive.
-The acceptable values for this parameter are:
-
-
-- Aes128
-
-- Aes256
-- Hardware
 
 ```yaml
 Type: BitLockerVolumeEncryptionMethodOnEnable
@@ -257,6 +267,7 @@ Accept wildcard characters: False
 ```
 
 ### -HardwareEncryption
+
 Indicates that the volume uses hardware encryption.
 
 ```yaml
@@ -272,6 +283,7 @@ Accept wildcard characters: False
 ```
 
 ### -MountPoint
+
 Specifies an array of drive letters or BitLocker volume objects.
 This cmdlet enables protection for the volumes specified.
 To obtain a BitLocker volume object, use the **Get-BitLockerVolume** cmdlet.
@@ -289,6 +301,7 @@ Accept wildcard characters: False
 ```
 
 ### -Password
+
 Specifies a secure string object that contains a password.
 The password specified acts as a protector for the volume encryption key.
 
@@ -305,6 +318,7 @@ Accept wildcard characters: False
 ```
 
 ### -PasswordProtector
+
 Indicates that BitLocker uses a password as a protector for the volume encryption key.
 
 ```yaml
@@ -320,6 +334,7 @@ Accept wildcard characters: False
 ```
 
 ### -Pin
+
 Specifies a secure string object that contains a PIN.
 BitLocker uses the PIN specified, with other data, as a protector for the volume encryption key.
 
@@ -336,6 +351,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryKeyPath
+
 Specifies a path to a folder.
 This cmdlet adds a randomly generated recovery key as a protector for the volume encryption key and stores it in the specified path.
 
@@ -352,6 +368,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryKeyProtector
+
 Indicates that BitLocker uses a recovery key as a protector for the volume encryption key.
 
 ```yaml
@@ -367,6 +384,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPassword
+
 Specifies a recovery password.
 If you do not specify this parameter, but you do include the *RecoveryPasswordProtector* parameter, the cmdlet creates a random password.
 You can enter a 48-digit password.
@@ -385,6 +403,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPasswordProtector
+
 Indicates that BitLocker uses a recovery password as a protector for the volume encryption key.
 
 ```yaml
@@ -400,6 +419,7 @@ Accept wildcard characters: False
 ```
 
 ### -Service
+
 Indicates that the system account for this computer unlocks the encrypted volume.
 
 ```yaml
@@ -415,6 +435,7 @@ Accept wildcard characters: False
 ```
 
 ### -SkipHardwareTest
+
 Indicates that BitLocker does not perform a hardware test before it begins encryption.
 BitLocker uses a hardware test as a dry run to make sure that all the key protectors are correctly set up and that the computer can start without issues.
 
@@ -431,6 +452,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartupKeyPath
+
 Specifies a path to a startup key.
 The key stored in the specified path acts as a protector for the volume encryption key.
 
@@ -447,6 +469,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartupKeyProtector
+
 Indicates that BitLocker uses a startup key as a protector for the volume encryption key.
 
 ```yaml
@@ -462,6 +485,7 @@ Accept wildcard characters: False
 ```
 
 ### -TpmAndPinAndStartupKeyProtector
+
 Indicates that BitLocker uses a combination of the TPM, a PIN, and a startup key as a protector for the volume encryption key.
 
 ```yaml
@@ -477,6 +501,7 @@ Accept wildcard characters: False
 ```
 
 ### -TpmAndPinProtector
+
 Indicates that BitLocker uses a combination of the TPM and a PIN as a protector for the volume encryption key.
 
 ```yaml
@@ -492,6 +517,7 @@ Accept wildcard characters: False
 ```
 
 ### -TpmAndStartupKeyProtector
+
 Indicates that BitLocker uses a combination of the TPM and a startup key as a protector for the volume encryption key.
 
 ```yaml
@@ -507,6 +533,7 @@ Accept wildcard characters: False
 ```
 
 ### -TpmProtector
+
 Indicates that BitLocker uses the TPM as a protector for the volume encryption key.
 
 ```yaml
@@ -522,6 +549,7 @@ Accept wildcard characters: False
 ```
 
 ### -UsedSpaceOnly
+
 Indicates that BitLocker does not encrypt disk space which contains unused data.
 
 ```yaml
@@ -537,6 +565,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -553,6 +582,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -578,4 +608,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Suspend-BitLocker](./Suspend-BitLocker.md)
 
 [Unlock-BitLocker](./Unlock-BitLocker.md)
-

--- a/docset/winserver2016-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2016-ps/bitlocker/Enable-BitLocker.md
@@ -19,144 +19,149 @@ Enables BitLocker Drive Encryption for a volume.
 ### PasswordProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-PasswordProtector] [[-Password] <SecureString>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -PasswordProtector [-Password] <SecureString>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly][-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryPasswordProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryPasswordProtector]
- [[-RecoveryPassword] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -RecoveryPasswordProtector [[-RecoveryPassword] <String>]
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### StartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyProtector] [-StartupKeyPath] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -StartupKeyProtector [-StartupKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndStartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
- [-TpmAndStartupKeyProtector] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndStartupKeyProtector [-StartupKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinAndStartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
- [-TpmAndPinAndStartupKeyProtector] [[-Pin] <SecureString>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndPinAndStartupKeyProtector -StartupKeyPath <String>
+[-Pin] <SecureString> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+[-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm]
+[<CommonParameters>]
 ```
 
 ### AdAccountOrGroupProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-AdAccountOrGroupProtector] [-Service]
- [-AdAccountOrGroup] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -AdAccountOrGroupProtector [-AdAccountOrGroup] <String>
+[-Service] [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [[-Pin] <SecureString>] [-TpmAndPinProtector]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndPinProtector [-Pin] <SecureString>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-TpmProtector] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmProtector
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryKeyProtector] [-RecoveryKeyPath] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -RecoveryKeyProtector [-RecoveryKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 The **Enable-BitLocker** cmdlet enables BitLocker Drive Encryption for a volume.
 
-When you enable encryption, you must specify a volume and an encryption method for that volume.
-You can specify a volume by drive letter or by specifying a BitLocker volume object.
-For the encryption method, you can choose either Advanced Encryption Standard (AES) algorithms AES-128 or AES-256, or you can use hardware encryption if it is supported by the disk hardware.
+When you enable encryption, you must specify a volume, either by its drive letter or by its
+BitLocker volume object.
 
-You must also establish a key protector.
-BitLocker uses a key protector to encrypt the volume encryption key.
-When a user accesses a BitLocker encrypted drive, such as when starting a computer, BitLocker requests the relevant key protector.
-For example, the user can enter a PIN or provide a USB drive that contains a key.
-BitLocker decrypts the encryption key and uses it to read data from the drive.
-You can use one of the following methods or combinations of methods for a key protector:
+You must also establish a key protector. BitLocker uses a key protector to encrypt the volume
+encryption key. When a user accesses a BitLocker encrypted drive, such as when starting a computer,
+BitLocker requests the relevant key protector. For example, the user can enter a PIN or provide a
+USB drive that contains a key. BitLocker decrypts the encryption key and uses it to read data from
+the drive. You can use one of the following methods or combinations of methods for a key protector:
 
-- Trusted Platform Module (TPM).
-BitLocker uses the computer's TPM to protect the encryption key.
-If you select this key protector, users can access the encrypted drive as long as it is connected to the system board that hosts the TPM and system boot integrity is intact.
-In general, TPM-based protectors can only be associated to an operating system volume.
+- **Trusted Platform Module (TPM):** BitLocker uses the computer's TPM to protect the encryption
+  key. If you select this key protector, users can access the encrypted drive as long as it is
+  connected to the system board that hosts the TPM and system boot integrity is intact. In general,
+  TPM-based protectors can only be associated to an operating system volume.
 
-- TPM and Personal Identification Number (PIN).
-BitLocker uses a combination of the TPM and a user-supplied PIN.
-A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers.
+- **TPM and Personal Identification Number (PIN):** BitLocker uses a combination of the TPM and a
+  user-supplied PIN. A PIN is four to twenty digits or, if you allow enhanced PINs, is four to
+  twenty letters, symbols, spaces, or numbers.
 
-- TPM, PIN, and startup key.
-BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key.
+- **TPM, PIN, and startup key:** BitLocker uses a combination of the TPM, a user-supplied PIN, and
+  input from of a USB memory device that contains an external key.
 
-- TPM and startup key.
-BitLocker uses a combination of the TPM and input from of a USB memory device.
+- **TPM and startup key:** BitLocker uses a combination of the TPM and a USB flash drive that
+  contains the external key.
 
-- Startup key.
-BitLocker uses input from of a USB memory device that contains the external key.
+- **Startup key:** BitLocker uses a USB flash drive that contains the external key.
 
-- Password.
-BitLocker uses a password.
+- **Password:** BitLocker uses a password.
 
-- Recovery key.
-BitLocker uses a recovery key stored as a specified file.
+- **Recovery key:** BitLocker uses a recovery key stored as a specified file.
 
-- Recovery password.
-BitLocker uses a recovery password.
+- **Recovery password:** BitLocker uses a recovery password.
 
-- Active Directory Domain Services (AD DS) account.
-BitLocker uses domain authentication.
+- **Active Directory Domain Services (AD DS) account:** BitLocker uses domain authentication.
 
-You can specify only one of these methods or combinations when you enable encryption, but you can use the **Add-BitLockerKeyProtector** cmdlet to add other protectors.
+You can specify only one of these methods or combinations when you enable encryption, but you can
+use the **Add-BitLockerKeyProtector** cmdlet to add other protectors.
 
-For a password or PIN key protector, specify a secure string.
-You can use the **ConvertTo-SecureString** cmdlet to create a secure string.
-You can use secure strings in a script and still maintain confidentiality of passwords.
+For a password or PIN key protector, specify a secure string. You can use the
+**ConvertTo-SecureString** cmdlet to create a secure string. You can use secure strings in a script
+and still maintain confidentiality of passwords.
 
-This cmdlet returns a BitLocker volume object.
-If you choose recovery password as your key protector but do not specify a 48-digit recovery password, this cmdlet creates a random 48-digit recovery password.
-The cmdlet stores the password as the **RecoveryPassword** field of the **KeyProtector** attribute of the BitLocker volume object.
+We strongly recommend specifying the encryption method. By default, BitLocker uses XTS-AES-128. You
+can opt XTS-AES-256 for stronger security. However, if you are encrypting a removable media and
+intend to use it on Windows 8.1 or Windows Server 2012 R2, you must opt either AES-128 or AES-256
+for backward compatibility. You may request hardware encryption but Microsoft strongly advices
+against it. For further guidance, see the "[ADV180028 Security Advisory][1]".
 
-If you use startup key or recovery key as part of your key protector, provide a path to store the key.
-This cmdlet stores the name of the file that contains the key in the **KeyFileName** field of the **KeyProtector** field in the BitLocker volume object.
+This cmdlet returns a BitLocker volume object. If you choose recovery password as your key protector
+but do not specify a 48-digit recovery password, this cmdlet generates a random one for you, and
+stores it in the **RecoveryPassword** field of the **KeyProtector** attribute of the BitLocker
+volume object.
 
-If you use the **Enable-BitLocker** cmdlet on an encrypted volume or on a volume that with encryption in process, it takes no action.
-If you use the cmdlet on a drive that has encryption paused, it resumes encryption on the volume.
+If you use startup key or recovery key as part of your key protector, provide a path to store the
+key. This cmdlet stores the name of the file that contains the key in the **KeyFileName** field of
+the **KeyProtector** field in the BitLocker volume object.
 
-By default, this cmdlet encrypts the entire drive.
-If you use the *UsedSpaceOnly* parameter, it only encrypts the used space in the disk.
-This option can significant reduce encryption time.
+If you use the **Enable-BitLocker** cmdlet on an encrypted volume or on a volume that with
+encryption in process, it takes no action. If you use the cmdlet on a drive that has encryption
+paused, it resumes encryption on the volume.
 
-It is common practice to add a recovery password to an operating system volume by using the **Add-BitLockerKeyProtector** cmdlet, and then save the recovery password by using the **Backup-BitLockerKeyProtector** cmdlet, and then enable BitLocker for the drive.
-This procedure ensures that you have a recovery option.
+By default, this cmdlet encrypts the entire drive. If you use the *UsedSpaceOnly* parameter, it only
+encrypts the used space on the disk. This option can significant reduce encryption time.
 
-For an overview of BitLocker, see [BitLocker Drive Encryption Overview](https://technet.microsoft.com/en-us/library/cc732774.aspx) on TechNet.
+It is common practice to add a recovery password for an operating system volume using the
+**Add-BitLockerKeyProtector** cmdlet, save the recovery password using the
+**Backup-BitLockerKeyProtector** cmdlet, and then enable BitLocker on that volume. This procedure
+ensures that you have a recovery option.
+
+For an overview of BitLocker, see "[BitLocker Drive Encryption Overview][2]" on Microsoft Docs.
 
 ## EXAMPLES
 
@@ -587,24 +592,22 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### BitLockerVolume[],String[]
+`BitLockerVolume[]`, `String[]`
 
 ## OUTPUTS
 
-### BitLockerVolume[]
+`BitLockerVolume[]`
 
 ## NOTES
 
 ## RELATED LINKS
 
-[Disable-BitLocker](./Disable-BitLocker.md)
+- [Disable-BitLocker](./Disable-BitLocker.md)
+- [Get-BitLockerVolume](./Get-BitLockerVolume.md)
+- [Lock-BitLocker](./Lock-BitLocker.md)
+- [Resume-BitLocker](./Resume-BitLocker.md)
+- [Suspend-BitLocker](./Suspend-BitLocker.md)
+- [Unlock-BitLocker](./Unlock-BitLocker.md)
 
-[Get-BitLockerVolume](./Get-BitLockerVolume.md)
-
-[Lock-BitLocker](./Lock-BitLocker.md)
-
-[Resume-BitLocker](./Resume-BitLocker.md)
-
-[Suspend-BitLocker](./Suspend-BitLocker.md)
-
-[Unlock-BitLocker](./Unlock-BitLocker.md)
+[1]: https://msrc.microsoft.com/update-guide/en-us/vulnerability/ADV180028
+[2]: https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc732774(v=ws.11)

--- a/docset/winserver2016-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2016-ps/bitlocker/Enable-BitLocker.md
@@ -592,11 +592,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-`BitLockerVolume[]`, `String[]`
+### BitLockerVolume[], String[]
 
 ## OUTPUTS
 
-`BitLockerVolume[]`
+### BitLockerVolume[]
 
 ## NOTES
 

--- a/docset/winserver2019-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2019-ps/bitlocker/Enable-BitLocker.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: BitLocker-help.xml
 Module Name: BitLocker
-ms.date: 12/20/2016
+ms.date: 12/14/2021
 online version: https://docs.microsoft.com/powershell/module/bitlocker/enable-bitlocker?view=windowsserver2019-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enable-BitLocker
@@ -11,74 +11,85 @@ title: Enable-BitLocker
 # Enable-BitLocker
 
 ## SYNOPSIS
+
 Enables BitLocker Drive Encryption for a volume.
 
 ## SYNTAX
 
 ### PasswordProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-PasswordProtector] [[-Password] <SecureString>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryPasswordProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryPasswordProtector]
  [[-RecoveryPassword] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### StartupKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyProtector] [-StartupKeyPath] <String>
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndStartupKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
  [-TpmAndStartupKeyProtector] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinAndStartupKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
  [-TpmAndPinAndStartupKeyProtector] [[-Pin] <SecureString>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### AdAccountOrGroupProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-AdAccountOrGroupProtector] [-Service]
  [-AdAccountOrGroup] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [[-Pin] <SecureString>] [-TpmAndPinProtector]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-TpmProtector] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### RecoveryKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryKeyProtector] [-RecoveryKeyPath] <String>
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 The **Enable-BitLocker** cmdlet enables BitLocker Drive Encryption for a volume.
 
 When you enable encryption, you must specify a volume and an encryption method for that volume.
@@ -90,35 +101,34 @@ BitLocker uses a key protector to encrypt the volume encryption key.
 When a user accesses a BitLocker encrypted drive, such as when starting a computer, BitLocker requests the relevant key protector.
 For example, the user can enter a PIN or provide a USB drive that contains a key.
 BitLocker decrypts the encryption key and uses it to read data from the drive.
-You can use one of the following methods or combinations of methods for a key protector: 
-
+You can use one of the following methods or combinations of methods for a key protector:
 
 - Trusted Platform Module (TPM).
 BitLocker uses the computer's TPM to protect the encryption key.
 If you select this key protector, users can access the encrypted drive as long as it is connected to the system board that hosts the TPM and system boot integrity is intact.
-In general, TPM-based protectors can only be associated to an operating system volume. 
+In general, TPM-based protectors can only be associated to an operating system volume.
 
 - TPM and Personal Identification Number (PIN).
 BitLocker uses a combination of the TPM and a user-supplied PIN.
-A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers. 
+A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers.
 
 - TPM, PIN, and startup key.
-BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key. 
+BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key.
 
 - TPM and startup key.
-BitLocker uses a combination of the TPM and input from of a USB memory device. 
+BitLocker uses a combination of the TPM and input from of a USB memory device.
 
 - Startup key.
-BitLocker uses input from of a USB memory device that contains the external key. 
+BitLocker uses input from of a USB memory device that contains the external key.
 
 - Password.
-BitLocker uses a password. 
+BitLocker uses a password.
 
 - Recovery key.
-BitLocker uses a recovery key stored as a specified file. 
+BitLocker uses a recovery key stored as a specified file.
 
 - Recovery password.
-BitLocker uses a recovery password. 
+BitLocker uses a recovery password.
 
 - Active Directory Domain Services (AD DS) account.
 BitLocker uses domain authentication.
@@ -151,9 +161,10 @@ For an overview of BitLocker, see [BitLocker Drive Encryption Overview](https://
 ## EXAMPLES
 
 ### Example 1: Enable BitLocker
-```
-PS C:\> $SecureString = ConvertTo-SecureString "1234" -AsPlainText -Force
-PS C:\> Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes256 -UsedSpaceOnly -Pin $SecureString -TPMandPinProtector
+
+```PowerShell
+$SecureString = ConvertTo-SecureString "1234" -AsPlainText -Force
+Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes256 -UsedSpaceOnly -Pin $SecureString -TPMandPinProtector
 ```
 
 This example enables BitLocker for a specified drive using the TPM and a PIN for key protector.
@@ -168,8 +179,9 @@ The command also specifies to encrypt the used space data on the disk, instead o
 When the system writes data to the volume in the future, that data is encrypted.
 
 ### Example 2: Enable BitLocker with a recovery key
-```
-PS C:\> Get-BitLockerVolume | Enable-BitLocker -EncryptionMethod Aes128 -RecoveryKeyPath "E:\Recovery\" -RecoveryKeyProtector
+
+```PowerShell
+Get-BitLockerVolume | Enable-BitLocker -EncryptionMethod Aes128 -RecoveryKeyPath "E:\Recovery\" -RecoveryKeyProtector
 ```
 
 This command gets all the BitLocker volumes for the current computer and passes pipes them to the **Enable-BitLocker** cmdlet by using the pipe operator.
@@ -177,8 +189,9 @@ This cmdlet specifies an encryption algorithm for the volume or volumes.
 This cmdlet specifies a path to a folder where the randomly generated recovery key will be stored and indicates that these volumes use a recovery key as a key protector.
 
 ### Example 3: Enable BitLocker with a specified user account
-```
-PS C:\> Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes128 -AdAccountOrGroup "Western\SarahJones" -AdAccountOrGroupProtector
+
+```PowerShell
+Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes128 -AdAccountOrGroup "Western\SarahJones" -AdAccountOrGroupProtector
 ```
 
 This command encrypts the BitLocker volume specified by the *MountPoint* parameter, and uses the AES 128 encryption method.
@@ -188,6 +201,7 @@ When a user accesses this volume, BitLocker prompts for credentials for the user
 ## PARAMETERS
 
 ### -AdAccountOrGroup
+
 Specifies an account using the format Domain\User.
 This cmdlet adds the account you specify as a key protector for the volume encryption key.
 
@@ -204,6 +218,7 @@ Accept wildcard characters: False
 ```
 
 ### -AdAccountOrGroupProtector
+
 Indicates that BitLocker uses an AD DS account as a protector for the volume encryption key.
 
 ```yaml
@@ -219,6 +234,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -234,14 +250,8 @@ Accept wildcard characters: False
 ```
 
 ### -EncryptionMethod
+
 Specifies an encryption method for the encrypted drive.
-The acceptable values for this parameter are:
-
-
-- Aes128
-
-- Aes256
-- Hardware
 
 ```yaml
 Type: BitLockerVolumeEncryptionMethodOnEnable
@@ -257,6 +267,7 @@ Accept wildcard characters: False
 ```
 
 ### -HardwareEncryption
+
 Indicates that the volume uses hardware encryption.
 
 ```yaml
@@ -272,6 +283,7 @@ Accept wildcard characters: False
 ```
 
 ### -MountPoint
+
 Specifies an array of drive letters or BitLocker volume objects.
 This cmdlet enables protection for the volumes specified.
 To obtain a BitLocker volume object, use the **Get-BitLockerVolume** cmdlet.
@@ -289,6 +301,7 @@ Accept wildcard characters: False
 ```
 
 ### -Password
+
 Specifies a secure string object that contains a password.
 The password specified acts as a protector for the volume encryption key.
 
@@ -305,6 +318,7 @@ Accept wildcard characters: False
 ```
 
 ### -PasswordProtector
+
 Indicates that BitLocker uses a password as a protector for the volume encryption key.
 
 ```yaml
@@ -320,6 +334,7 @@ Accept wildcard characters: False
 ```
 
 ### -Pin
+
 Specifies a secure string object that contains a PIN.
 BitLocker uses the PIN specified, with other data, as a protector for the volume encryption key.
 
@@ -336,6 +351,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryKeyPath
+
 Specifies a path to a folder.
 This cmdlet adds a randomly generated recovery key as a protector for the volume encryption key and stores it in the specified path.
 
@@ -352,6 +368,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryKeyProtector
+
 Indicates that BitLocker uses a recovery key as a protector for the volume encryption key.
 
 ```yaml
@@ -367,6 +384,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPassword
+
 Specifies a recovery password.
 If you do not specify this parameter, but you do include the *RecoveryPasswordProtector* parameter, the cmdlet creates a random password.
 You can enter a 48-digit password.
@@ -385,6 +403,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPasswordProtector
+
 Indicates that BitLocker uses a recovery password as a protector for the volume encryption key.
 
 ```yaml
@@ -400,6 +419,7 @@ Accept wildcard characters: False
 ```
 
 ### -Service
+
 Indicates that the system account for this computer unlocks the encrypted volume.
 
 ```yaml
@@ -415,6 +435,7 @@ Accept wildcard characters: False
 ```
 
 ### -SkipHardwareTest
+
 Indicates that BitLocker does not perform a hardware test before it begins encryption.
 BitLocker uses a hardware test as a dry run to make sure that all the key protectors are correctly set up and that the computer can start without issues.
 
@@ -431,6 +452,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartupKeyPath
+
 Specifies a path to a startup key.
 The key stored in the specified path acts as a protector for the volume encryption key.
 
@@ -447,6 +469,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartupKeyProtector
+
 Indicates that BitLocker uses a startup key as a protector for the volume encryption key.
 
 ```yaml
@@ -462,6 +485,7 @@ Accept wildcard characters: False
 ```
 
 ### -TpmAndPinAndStartupKeyProtector
+
 Indicates that BitLocker uses a combination of the TPM, a PIN, and a startup key as a protector for the volume encryption key.
 
 ```yaml
@@ -477,6 +501,7 @@ Accept wildcard characters: False
 ```
 
 ### -TpmAndPinProtector
+
 Indicates that BitLocker uses a combination of the TPM and a PIN as a protector for the volume encryption key.
 
 ```yaml
@@ -492,6 +517,7 @@ Accept wildcard characters: False
 ```
 
 ### -TpmAndStartupKeyProtector
+
 Indicates that BitLocker uses a combination of the TPM and a startup key as a protector for the volume encryption key.
 
 ```yaml
@@ -507,6 +533,7 @@ Accept wildcard characters: False
 ```
 
 ### -TpmProtector
+
 Indicates that BitLocker uses the TPM as a protector for the volume encryption key.
 
 ```yaml
@@ -522,6 +549,7 @@ Accept wildcard characters: False
 ```
 
 ### -UsedSpaceOnly
+
 Indicates that BitLocker does not encrypt disk space which contains unused data.
 
 ```yaml
@@ -537,6 +565,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -553,6 +582,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -578,4 +608,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Suspend-BitLocker](./Suspend-BitLocker.md)
 
 [Unlock-BitLocker](./Unlock-BitLocker.md)
-

--- a/docset/winserver2019-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2019-ps/bitlocker/Enable-BitLocker.md
@@ -19,144 +19,149 @@ Enables BitLocker Drive Encryption for a volume.
 ### PasswordProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-PasswordProtector] [[-Password] <SecureString>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -PasswordProtector [-Password] <SecureString>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly][-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryPasswordProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryPasswordProtector]
- [[-RecoveryPassword] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -RecoveryPasswordProtector [[-RecoveryPassword] <String>]
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### StartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyProtector] [-StartupKeyPath] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -StartupKeyProtector [-StartupKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndStartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
- [-TpmAndStartupKeyProtector] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndStartupKeyProtector [-StartupKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinAndStartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
- [-TpmAndPinAndStartupKeyProtector] [[-Pin] <SecureString>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndPinAndStartupKeyProtector -StartupKeyPath <String>
+[-Pin] <SecureString> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+[-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm]
+[<CommonParameters>]
 ```
 
 ### AdAccountOrGroupProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-AdAccountOrGroupProtector] [-Service]
- [-AdAccountOrGroup] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -AdAccountOrGroupProtector [-AdAccountOrGroup] <String>
+[-Service] [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [[-Pin] <SecureString>] [-TpmAndPinProtector]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndPinProtector [-Pin] <SecureString>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-TpmProtector] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmProtector
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryKeyProtector] [-RecoveryKeyPath] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -RecoveryKeyProtector [-RecoveryKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 The **Enable-BitLocker** cmdlet enables BitLocker Drive Encryption for a volume.
 
-When you enable encryption, you must specify a volume and an encryption method for that volume.
-You can specify a volume by drive letter or by specifying a BitLocker volume object.
-For the encryption method, you can choose either Advanced Encryption Standard (AES) algorithms AES-128 or AES-256, or you can use hardware encryption if it is supported by the disk hardware.
+When you enable encryption, you must specify a volume, either by its drive letter or by its
+BitLocker volume object.
 
-You must also establish a key protector.
-BitLocker uses a key protector to encrypt the volume encryption key.
-When a user accesses a BitLocker encrypted drive, such as when starting a computer, BitLocker requests the relevant key protector.
-For example, the user can enter a PIN or provide a USB drive that contains a key.
-BitLocker decrypts the encryption key and uses it to read data from the drive.
-You can use one of the following methods or combinations of methods for a key protector:
+You must also establish a key protector. BitLocker uses a key protector to encrypt the volume
+encryption key. When a user accesses a BitLocker encrypted drive, such as when starting a computer,
+BitLocker requests the relevant key protector. For example, the user can enter a PIN or provide a
+USB drive that contains a key. BitLocker decrypts the encryption key and uses it to read data from
+the drive. You can use one of the following methods or combinations of methods for a key protector:
 
-- Trusted Platform Module (TPM).
-BitLocker uses the computer's TPM to protect the encryption key.
-If you select this key protector, users can access the encrypted drive as long as it is connected to the system board that hosts the TPM and system boot integrity is intact.
-In general, TPM-based protectors can only be associated to an operating system volume.
+- **Trusted Platform Module (TPM):** BitLocker uses the computer's TPM to protect the encryption
+  key. If you select this key protector, users can access the encrypted drive as long as it is
+  connected to the system board that hosts the TPM and system boot integrity is intact. In general,
+  TPM-based protectors can only be associated to an operating system volume.
 
-- TPM and Personal Identification Number (PIN).
-BitLocker uses a combination of the TPM and a user-supplied PIN.
-A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers.
+- **TPM and Personal Identification Number (PIN):** BitLocker uses a combination of the TPM and a
+  user-supplied PIN. A PIN is four to twenty digits or, if you allow enhanced PINs, is four to
+  twenty letters, symbols, spaces, or numbers.
 
-- TPM, PIN, and startup key.
-BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key.
+- **TPM, PIN, and startup key:** BitLocker uses a combination of the TPM, a user-supplied PIN, and
+  input from of a USB memory device that contains an external key.
 
-- TPM and startup key.
-BitLocker uses a combination of the TPM and input from of a USB memory device.
+- **TPM and startup key:** BitLocker uses a combination of the TPM and a USB flash drive that
+  contains the external key.
 
-- Startup key.
-BitLocker uses input from of a USB memory device that contains the external key.
+- **Startup key:** BitLocker uses a USB flash drive that contains the external key.
 
-- Password.
-BitLocker uses a password.
+- **Password:** BitLocker uses a password.
 
-- Recovery key.
-BitLocker uses a recovery key stored as a specified file.
+- **Recovery key:** BitLocker uses a recovery key stored as a specified file.
 
-- Recovery password.
-BitLocker uses a recovery password.
+- **Recovery password:** BitLocker uses a recovery password.
 
-- Active Directory Domain Services (AD DS) account.
-BitLocker uses domain authentication.
+- **Active Directory Domain Services (AD DS) account:** BitLocker uses domain authentication.
 
-You can specify only one of these methods or combinations when you enable encryption, but you can use the **Add-BitLockerKeyProtector** cmdlet to add other protectors.
+You can specify only one of these methods or combinations when you enable encryption, but you can
+use the **Add-BitLockerKeyProtector** cmdlet to add other protectors.
 
-For a password or PIN key protector, specify a secure string.
-You can use the **ConvertTo-SecureString** cmdlet to create a secure string.
-You can use secure strings in a script and still maintain confidentiality of passwords.
+For a password or PIN key protector, specify a secure string. You can use the
+**ConvertTo-SecureString** cmdlet to create a secure string. You can use secure strings in a script
+and still maintain confidentiality of passwords.
 
-This cmdlet returns a BitLocker volume object.
-If you choose recovery password as your key protector but do not specify a 48-digit recovery password, this cmdlet creates a random 48-digit recovery password.
-The cmdlet stores the password as the **RecoveryPassword** field of the **KeyProtector** attribute of the BitLocker volume object.
+We strongly recommend specifying the encryption method. By default, BitLocker uses XTS-AES-128. You
+can opt XTS-AES-256 for stronger security. However, if you are encrypting a removable media and
+intend to use it on Windows 8.1 or Windows Server 2012 R2, you must opt either AES-128 or AES-256
+for backward compatibility. You may request hardware encryption but Microsoft strongly advices
+against it. For further guidance, see the "[ADV180028 Security Advisory][1]".
 
-If you use startup key or recovery key as part of your key protector, provide a path to store the key.
-This cmdlet stores the name of the file that contains the key in the **KeyFileName** field of the **KeyProtector** field in the BitLocker volume object.
+This cmdlet returns a BitLocker volume object. If you choose recovery password as your key protector
+but do not specify a 48-digit recovery password, this cmdlet generates a random one for you, and
+stores it in the **RecoveryPassword** field of the **KeyProtector** attribute of the BitLocker
+volume object.
 
-If you use the **Enable-BitLocker** cmdlet on an encrypted volume or on a volume that with encryption in process, it takes no action.
-If you use the cmdlet on a drive that has encryption paused, it resumes encryption on the volume.
+If you use startup key or recovery key as part of your key protector, provide a path to store the
+key. This cmdlet stores the name of the file that contains the key in the **KeyFileName** field of
+the **KeyProtector** field in the BitLocker volume object.
 
-By default, this cmdlet encrypts the entire drive.
-If you use the *UsedSpaceOnly* parameter, it only encrypts the used space in the disk.
-This option can significant reduce encryption time.
+If you use the **Enable-BitLocker** cmdlet on an encrypted volume or on a volume that with
+encryption in process, it takes no action. If you use the cmdlet on a drive that has encryption
+paused, it resumes encryption on the volume.
 
-It is common practice to add a recovery password to an operating system volume by using the **Add-BitLockerKeyProtector** cmdlet, and then save the recovery password by using the **Backup-BitLockerKeyProtector** cmdlet, and then enable BitLocker for the drive.
-This procedure ensures that you have a recovery option.
+By default, this cmdlet encrypts the entire drive. If you use the *UsedSpaceOnly* parameter, it only
+encrypts the used space on the disk. This option can significant reduce encryption time.
 
-For an overview of BitLocker, see [BitLocker Drive Encryption Overview](https://technet.microsoft.com/en-us/library/cc732774.aspx) on TechNet.
+It is common practice to add a recovery password for an operating system volume using the
+**Add-BitLockerKeyProtector** cmdlet, save the recovery password using the
+**Backup-BitLockerKeyProtector** cmdlet, and then enable BitLocker on that volume. This procedure
+ensures that you have a recovery option.
+
+For an overview of BitLocker, see "[BitLocker Drive Encryption Overview][2]" on Microsoft Docs.
 
 ## EXAMPLES
 
@@ -587,24 +592,22 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### BitLockerVolume[],String[]
+`BitLockerVolume[]`, `String[]`
 
 ## OUTPUTS
 
-### BitLockerVolume[]
+`BitLockerVolume[]`
 
 ## NOTES
 
 ## RELATED LINKS
 
-[Disable-BitLocker](./Disable-BitLocker.md)
+- [Disable-BitLocker](./Disable-BitLocker.md)
+- [Get-BitLockerVolume](./Get-BitLockerVolume.md)
+- [Lock-BitLocker](./Lock-BitLocker.md)
+- [Resume-BitLocker](./Resume-BitLocker.md)
+- [Suspend-BitLocker](./Suspend-BitLocker.md)
+- [Unlock-BitLocker](./Unlock-BitLocker.md)
 
-[Get-BitLockerVolume](./Get-BitLockerVolume.md)
-
-[Lock-BitLocker](./Lock-BitLocker.md)
-
-[Resume-BitLocker](./Resume-BitLocker.md)
-
-[Suspend-BitLocker](./Suspend-BitLocker.md)
-
-[Unlock-BitLocker](./Unlock-BitLocker.md)
+[1]: https://msrc.microsoft.com/update-guide/en-us/vulnerability/ADV180028
+[2]: https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc732774(v=ws.11)

--- a/docset/winserver2019-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2019-ps/bitlocker/Enable-BitLocker.md
@@ -592,11 +592,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-`BitLockerVolume[]`, `String[]`
+### BitLockerVolume[], String[]
 
 ## OUTPUTS
 
-`BitLockerVolume[]`
+### BitLockerVolume[]
 
 ## NOTES
 

--- a/docset/winserver2022-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2022-ps/bitlocker/Enable-BitLocker.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: BitLocker-help.xml
 Module Name: BitLocker
-ms.date: 12/20/2016
+ms.date: 12/14/2021
 online version: https://docs.microsoft.com/powershell/module/bitlocker/enable-bitlocker?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enable-BitLocker
@@ -11,74 +11,85 @@ title: Enable-BitLocker
 # Enable-BitLocker
 
 ## SYNOPSIS
+
 Enables BitLocker Drive Encryption for a volume.
 
 ## SYNTAX
 
 ### PasswordProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-PasswordProtector] [[-Password] <SecureString>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryPasswordProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryPasswordProtector]
  [[-RecoveryPassword] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### StartupKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyProtector] [-StartupKeyPath] <String>
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndStartupKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
  [-TpmAndStartupKeyProtector] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinAndStartupKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
  [-TpmAndPinAndStartupKeyProtector] [[-Pin] <SecureString>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### AdAccountOrGroupProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-AdAccountOrGroupProtector] [-Service]
  [-AdAccountOrGroup] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [[-Pin] <SecureString>] [-TpmAndPinProtector]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-TpmProtector] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### RecoveryKeyProtector
-```
+
+```PowerShell
 Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
  [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryKeyProtector] [-RecoveryKeyPath] <String>
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 The **Enable-BitLocker** cmdlet enables BitLocker Drive Encryption for a volume.
 
 When you enable encryption, you must specify a volume and an encryption method for that volume.
@@ -90,35 +101,34 @@ BitLocker uses a key protector to encrypt the volume encryption key.
 When a user accesses a BitLocker encrypted drive, such as when starting a computer, BitLocker requests the relevant key protector.
 For example, the user can enter a PIN or provide a USB drive that contains a key.
 BitLocker decrypts the encryption key and uses it to read data from the drive.
-You can use one of the following methods or combinations of methods for a key protector: 
-
+You can use one of the following methods or combinations of methods for a key protector:
 
 - Trusted Platform Module (TPM).
 BitLocker uses the computer's TPM to protect the encryption key.
 If you select this key protector, users can access the encrypted drive as long as it is connected to the system board that hosts the TPM and system boot integrity is intact.
-In general, TPM-based protectors can only be associated to an operating system volume. 
+In general, TPM-based protectors can only be associated to an operating system volume.
 
 - TPM and Personal Identification Number (PIN).
 BitLocker uses a combination of the TPM and a user-supplied PIN.
-A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers. 
+A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers.
 
 - TPM, PIN, and startup key.
-BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key. 
+BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key.
 
 - TPM and startup key.
-BitLocker uses a combination of the TPM and input from of a USB memory device. 
+BitLocker uses a combination of the TPM and input from of a USB memory device.
 
 - Startup key.
-BitLocker uses input from of a USB memory device that contains the external key. 
+BitLocker uses input from of a USB memory device that contains the external key.
 
 - Password.
-BitLocker uses a password. 
+BitLocker uses a password.
 
 - Recovery key.
-BitLocker uses a recovery key stored as a specified file. 
+BitLocker uses a recovery key stored as a specified file.
 
 - Recovery password.
-BitLocker uses a recovery password. 
+BitLocker uses a recovery password.
 
 - Active Directory Domain Services (AD DS) account.
 BitLocker uses domain authentication.
@@ -151,9 +161,10 @@ For an overview of BitLocker, see [BitLocker Drive Encryption Overview](https://
 ## EXAMPLES
 
 ### Example 1: Enable BitLocker
-```
-PS C:\> $SecureString = ConvertTo-SecureString "1234" -AsPlainText -Force
-PS C:\> Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes256 -UsedSpaceOnly -Pin $SecureString -TPMandPinProtector
+
+```PowerShell
+$SecureString = ConvertTo-SecureString "1234" -AsPlainText -Force
+Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes256 -UsedSpaceOnly -Pin $SecureString -TPMandPinProtector
 ```
 
 This example enables BitLocker for a specified drive using the TPM and a PIN for key protector.
@@ -168,8 +179,9 @@ The command also specifies to encrypt the used space data on the disk, instead o
 When the system writes data to the volume in the future, that data is encrypted.
 
 ### Example 2: Enable BitLocker with a recovery key
-```
-PS C:\> Get-BitLockerVolume | Enable-BitLocker -EncryptionMethod Aes128 -RecoveryKeyPath "E:\Recovery\" -RecoveryKeyProtector
+
+```PowerShell
+Get-BitLockerVolume | Enable-BitLocker -EncryptionMethod Aes128 -RecoveryKeyPath "E:\Recovery\" -RecoveryKeyProtector
 ```
 
 This command gets all the BitLocker volumes for the current computer and passes pipes them to the **Enable-BitLocker** cmdlet by using the pipe operator.
@@ -177,8 +189,9 @@ This cmdlet specifies an encryption algorithm for the volume or volumes.
 This cmdlet specifies a path to a folder where the randomly generated recovery key will be stored and indicates that these volumes use a recovery key as a key protector.
 
 ### Example 3: Enable BitLocker with a specified user account
-```
-PS C:\> Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes128 -AdAccountOrGroup "Western\SarahJones" -AdAccountOrGroupProtector
+
+```PowerShell
+Enable-BitLocker -MountPoint "C:" -EncryptionMethod Aes128 -AdAccountOrGroup "Western\SarahJones" -AdAccountOrGroupProtector
 ```
 
 This command encrypts the BitLocker volume specified by the *MountPoint* parameter, and uses the AES 128 encryption method.
@@ -188,6 +201,7 @@ When a user accesses this volume, BitLocker prompts for credentials for the user
 ## PARAMETERS
 
 ### -AdAccountOrGroup
+
 Specifies an account using the format Domain\User.
 This cmdlet adds the account you specify as a key protector for the volume encryption key.
 
@@ -204,6 +218,7 @@ Accept wildcard characters: False
 ```
 
 ### -AdAccountOrGroupProtector
+
 Indicates that BitLocker uses an AD DS account as a protector for the volume encryption key.
 
 ```yaml
@@ -219,6 +234,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -234,14 +250,8 @@ Accept wildcard characters: False
 ```
 
 ### -EncryptionMethod
+
 Specifies an encryption method for the encrypted drive.
-The acceptable values for this parameter are:
-
-
-- Aes128
-
-- Aes256
-- Hardware
 
 ```yaml
 Type: BitLockerVolumeEncryptionMethodOnEnable
@@ -257,6 +267,7 @@ Accept wildcard characters: False
 ```
 
 ### -HardwareEncryption
+
 Indicates that the volume uses hardware encryption.
 
 ```yaml
@@ -272,6 +283,7 @@ Accept wildcard characters: False
 ```
 
 ### -MountPoint
+
 Specifies an array of drive letters or BitLocker volume objects.
 This cmdlet enables protection for the volumes specified.
 To obtain a BitLocker volume object, use the **Get-BitLockerVolume** cmdlet.
@@ -289,6 +301,7 @@ Accept wildcard characters: False
 ```
 
 ### -Password
+
 Specifies a secure string object that contains a password.
 The password specified acts as a protector for the volume encryption key.
 
@@ -305,6 +318,7 @@ Accept wildcard characters: False
 ```
 
 ### -PasswordProtector
+
 Indicates that BitLocker uses a password as a protector for the volume encryption key.
 
 ```yaml
@@ -320,6 +334,7 @@ Accept wildcard characters: False
 ```
 
 ### -Pin
+
 Specifies a secure string object that contains a PIN.
 BitLocker uses the PIN specified, with other data, as a protector for the volume encryption key.
 
@@ -336,6 +351,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryKeyPath
+
 Specifies a path to a folder.
 This cmdlet adds a randomly generated recovery key as a protector for the volume encryption key and stores it in the specified path.
 
@@ -352,6 +368,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryKeyProtector
+
 Indicates that BitLocker uses a recovery key as a protector for the volume encryption key.
 
 ```yaml
@@ -367,6 +384,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPassword
+
 Specifies a recovery password.
 If you do not specify this parameter, but you do include the *RecoveryPasswordProtector* parameter, the cmdlet creates a random password.
 You can enter a 48-digit password.
@@ -385,6 +403,7 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPasswordProtector
+
 Indicates that BitLocker uses a recovery password as a protector for the volume encryption key.
 
 ```yaml
@@ -400,6 +419,7 @@ Accept wildcard characters: False
 ```
 
 ### -Service
+
 Indicates that the system account for this computer unlocks the encrypted volume.
 
 ```yaml
@@ -415,6 +435,7 @@ Accept wildcard characters: False
 ```
 
 ### -SkipHardwareTest
+
 Indicates that BitLocker does not perform a hardware test before it begins encryption.
 BitLocker uses a hardware test as a dry run to make sure that all the key protectors are correctly set up and that the computer can start without issues.
 
@@ -431,6 +452,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartupKeyPath
+
 Specifies a path to a startup key.
 The key stored in the specified path acts as a protector for the volume encryption key.
 
@@ -447,6 +469,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartupKeyProtector
+
 Indicates that BitLocker uses a startup key as a protector for the volume encryption key.
 
 ```yaml
@@ -462,6 +485,7 @@ Accept wildcard characters: False
 ```
 
 ### -TpmAndPinAndStartupKeyProtector
+
 Indicates that BitLocker uses a combination of the TPM, a PIN, and a startup key as a protector for the volume encryption key.
 
 ```yaml
@@ -477,6 +501,7 @@ Accept wildcard characters: False
 ```
 
 ### -TpmAndPinProtector
+
 Indicates that BitLocker uses a combination of the TPM and a PIN as a protector for the volume encryption key.
 
 ```yaml
@@ -492,6 +517,7 @@ Accept wildcard characters: False
 ```
 
 ### -TpmAndStartupKeyProtector
+
 Indicates that BitLocker uses a combination of the TPM and a startup key as a protector for the volume encryption key.
 
 ```yaml
@@ -507,6 +533,7 @@ Accept wildcard characters: False
 ```
 
 ### -TpmProtector
+
 Indicates that BitLocker uses the TPM as a protector for the volume encryption key.
 
 ```yaml
@@ -522,6 +549,7 @@ Accept wildcard characters: False
 ```
 
 ### -UsedSpaceOnly
+
 Indicates that BitLocker does not encrypt disk space which contains unused data.
 
 ```yaml
@@ -537,6 +565,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -553,6 +582,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -578,4 +608,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Suspend-BitLocker](./Suspend-BitLocker.md)
 
 [Unlock-BitLocker](./Unlock-BitLocker.md)
-

--- a/docset/winserver2022-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2022-ps/bitlocker/Enable-BitLocker.md
@@ -19,144 +19,149 @@ Enables BitLocker Drive Encryption for a volume.
 ### PasswordProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-PasswordProtector] [[-Password] <SecureString>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -PasswordProtector [-Password] <SecureString>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly][-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryPasswordProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryPasswordProtector]
- [[-RecoveryPassword] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -RecoveryPasswordProtector [[-RecoveryPassword] <String>]
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### StartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyProtector] [-StartupKeyPath] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -StartupKeyProtector [-StartupKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndStartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
- [-TpmAndStartupKeyProtector] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndStartupKeyProtector [-StartupKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinAndStartupKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-StartupKeyPath] <String>
- [-TpmAndPinAndStartupKeyProtector] [[-Pin] <SecureString>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndPinAndStartupKeyProtector -StartupKeyPath <String>
+[-Pin] <SecureString> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
+[-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm]
+[<CommonParameters>]
 ```
 
 ### AdAccountOrGroupProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-AdAccountOrGroupProtector] [-Service]
- [-AdAccountOrGroup] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -AdAccountOrGroupProtector [-AdAccountOrGroup] <String>
+[-Service] [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmAndPinProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [[-Pin] <SecureString>] [-TpmAndPinProtector]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmAndPinProtector [-Pin] <SecureString>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TpmProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-TpmProtector] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -TpmProtector
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RecoveryKeyProtector
 
 ```PowerShell
-Enable-BitLocker [-MountPoint] <String[]> [-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>]
- [-HardwareEncryption] [-SkipHardwareTest] [-UsedSpaceOnly] [-RecoveryKeyProtector] [-RecoveryKeyPath] <String>
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-BitLocker [-MountPoint] <String[]> -RecoveryKeyProtector [-RecoveryKeyPath] <String>
+[-EncryptionMethod <BitLockerVolumeEncryptionMethodOnEnable>] [-HardwareEncryption]
+[-SkipHardwareTest] [-UsedSpaceOnly] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 The **Enable-BitLocker** cmdlet enables BitLocker Drive Encryption for a volume.
 
-When you enable encryption, you must specify a volume and an encryption method for that volume.
-You can specify a volume by drive letter or by specifying a BitLocker volume object.
-For the encryption method, you can choose either Advanced Encryption Standard (AES) algorithms AES-128 or AES-256, or you can use hardware encryption if it is supported by the disk hardware.
+When you enable encryption, you must specify a volume, either by its drive letter or by its
+BitLocker volume object.
 
-You must also establish a key protector.
-BitLocker uses a key protector to encrypt the volume encryption key.
-When a user accesses a BitLocker encrypted drive, such as when starting a computer, BitLocker requests the relevant key protector.
-For example, the user can enter a PIN or provide a USB drive that contains a key.
-BitLocker decrypts the encryption key and uses it to read data from the drive.
-You can use one of the following methods or combinations of methods for a key protector:
+You must also establish a key protector. BitLocker uses a key protector to encrypt the volume
+encryption key. When a user accesses a BitLocker encrypted drive, such as when starting a computer,
+BitLocker requests the relevant key protector. For example, the user can enter a PIN or provide a
+USB drive that contains a key. BitLocker decrypts the encryption key and uses it to read data from
+the drive. You can use one of the following methods or combinations of methods for a key protector:
 
-- Trusted Platform Module (TPM).
-BitLocker uses the computer's TPM to protect the encryption key.
-If you select this key protector, users can access the encrypted drive as long as it is connected to the system board that hosts the TPM and system boot integrity is intact.
-In general, TPM-based protectors can only be associated to an operating system volume.
+- **Trusted Platform Module (TPM):** BitLocker uses the computer's TPM to protect the encryption
+  key. If you select this key protector, users can access the encrypted drive as long as it is
+  connected to the system board that hosts the TPM and system boot integrity is intact. In general,
+  TPM-based protectors can only be associated to an operating system volume.
 
-- TPM and Personal Identification Number (PIN).
-BitLocker uses a combination of the TPM and a user-supplied PIN.
-A PIN is four to twenty digits or, if you allow enhanced PINs, is four to twenty letters, symbols, spaces, or numbers.
+- **TPM and Personal Identification Number (PIN):** BitLocker uses a combination of the TPM and a
+  user-supplied PIN. A PIN is four to twenty digits or, if you allow enhanced PINs, is four to
+  twenty letters, symbols, spaces, or numbers.
 
-- TPM, PIN, and startup key.
-BitLocker uses a combination of the TPM, a user-supplied PIN, and input from of a USB memory device that contains an external key.
+- **TPM, PIN, and startup key:** BitLocker uses a combination of the TPM, a user-supplied PIN, and
+  input from of a USB memory device that contains an external key.
 
-- TPM and startup key.
-BitLocker uses a combination of the TPM and input from of a USB memory device.
+- **TPM and startup key:** BitLocker uses a combination of the TPM and a USB flash drive that
+  contains the external key.
 
-- Startup key.
-BitLocker uses input from of a USB memory device that contains the external key.
+- **Startup key:** BitLocker uses a USB flash drive that contains the external key.
 
-- Password.
-BitLocker uses a password.
+- **Password:** BitLocker uses a password.
 
-- Recovery key.
-BitLocker uses a recovery key stored as a specified file.
+- **Recovery key:** BitLocker uses a recovery key stored as a specified file.
 
-- Recovery password.
-BitLocker uses a recovery password.
+- **Recovery password:** BitLocker uses a recovery password.
 
-- Active Directory Domain Services (AD DS) account.
-BitLocker uses domain authentication.
+- **Active Directory Domain Services (AD DS) account:** BitLocker uses domain authentication.
 
-You can specify only one of these methods or combinations when you enable encryption, but you can use the **Add-BitLockerKeyProtector** cmdlet to add other protectors.
+You can specify only one of these methods or combinations when you enable encryption, but you can
+use the **Add-BitLockerKeyProtector** cmdlet to add other protectors.
 
-For a password or PIN key protector, specify a secure string.
-You can use the **ConvertTo-SecureString** cmdlet to create a secure string.
-You can use secure strings in a script and still maintain confidentiality of passwords.
+For a password or PIN key protector, specify a secure string. You can use the
+**ConvertTo-SecureString** cmdlet to create a secure string. You can use secure strings in a script
+and still maintain confidentiality of passwords.
 
-This cmdlet returns a BitLocker volume object.
-If you choose recovery password as your key protector but do not specify a 48-digit recovery password, this cmdlet creates a random 48-digit recovery password.
-The cmdlet stores the password as the **RecoveryPassword** field of the **KeyProtector** attribute of the BitLocker volume object.
+We strongly recommend specifying the encryption method. By default, BitLocker uses XTS-AES-128. You
+can opt XTS-AES-256 for stronger security. However, if you are encrypting a removable media and
+intend to use it on Windows 8.1 or Windows Server 2012 R2, you must opt either AES-128 or AES-256
+for backward compatibility. You may request hardware encryption but Microsoft strongly advices
+against it. For further guidance, see the "[ADV180028 Security Advisory][1]".
 
-If you use startup key or recovery key as part of your key protector, provide a path to store the key.
-This cmdlet stores the name of the file that contains the key in the **KeyFileName** field of the **KeyProtector** field in the BitLocker volume object.
+This cmdlet returns a BitLocker volume object. If you choose recovery password as your key protector
+but do not specify a 48-digit recovery password, this cmdlet generates a random one for you, and
+stores it in the **RecoveryPassword** field of the **KeyProtector** attribute of the BitLocker
+volume object.
 
-If you use the **Enable-BitLocker** cmdlet on an encrypted volume or on a volume that with encryption in process, it takes no action.
-If you use the cmdlet on a drive that has encryption paused, it resumes encryption on the volume.
+If you use startup key or recovery key as part of your key protector, provide a path to store the
+key. This cmdlet stores the name of the file that contains the key in the **KeyFileName** field of
+the **KeyProtector** field in the BitLocker volume object.
 
-By default, this cmdlet encrypts the entire drive.
-If you use the *UsedSpaceOnly* parameter, it only encrypts the used space in the disk.
-This option can significant reduce encryption time.
+If you use the **Enable-BitLocker** cmdlet on an encrypted volume or on a volume that with
+encryption in process, it takes no action. If you use the cmdlet on a drive that has encryption
+paused, it resumes encryption on the volume.
 
-It is common practice to add a recovery password to an operating system volume by using the **Add-BitLockerKeyProtector** cmdlet, and then save the recovery password by using the **Backup-BitLockerKeyProtector** cmdlet, and then enable BitLocker for the drive.
-This procedure ensures that you have a recovery option.
+By default, this cmdlet encrypts the entire drive. If you use the *UsedSpaceOnly* parameter, it only
+encrypts the used space on the disk. This option can significant reduce encryption time.
 
-For an overview of BitLocker, see [BitLocker Drive Encryption Overview](https://technet.microsoft.com/en-us/library/cc732774.aspx) on TechNet.
+It is common practice to add a recovery password for an operating system volume using the
+**Add-BitLockerKeyProtector** cmdlet, save the recovery password using the
+**Backup-BitLockerKeyProtector** cmdlet, and then enable BitLocker on that volume. This procedure
+ensures that you have a recovery option.
+
+For an overview of BitLocker, see "[BitLocker Drive Encryption Overview][2]" on Microsoft Docs.
 
 ## EXAMPLES
 
@@ -587,24 +592,22 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### BitLockerVolume[],String[]
+`BitLockerVolume[]`, `String[]`
 
 ## OUTPUTS
 
-### BitLockerVolume[]
+`BitLockerVolume[]`
 
 ## NOTES
 
 ## RELATED LINKS
 
-[Disable-BitLocker](./Disable-BitLocker.md)
+- [Disable-BitLocker](./Disable-BitLocker.md)
+- [Get-BitLockerVolume](./Get-BitLockerVolume.md)
+- [Lock-BitLocker](./Lock-BitLocker.md)
+- [Resume-BitLocker](./Resume-BitLocker.md)
+- [Suspend-BitLocker](./Suspend-BitLocker.md)
+- [Unlock-BitLocker](./Unlock-BitLocker.md)
 
-[Get-BitLockerVolume](./Get-BitLockerVolume.md)
-
-[Lock-BitLocker](./Lock-BitLocker.md)
-
-[Resume-BitLocker](./Resume-BitLocker.md)
-
-[Suspend-BitLocker](./Suspend-BitLocker.md)
-
-[Unlock-BitLocker](./Unlock-BitLocker.md)
+[1]: https://msrc.microsoft.com/update-guide/en-us/vulnerability/ADV180028
+[2]: https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc732774(v=ws.11)

--- a/docset/winserver2022-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2022-ps/bitlocker/Enable-BitLocker.md
@@ -592,11 +592,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-`BitLockerVolume[]`, `String[]`
+### BitLockerVolume[], String[]
 
 ## OUTPUTS
 
-`BitLockerVolume[]`
+### BitLockerVolume[]
 
 ## NOTES
 


### PR DESCRIPTION
Hello

Here is a list of changes in this PR, all of which apply to the five different versions of the Enable-BitLocker doc page:

- Fix technical errors
    - Selecting an encryption method is optional, not mandatory. However, on Windows Server 2016 and later, the administrator might want to specify it to make a conscious choice between backward compatibility and security.
    - Microsoft discourages using hardware-based encryption on SEDs. See Microsoft ADV180028 security advisory for details.
- Fix `-EncryptionMethod` parameter
    - The acceptable values on Windows Server 2016 and later are: `Aes128`, `Aes256`, `XtsAes128`, `XtsAes256`
    - The acceptable values on Windows Server 2012 and 2012R2 are: `Aes128`, `Aes256`
    - `Hardware` is not an acceptable value. Setting hardware encryption is the job of `-HardwareEncryption`.
- Fix syntax: Mandatory parameters were shown as optional
- Fix hyperlink: TechNet website is now Microsoft Docs.
- Fix typos:
    - "48-digit" (not "48-bit")
    - "USB flash drive" (not "USB memory device")
    - "Services (AD DS) account" \[not "Services(AD DS). account"\]

