### PR TITLE
[BrokenLinksH2] add 2022 versions of redirects reported as not working

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -5201,6 +5201,21 @@
       "redirect_document_id": false
     },
     {
+      "source_path": "docset/winserver2022-ps/pkiclient/Export-PfxCertificate.md",
+      "redirect_url": "/powershell/module/pki/Export-PfxCertificate?view=windowsserver2022-ps",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "docset/winserver2022-ps/pkiclient/PKIClient.md",
+      "redirect_url": "/powershell/module/pki/?view=windowsserver2022-ps",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "docset/winserver2022-ps/pkiclient/New-SelfSignedCertificate.md",
+      "redirect_url": "/powershell/module/pki/New-SelfSignedCertificate?view=winserver2022-ps",
+      "redirect_document_id": false
+    },
+    {
       "source_path": "docset/winserver2022-ps/remotedesktop/Set-RDDeploymentGatewayConfiguration.md",
       "redirect_url": "/powershell/module/rdmgmt/Set-RDDeploymentGatewayConfiguration.md?view=windowsserver2022-ps",
       "redirect_document_id": false


### PR DESCRIPTION
Redirects not working for:
-/powershell/module/pkiclient
-/powershell/module/pkiclient/export-pfxcertificate
-/powershell/module/pkiclient/new-selfsignedcertificate

Existing redirects look fine, but source targets not specifying a version, which now defaults to winserver2022-ps. I've added just 3 redirects for the reported issues.