### PR TITLE
[BULK] DocuTune - Fix build validation issues: docs-link-absolute (part 2)

### DIFF
--- a/docset/winserver2012-ps/iscsi/Get-IscsiTargetPortal.md
+++ b/docset/winserver2012-ps/iscsi/Get-IscsiTargetPortal.md
@@ -273,7 +273,7 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 
 ## RELATED LINKS
 
-[iSCSI Target Server Overview](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))
+[iSCSI Target Server Overview](/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))
 
 [Get-IscsiConnection](./Get-IscsiConnection.md)
 

--- a/docset/winserver2012-ps/iscsi/New-IscsiTargetPortal.md
+++ b/docset/winserver2012-ps/iscsi/New-IscsiTargetPortal.md
@@ -244,4 +244,4 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 
 ## RELATED LINKS
 
-[iSCSI Target Server Overview](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))
+[iSCSI Target Server Overview](/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))

--- a/docset/winserver2012-ps/iscsi/Register-IscsiSession.md
+++ b/docset/winserver2012-ps/iscsi/Register-IscsiSession.md
@@ -198,4 +198,4 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 
 ## RELATED LINKS
 
-[iSCSI Target Server Overview](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))
+[iSCSI Target Server Overview](/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))

--- a/docset/winserver2012-ps/iscsi/Remove-IscsiTargetPortal.md
+++ b/docset/winserver2012-ps/iscsi/Remove-IscsiTargetPortal.md
@@ -239,4 +239,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[iSCSI Target Server Overview](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))
+[iSCSI Target Server Overview](/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))

--- a/docset/winserver2012-ps/iscsi/Set-IscsiChapSecret.md
+++ b/docset/winserver2012-ps/iscsi/Set-IscsiChapSecret.md
@@ -106,4 +106,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[iSCSI Target Server Overview](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))
+[iSCSI Target Server Overview](/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))

--- a/docset/winserver2012-ps/iscsi/Unregister-IscsiSession.md
+++ b/docset/winserver2012-ps/iscsi/Unregister-IscsiSession.md
@@ -200,6 +200,6 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[iSCSI Target Server Overview](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))
+[iSCSI Target Server Overview](/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))
 
 [Get-iSCSISession](./Get-IscsiSession.md)

--- a/docset/winserver2012-ps/iscsi/Update-IscsiTarget.md
+++ b/docset/winserver2012-ps/iscsi/Update-IscsiTarget.md
@@ -249,7 +249,7 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 
 ## RELATED LINKS
 
-[iSCSI Target Server Overview](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))
+[iSCSI Target Server Overview](/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh848272(v=ws.11))
 
 [Get-IscsiConnection](./Get-IscsiConnection.md)
 

--- a/docset/winserver2012-ps/msdtc/Test-Dtc.md
+++ b/docset/winserver2012-ps/msdtc/Test-Dtc.md
@@ -30,7 +30,7 @@ To run this cmdlet, you must first enable the firewall rule for Distributed Tran
 
 `netsh advfirewall firewall set rule group="Distributed Transaction Coordinator" new enable=yes`
 
-For more information, see [Netsh Command Syntax, Contexts, and Formatting](https://docs.microsoft.com/en-us/windows-server/networking/technologies/netsh/netsh-contexts).
+For more information, see [Netsh Command Syntax, Contexts, and Formatting](/windows-server/networking/technologies/netsh/netsh-contexts).
 
 To enable the rule using PowerShell run the following command:
 
@@ -312,4 +312,3 @@ Accept wildcard characters: False
 [Stop-Dtc](./Stop-Dtc.md)
 
 [Uninstall-Dtc](./Uninstall-Dtc.md)
-

--- a/docset/winserver2012-ps/netadapter/Enable-NetAdapterVmq.md
+++ b/docset/winserver2012-ps/netadapter/Enable-NetAdapterVmq.md
@@ -68,7 +68,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -250,4 +250,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-NetAdapterVmqQueue](./Get-NetAdapterVmqQueue.md)
 
 [Set-NetAdapterVmq](./Set-NetAdapterVmq.md)
-

