### PR TITLE
Path handling in -FileName of Export-DnsServerZone

### DIFF
--- a/docset/winserver2012-ps/dnsserver/Export-DnsServerZone.md
+++ b/docset/winserver2012-ps/dnsserver/Export-DnsServerZone.md
@@ -84,7 +84,7 @@ Accept wildcard characters: False
 
 ### -FileName
 Specifies a name for the export file.
-You can include a file path.
+The file will be created in the default DNS directory.
 
 ```yaml
 Type: String

--- a/docset/winserver2012r2-ps/dnsserver/Export-DnsServerZone.md
+++ b/docset/winserver2012r2-ps/dnsserver/Export-DnsServerZone.md
@@ -101,7 +101,7 @@ Accept wildcard characters: False
 
 ### -FileName
 Specifies a name for the export file.
-You can include a file path.
+The file will be created in the default DNS directory.
 
 ```yaml
 Type: String

--- a/docset/winserver2016-ps/dnsserver/Export-DnsServerZone.md
+++ b/docset/winserver2016-ps/dnsserver/Export-DnsServerZone.md
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 
 ### -FileName
 Specifies a name for the export file.
-You can include a file path.
+The file will be created in the default DNS directory.
 
 ```yaml
 Type: String

--- a/docset/winserver2022-ps/dnsserver/Export-DnsServerZone.md
+++ b/docset/winserver2022-ps/dnsserver/Export-DnsServerZone.md
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 
 ### -FileName
 Specifies a name for the export file.
-You can include a file path.
+The file will be created in the default DNS directory.
 
 ```yaml
 Type: String


### PR DESCRIPTION
The current docs say, except for Server 2019, that you can specify a path for the -FileName parameter. With the actual cmdlet, it is not the case.