### PR TITLE
Update Example

### DIFF
--- a/docset/winserver2019-ps/fileserverresourcemanager/New-FsrmFileScreenTemplate.md
+++ b/docset/winserver2019-ps/fileserverresourcemanager/New-FsrmFileScreenTemplate.md
@@ -32,7 +32,7 @@ When you make changes to a template, you can choose to apply those changes to al
 
 ### Example 1: Create a passive file screen template
 ```
-PS C:\> New-FsrmFileScreenTemplate "Filter Non-HTML text files" -IncludeGroup "Non-HTML text files"
+PS C:\> New-FsrmFileScreenTemplate "Filter Non-HTML text files" -IncludeGroup "Non-HTML text files" -Active:$False
 ```
 
 This command creates a passive file screen template named "Filter Non-HTML text files" that logs any files that match the "Non-HTML text files" file group.


### PR DESCRIPTION
Added -Active:$False to the end of the example to create a passive file screen template. 
Tested on Server 2019
Included outputs of old and new commands below: 

PS C:\Users\it> New-FsrmFileScreenTemplate "Filter Non-HTML text files" -IncludeGroup "Non-HTML text files"
Active                : True
Description           :
IncludeGroup          : {Non-HTML text files}
Name                  : Filter Non-HTML text files
Notification          :
UpdateDerived         : False
UpdateDerivedMatching : False
PSComputerName        :


PS C:\Users\it> New-FsrmFileScreenTemplate "Filter Non-HTML text files" -IncludeGroup "Non-HTML text files" -Active:$False

Active                : False
Description           :
IncludeGroup          : {Non-HTML text files}
Name                  : Filter Non-HTML text files
Notification          :
UpdateDerived         : False
UpdateDerivedMatching : False
PSComputerName        :