--- a/docset/winserver2012-ps/netadapter/Get-NetAdapter.md
+++ b/docset/winserver2012-ps/netadapter/Get-NetAdapter.md
@@ -152,7 +152,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -272,7 +272,7 @@ Accept wildcard characters: False
 The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays Windows Management Instrumentation (WMI) objects.
 The path after the pound sign (`#`) provides the namespace and class name for the underlying WMI object.
 
-[CIM_NetworkAdapter class](https://docs.microsoft.com/windows/win32/cimwin32prov/cim-networkadapter)
+[CIM_NetworkAdapter class](/windows/win32/cimwin32prov/cim-networkadapter)
 
 ## NOTES
 
@@ -291,4 +291,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Restart-NetAdapter](./Restart-NetAdapter.md)
 
 [Set-NetAdapter](./Set-NetAdapter.md)
-

--- a/docset/winserver2012-ps/netconnection/Get-NetConnectionProfile.md
+++ b/docset/winserver2012-ps/netconnection/Get-NetConnectionProfile.md
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -216,4 +216,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Set-NetConnectionProfile](./Set-NetConnectionProfile.md)
-

--- a/docset/winserver2012-ps/netconnection/Set-NetConnectionProfile.md
+++ b/docset/winserver2012-ps/netconnection/Set-NetConnectionProfile.md
@@ -66,7 +66,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -285,4 +285,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Get-NetConnectionProfile](./Get-NetConnectionProfile.md)
-

--- a/docset/winserver2012-ps/netsecurity/Set-NetFirewallAddressFilter.md
+++ b/docset/winserver2012-ps/netsecurity/Set-NetFirewallAddressFilter.md
@@ -90,7 +90,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -348,4 +348,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Set-NetIPSecRule](./Set-NetIPsecRule.md)
 
 [New-GPO](../grouppolicy/New-GPO.md)
-

--- a/docset/winserver2012-ps/nettcpip/New-NetRoute.md
+++ b/docset/winserver2012-ps/nettcpip/New-NetRoute.md
@@ -98,7 +98,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/New-CimSession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/Get-CimSession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/New-CimSession) or [Get-CimSession](/powershell/module/cimcmdlets/Get-CimSession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2012-ps/nettcpip/Set-NetRoute.md
+++ b/docset/winserver2012-ps/nettcpip/Set-NetRoute.md
@@ -249,7 +249,7 @@ Accept wildcard characters: False
 
 ### -PreferredLifetime
 Modifies the preferred lifetime of the IP route.
-This parameter value uses time as defined by the TimeSpanhttp://msdn.microsoft.com/library/system.timespan.aspx structure.
+This parameter value uses time as defined by the [TimeSpan](http://msdn.microsoft.com/library/system.timespan.aspx) structure.
 
 ```yaml
 Type: TimeSpan
@@ -324,7 +324,7 @@ Accept wildcard characters: False
 
 ### -ValidLifetime
 Modifies the valid lifetime of a route.
-This parameter value uses time as defined by the TimeSpanhttp://msdn.microsoft.com/library/system.timespan.aspx structure.
+This parameter value uses time as defined by the [TimeSpan](http://msdn.microsoft.com/library/system.timespan.aspx) structure.
 
 ```yaml
 Type: TimeSpan
@@ -389,5 +389,4 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 
 [Remove-NetRoute](./Remove-NetRoute.md)
 
-[New-TimeSpan](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan)
-
+[New-TimeSpan](/powershell/module/microsoft.powershell.utility/new-timespan)

--- a/docset/winserver2012-ps/printmanagement/Get-PrintConfiguration.md
+++ b/docset/winserver2012-ps/printmanagement/Get-PrintConfiguration.md
@@ -82,7 +82,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -174,4 +174,3 @@ This cmdlet returns a printer configuration object.
 ## RELATED LINKS
 
 [Set-PrintConfiguration](./Set-PrintConfiguration.md)
-

--- a/docset/winserver2012-ps/scheduledtasks/New-ScheduledTask.md
+++ b/docset/winserver2012-ps/scheduledtasks/New-ScheduledTask.md
@@ -101,7 +101,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2012-ps/scheduledtasks/Register-ScheduledTask.md
+++ b/docset/winserver2012-ps/scheduledtasks/Register-ScheduledTask.md
@@ -339,7 +339,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docset/winserver2012-ps/scheduledtasks/Register-ScheduledTask.md
+++ b/docset/winserver2012-ps/scheduledtasks/Register-ScheduledTask.md
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -339,7 +339,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 

--- a/docset/winserver2012-ps/smbshare/Grant-SmbShareAccess.md
+++ b/docset/winserver2012-ps/smbshare/Grant-SmbShareAccess.md
@@ -112,7 +112,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -275,4 +275,3 @@ This cmdlet returns a **MSFT_SmbShareAccessControlEntry** object.
 [Revoke-SmbShareAccess](./Revoke-SmbShareAccess.md)
 
 [Unblock-SmbShareAccess](./Unblock-SmbShareAccess.md)
-

--- a/docset/winserver2012-ps/smbshare/Set-SmbServerConfiguration.md
+++ b/docset/winserver2012-ps/smbshare/Set-SmbServerConfiguration.md
@@ -32,7 +32,7 @@ Set-SmbServerConfiguration [-AnnounceComment <String>] [-AnnounceServer <Boolean
 ```
 
 ## DESCRIPTION
-The **Set-SmbServerConfiguration** cmdlet sets the Server Message Block (SMB) server configuration. For more information on SMB server and protocol specifications, see [Server Message Block Overview](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh831795(v=ws.11)). For protocol specification, see [[MS-SMB2]: Server Message Block (SMB) Protocol Versions 2 and 3](https://docs.microsoft.com/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962).
+The **Set-SmbServerConfiguration** cmdlet sets the Server Message Block (SMB) server configuration. For more information on SMB server and protocol specifications, see [Server Message Block Overview](/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh831795(v=ws.11)). For protocol specification, see [[MS-SMB2]: Server Message Block (SMB) Protocol Versions 2 and 3](/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962).
 
 
 ## EXAMPLES
@@ -224,7 +224,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2012-ps/storage/Get-PhysicalDisk.md
+++ b/docset/winserver2012-ps/storage/Get-PhysicalDisk.md
@@ -112,7 +112,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -410,4 +410,3 @@ The Get-PhysicalDisk cmdlet returns objects that represent physical disks.
 [Reset-PhysicalDisk](./Reset-PhysicalDisk.md)
 
 [Set-PhysicalDisk](./Set-PhysicalDisk.md)
-

--- a/docset/winserver2012-ps/vpnclient/Add-VpnConnection.md
+++ b/docset/winserver2012-ps/vpnclient/Add-VpnConnection.md
@@ -143,7 +143,7 @@ PS C:\> $EAPXml = [xml]Get-Content -Path C:\eap-config.xml
 PS C:\> Add-VpnConnection -Name "Test6" -ServerAddress "10.1.1.1" -TunnelType "L2tp" -EncryptionLevel "Required" -AuthenticationMethod Eap -SplitTunneling -AllUserConnection -RememberCredential -EapConfigXmlStream $EAPXml
 ```
 
-This set of commands adds a VPN connection using an already generated EAP XML configuration. For more information about how to generate EAP XML configuration, see [EAP Configuration](https://docs.microsoft.com/windows/client-management/mdm/eap-configuration).
+This set of commands adds a VPN connection using an already generated EAP XML configuration. For more information about how to generate EAP XML configuration, see [EAP Configuration](/windows/client-management/mdm/eap-configuration).
 
 ## PARAMETERS
 
@@ -447,4 +447,3 @@ The VpnConnection object contains the VpnConnection configuration settings.
 [Remove-VpnConnection](./Remove-VpnConnection.md)
 
 [New-EapConfiguration](./New-EapConfiguration.md)
-

--- a/docset/winserver2012-ps/webadministration/Get-WebApplication.md
+++ b/docset/winserver2012-ps/webadministration/Get-WebApplication.md
@@ -82,4 +82,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-WebApplication](./Remove-WebApplication.md)
 
-[Microsoft.Web.Administration.ConfigurationElement#Application](https://docs.microsoft.com/dotnet/api/microsoft.web.administration.application?view=iis-dotnet)
+[Microsoft.Web.Administration.ConfigurationElement#Application](/dotnet/api/microsoft.web.administration.application?view=iis-dotnet)

--- a/docset/winserver2012-ps/webadministration/New-WebAppPool.md
+++ b/docset/winserver2012-ps/webadministration/New-WebAppPool.md
@@ -17,7 +17,7 @@ New-WebAppPool [-Name] <String> [-Force] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **New-WebAppPool** cmdlet creates an Internet Information Services (IIS) application pool. For changing different properties of the application pool after creation, see [PowerShell Snap-in: Making Configuration Changes to Websites and App Pools](https://docs.microsoft.com/iis/manage/powershell/powershell-snap-in-making-simple-configuration-changes-to-web-sites-and-application-pools).
+The **New-WebAppPool** cmdlet creates an Internet Information Services (IIS) application pool. For changing different properties of the application pool after creation, see [PowerShell Snap-in: Making Configuration Changes to Websites and App Pools](/iis/manage/powershell/powershell-snap-in-making-simple-configuration-changes-to-web-sites-and-application-pools).
 
 ## EXAMPLES
 

--- a/docset/winserver2012r2-ps/activedirectory/Get-ADComputer.md
+++ b/docset/winserver2012r2-ps/activedirectory/Get-ADComputer.md
@@ -44,7 +44,7 @@ You can also set the parameter to a computer object variable, such as `$<localCo
 To search for and retrieve more than one computer, use the *Filter* or *LDAPFilter* parameters.
 The *Filter* parameter uses the PowerShell Expression Language to write query strings for Active Directory.
 PowerShell Expression Language syntax provides rich type conversion support for value types received by the *Filter* parameter.
-For more information about the *Filter* parameter syntax, type `Get-Help` [about_ActiveDirectory_Filter](https://docs.microsoft.com/previous-versions/windows/server/hh531527(v=ws.10)).
+For more information about the *Filter* parameter syntax, type `Get-Help` [about_ActiveDirectory_Filter](/previous-versions/windows/server/hh531527(v=ws.10)).
 If you have existing Lightweight Directory Access Protocol (LDAP) query strings, you can use the *LDAPFilter* parameter.
 
 This cmdlet retrieves a default set of computer object properties.
@@ -235,7 +235,7 @@ Specifies a query string that retrieves Active Directory objects.
 This string uses the Windows PowerShell Expression Language syntax.
 The Windows PowerShell Expression Language syntax provides rich type-conversion support for value types received by the *Filter* parameter.
 The syntax uses an in-order representation, which means that the operator is placed between the operand and the value.
-For more information about the *Filter* parameter, type `Get-Help` [about_ActiveDirectory_Filter](https://docs.microsoft.com/previous-versions/windows/server/hh531527(v=ws.10)).
+For more information about the *Filter* parameter, type `Get-Help` [about_ActiveDirectory_Filter](/previous-versions/windows/server/hh531527(v=ws.10)).
 
 Syntax:
 
@@ -307,7 +307,7 @@ Accept wildcard characters: False
 Specifies an LDAP query string that is used to filter Active Directory objects.
 You can use this parameter to run your existing LDAP queries.
 The *Filter* parameter syntax supports the same functionality as the LDAP syntax.
-For more information, see the *Filter* parameter description or type `Get-Help` [about_ActiveDirectory_Filter](https://docs.microsoft.com/previous-versions/windows/server/hh531527(v=ws.10)).
+For more information, see the *Filter* parameter description or type `Get-Help` [about_ActiveDirectory_Filter](/previous-versions/windows/server/hh531527(v=ws.10)).
 
 ```yaml
 Type: String
@@ -546,4 +546,3 @@ To get a list of all the properties of an ADComputer object, use the following c
 [Set-ADComputer](./Set-ADComputer.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./ActiveDirectory.md)
-

--- a/docset/winserver2012r2-ps/activedirectory/Get-ADUser.md
+++ b/docset/winserver2012r2-ps/activedirectory/Get-ADUser.md
@@ -189,7 +189,7 @@ The following syntax uses Backus-Naur form to show how to use the PowerShell Exp
 
 For a list of supported types for \<value\>, type `Get-Help about_ActiveDirectory_ObjectModel`.
 
-Note: For String parameter type, PowerShell will cast the filter query to a string while processing the command. When using a string variable as a value in the filter component, make sure that it complies with the [PowerShell Quoting Rules](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_quoting_rules). For example, if the filter expression is double-quoted, the variable should be enclosed using single quotation marks:
+Note: For String parameter type, PowerShell will cast the filter query to a string while processing the command. When using a string variable as a value in the filter component, make sure that it complies with the [PowerShell Quoting Rules](/powershell/module/microsoft.powershell.core/about/about_quoting_rules). For example, if the filter expression is double-quoted, the variable should be enclosed using single quotation marks:
 **Get-ADUser -Filter "Name -like '$UserName'"**. On the contrary, if curly braces are used to enclose the filter, the variable should not be quoted at all: **Get-ADUser -Filter {Name -like $UserName}**.
 
 Note: PowerShell wildcards other than \*, such as ?, are not supported by the *Filter* syntax.

--- a/docset/winserver2012r2-ps/adcsdeployment/install-adcscertificationauthority.md
+++ b/docset/winserver2012r2-ps/adcsdeployment/install-adcscertificationauthority.md
@@ -52,7 +52,7 @@ You can import the cmdlet by running the following commands from Windows PowerSh
 
 To include the Certification Authority and Certificate Templates consoles in a CA installation, you must use the *IncludeManagementTools* parameter at the end of the `Install-WindowsFeature Adcs-Cert-Authority` command.
 
-Int is equivalent to Int32 in the [.NET Framework](https://docs.microsoft.com/dotnet/csharp/language-reference/builtin-types/built-in-types).
+Int is equivalent to Int32 in the [.NET Framework](/dotnet/csharp/language-reference/builtin-types/built-in-types).
 
 ## EXAMPLES
 

--- a/docset/winserver2012r2-ps/bitlocker/Enable-BitLockerAutoUnlock.md
+++ b/docset/winserver2012r2-ps/bitlocker/Enable-BitLockerAutoUnlock.md
@@ -24,7 +24,7 @@ The **Enable-BitLockerAutoUnlock** cmdlet enables automatic unlocking for a volu
 You can configure BitLocker to automatically unlock volumes that do not host an operating system.
 After a user unlocks the operating system volume, BitLocker uses encrypted information stored in the registry and volume metadata to unlock any data volumes that use automatic unlocking.
 
-For an overview of BitLocker, see [BitLocker Drive Encryption Overview](https://docs.microsoft.com/windows/security/information-protection/bitlocker/bitlocker-device-encryption-overview-windows-10).
+For an overview of BitLocker, see [BitLocker Drive Encryption Overview](/windows/security/information-protection/bitlocker/bitlocker-device-encryption-overview-windows-10).
 
 ## EXAMPLES
 
@@ -105,4 +105,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Disable-BitLockerAutoUnlock](./Disable-BitLockerAutoUnlock.md)
 
 [Get-BitLockerVolume](./Get-BitLockerVolume.md)
-

--- a/docset/winserver2012r2-ps/bitlocker/Get-BitLockerVolume.md
+++ b/docset/winserver2012r2-ps/bitlocker/Get-BitLockerVolume.md
@@ -36,9 +36,9 @@ You can also use this cmdlet to view the following information about a BitLocker
 - Protection Status - Whether BitLocker currently uses a key protector to encrypt the volume encryption key.
 - EncryptionMethod - Indicates the encryption algorithm and key size used on the volume.
 
-See [BitLocker Overview](https://docs.microsoft.com/windows/security/information-protection/bitlocker/bitlocker-overview) for more information.
+See [BitLocker Overview](/windows/security/information-protection/bitlocker/bitlocker-overview) for more information.
 
-For an overview of encryption methods, see [GetEncryptionMethod method](https://docs.microsoft.com/windows/win32/secprov/getencryptionmethod-win32-encryptablevolume).
+For an overview of encryption methods, see [GetEncryptionMethod method](/windows/win32/secprov/getencryptionmethod-win32-encryptablevolume).
 
 ## EXAMPLES
 
@@ -129,4 +129,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Enable-BitLocker](./Enable-BitLocker.md)
 
 [Enable-BitLockerAutoUnlock](./Enable-BitLockerAutoUnlock.md)
-

--- a/docset/winserver2012r2-ps/bitlocker/Remove-BitLockerKeyProtector.md
+++ b/docset/winserver2012r2-ps/bitlocker/Remove-BitLockerKeyProtector.md
@@ -31,7 +31,7 @@ Any encrypted data on the drive remains encrypted.
 
 We recommend you have at least one recovery password as key protector to a volume in case you need to recover a system.
 
-For an overview of BitLocker, see [BitLocker Overview](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-8.1-and-8/dn641993(v=ws.11)).
+For an overview of BitLocker, see [BitLocker Overview](/previous-versions/windows/it-pro/windows-8.1-and-8/dn641993(v=ws.11)).
 
 ## EXAMPLES
 

--- a/docset/winserver2012r2-ps/deduplication/Disable-DedupVolume.md
+++ b/docset/winserver2012r2-ps/deduplication/Disable-DedupVolume.md
@@ -81,7 +81,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -171,4 +171,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Set-DedupVolume](./Set-DedupVolume.md)
 
 [Update-DedupStatus](./Update-DedupStatus.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Enable-DedupVolume.md
+++ b/docset/winserver2012r2-ps/deduplication/Enable-DedupVolume.md
@@ -82,7 +82,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -198,4 +198,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DedupVolume](./Get-DedupVolume.md)
 
 [Set-DedupVolume](./Set-DedupVolume.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Expand-DedupFile.md
+++ b/docset/winserver2012r2-ps/deduplication/Expand-DedupFile.md
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -124,4 +124,3 @@ A value of zero indicates success.
 ## RELATED LINKS
 
 [Get-DedupVolume](./Get-DedupVolume.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Get-DedupJob.md
+++ b/docset/winserver2012r2-ps/deduplication/Get-DedupJob.md
@@ -58,7 +58,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -150,4 +150,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Start-DedupJob](./Start-DedupJob.md)
 
 [Stop-DedupJob](./Stop-DedupJob.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Get-DedupMetadata.md
+++ b/docset/winserver2012r2-ps/deduplication/Get-DedupMetadata.md
@@ -86,7 +86,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -151,4 +151,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## NOTES
 
 ## RELATED LINKS
-

--- a/docset/winserver2012r2-ps/deduplication/Get-DedupSchedule.md
+++ b/docset/winserver2012r2-ps/deduplication/Get-DedupSchedule.md
@@ -72,7 +72,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -162,4 +162,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Remove-DedupSchedule](./Remove-DedupSchedule.md)
 
 [Set-DedupSchedule](./Set-DedupSchedule.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Get-DedupStatus.md
+++ b/docset/winserver2012r2-ps/deduplication/Get-DedupStatus.md
@@ -59,7 +59,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -128,4 +128,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Update-DedupStatus](./Update-DedupStatus.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Get-DedupVolume.md
+++ b/docset/winserver2012r2-ps/deduplication/Get-DedupVolume.md
@@ -73,7 +73,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -161,4 +161,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Enable-DedupVolume](./Enable-DedupVolume.md)
 
 [Set-DedupVolume](./Set-DedupVolume.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Measure-DedupFileMetadata.md
+++ b/docset/winserver2012r2-ps/deduplication/Measure-DedupFileMetadata.md
@@ -60,7 +60,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -117,4 +117,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Update-DedupStatus](./Update-DedupStatus.md)
-

--- a/docset/winserver2012r2-ps/deduplication/New-DedupSchedule.md
+++ b/docset/winserver2012r2-ps/deduplication/New-DedupSchedule.md
@@ -90,7 +90,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -376,4 +376,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Remove-DedupSchedule](./Remove-DedupSchedule.md)
 
 [Set-DedupSchedule](./Set-DedupSchedule.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Remove-DedupSchedule.md
+++ b/docset/winserver2012r2-ps/deduplication/Remove-DedupSchedule.md
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -172,4 +172,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [New-DedupSchedule](./New-DedupSchedule.md)
 
 [Set-DedupSchedule](./Set-DedupSchedule.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Set-DedupSchedule.md
+++ b/docset/winserver2012r2-ps/deduplication/Set-DedupSchedule.md
@@ -90,7 +90,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -404,4 +404,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [New-DedupSchedule](./New-DedupSchedule.md)
 
 [Remove-DedupSchedule](./Remove-DedupSchedule.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Set-DedupVolume.md
+++ b/docset/winserver2012r2-ps/deduplication/Set-DedupVolume.md
@@ -108,7 +108,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -389,4 +389,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Enable-DedupVolume](./Enable-DedupVolume.md)
 
 [Get-DedupVolume](./Get-DedupVolume.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Start-DedupJob.md
+++ b/docset/winserver2012r2-ps/deduplication/Start-DedupJob.md
@@ -63,7 +63,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -322,4 +322,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DedupJob](./Get-DedupJob.md)
 
 [Stop-DedupJob](./Stop-DedupJob.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Stop-DedupJob.md
+++ b/docset/winserver2012r2-ps/deduplication/Stop-DedupJob.md
@@ -71,7 +71,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -213,4 +213,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DedupJob](./Get-DedupJob.md)
 
 [Start-DedupJob](./Start-DedupJob.md)
-

--- a/docset/winserver2012r2-ps/deduplication/Update-DedupStatus.md
+++ b/docset/winserver2012r2-ps/deduplication/Update-DedupStatus.md
@@ -95,7 +95,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 ```yaml
 Type: CimSession[]
 Parameter Sets: (All)
@@ -160,4 +160,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Get-DedupStatus](./Get-DedupStatus.md)
-

--- a/docset/winserver2012r2-ps/dfsn/Get-DfsnFolderTarget.md
+++ b/docset/winserver2012r2-ps/dfsn/Get-DfsnFolderTarget.md
@@ -24,7 +24,7 @@ The **Get-DfsnFolderTarget** cmdlet gets settings for targets of a Distributed F
 You can specify a DFS namespace folder path to see all the targets for that path.
 You can specify a namespace path and a target path to see settings for a particular target.
 
-For more information about DFS namespaces, see [DFS Namespaces overview](https://docs.microsoft.com/windows-server/storage/dfs-namespaces/dfs-overview).
+For more information about DFS namespaces, see [DFS Namespaces overview](/windows-server/storage/dfs-namespaces/dfs-overview).
 
 ## EXAMPLES
 
@@ -67,7 +67,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-DfsnFolderTarget](./Remove-DfsnFolderTarget.md)
 
 [Set-DfsnFolderTarget](./Set-DfsnFolderTarget.md)
-

--- a/docset/winserver2012r2-ps/dhcpserver/Get-DhcpServerVersion.md
+++ b/docset/winserver2012r2-ps/dhcpserver/Get-DhcpServerVersion.md
@@ -56,7 +56,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -125,4 +125,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DhcpServerDatabase](./Get-DhcpServerDatabase.md)
 
 [Get-DhcpServerSetting](./Get-DhcpServerSetting.md)
-

--- a/docset/winserver2012r2-ps/dhcpserver/Get-DhcpServerv4FreeIPAddress.md
+++ b/docset/winserver2012r2-ps/dhcpserver/Get-DhcpServerv4FreeIPAddress.md
@@ -89,7 +89,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -215,4 +215,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Get-DhcpServerv6FreeIPAddress](./Get-DhcpServerv6FreeIPAddress.md)
-

--- a/docset/winserver2012r2-ps/dhcpserver/Get-DhcpServerv4Lease.md
+++ b/docset/winserver2012r2-ps/dhcpserver/Get-DhcpServerv4Lease.md
@@ -157,7 +157,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -285,4 +285,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DhcpServerv4Scope](./Get-DhcpServerv4Scope.md)
 
 [Remove-DhcpServerv4Lease](./Remove-DhcpServerv4Lease.md)
-


### PR DESCRIPTION
**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
