### PR TITLE
[BULK] DocuTune - Fix build validation issues: docs-link-absolute (part 3)

### DIFF
--- a/docset/winserver2012r2-ps/dhcpserver/Get-DhcpServerv6FreeIPAddress.md
+++ b/docset/winserver2012r2-ps/dhcpserver/Get-DhcpServerv6FreeIPAddress.md
@@ -89,7 +89,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 
 ```yaml
 Type: CimSession[]
@@ -213,4 +213,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Get-DhcpServerv4FreeIPAddress](./Get-DhcpServerv4FreeIPAddress.md)
-

--- a/docset/winserver2012r2-ps/dhcpserver/Get-DhcpServerv6Statistics.md
+++ b/docset/winserver2012r2-ps/dhcpserver/Get-DhcpServerv6Statistics.md
@@ -56,7 +56,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -121,4 +121,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Get-DhcpServerv6ScopeStatistics](./Get-DhcpServerv6ScopeStatistics.md)
-

--- a/docset/winserver2012r2-ps/dhcpserver/Import-DhcpServer.md
+++ b/docset/winserver2012r2-ps/dhcpserver/Import-DhcpServer.md
@@ -154,7 +154,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -356,4 +356,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Export-DhcpServer](./Export-DhcpServer.md)
 
 [Restore-DhcpServer](./Restore-DhcpServer.md)
-

--- a/docset/winserver2012r2-ps/dism/Add-AppxProvisionedPackage.md
+++ b/docset/winserver2012r2-ps/dism/Add-AppxProvisionedPackage.md
@@ -38,7 +38,7 @@ For example, you must install the x86 dependency on the x86 image.
 You cannot install an app package (.appx) on an operating system that does not support Windows 8 apps.
 Apps are not supported on Server Core installations of Windows Server 2012, Windows Preinstallation Environment (Windows PE) 4.0, or on any versions of Windows older than Windows 8 and Windows Server 2012.
 
-To install and run apps on Windows Server 2012 R2, you must install the [Desktop Experience Overview](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/dn609826(v=ws.11)).
+To install and run apps on Windows Server 2012 R2, you must install the [Desktop Experience Overview](/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/dn609826(v=ws.11)).
 
 Use the *Online* parameter to specify the running operating system on your local computer, or use the *Path* parameter to specify the location of a mounted Windows image.
 
@@ -49,7 +49,7 @@ Use the *FolderPath* parameter to specify the location of a folder of unpacked a
 
 To add an app package (.appx) for a particular user, or to test a package while developing your app, use the **Add-AppxPackage** cmdlet instead.
 
-For more information, including requirements for app package provisioning, see [Sideload Apps with DISM](https://docs.microsoft.com/windows-hardware/manufacture/desktop/sideload-apps-with-dism-s14) and [How to develop an OEM app that uses a custom file](https://docs.microsoft.com/windows/win32/appxpkg/how-to-develop-oem-app-with-custom-file) in MicrosoftDocs.
+For more information, including requirements for app package provisioning, see [Sideload Apps with DISM](/windows-hardware/manufacture/desktop/sideload-apps-with-dism-s14) and [How to develop an OEM app that uses a custom file](/windows/win32/appxpkg/how-to-develop-oem-app-with-custom-file) in MicrosoftDocs.
 
 ## EXAMPLES
 

--- a/docset/winserver2012r2-ps/dnsclient/Set-DnsClient.md
+++ b/docset/winserver2012r2-ps/dnsclient/Set-DnsClient.md
@@ -76,7 +76,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -297,4 +297,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DnsClient](./Get-DnsClient.md)
 
 [Register-DnsClient](./Register-DnsClient.md)
-

--- a/docset/winserver2012r2-ps/dnsserver/Get-DnsServer.md
+++ b/docset/winserver2012r2-ps/dnsserver/Get-DnsServer.md
@@ -24,7 +24,7 @@ The **Get-DnsServer** cmdlet retrieves a Domain Name System (DNS) server configu
 
 You can pipe the output of the **Get-DnsServer** cmdlet to the **Export-Clixml** cmdlet, which generates an XML file of the configuration.
 You can use the XML file to back up or transfer DNS settings between computers.
-For more information about **Export-Clixml**, see [Using the Export-Clixml cmdlet](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/export-clixml).
+For more information about **Export-Clixml**, see [Using the Export-Clixml cmdlet](/powershell/module/microsoft.powershell.utility/export-clixml).
 
 ## EXAMPLES
 
@@ -132,4 +132,3 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 [Set-DnsServer](./Set-DnsServer.md)
 
 [Test-DnsServer](./Test-DnsServer.md)
-

--- a/docset/winserver2012r2-ps/hyper-v/Set-VMReplicationServer.md
+++ b/docset/winserver2012r2-ps/hyper-v/Set-VMReplicationServer.md
@@ -142,7 +142,7 @@ To display a list of certificates in the computer's My store and the thumbprint 
 `PS C:\\\> cd cert:\LocalMachine\My`
 `PS C:\\\> dir | format-list`
 
-For more information about certificate stores, see [Certificate stores](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2003/cc757138(v=ws.10).
+For more information about certificate stores, see [Certificate stores](/previous-versions/windows/it-pro/windows-server-2003/cc757138(v=ws.10)).
 
 ```yaml
 Type: String

--- a/docset/winserver2012r2-ps/msdtc/Get-DtcLog.md
+++ b/docset/winserver2012r2-ps/msdtc/Get-DtcLog.md
@@ -71,7 +71,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -134,4 +134,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Reset-DtcLog](./Reset-DtcLog.md)
 
 [Set-DtcLog](./Set-DtcLog.md)
-

--- a/docset/winserver2012r2-ps/msdtc/Get-DtcTransaction.md
+++ b/docset/winserver2012r2-ps/msdtc/Get-DtcTransaction.md
@@ -63,7 +63,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -124,4 +124,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Set-DtcTransaction](./Set-DtcTransaction.md)
-

--- a/docset/winserver2012r2-ps/msdtc/Test-Dtc.md
+++ b/docset/winserver2012r2-ps/msdtc/Test-Dtc.md
@@ -32,7 +32,7 @@ To run this cmdlet, you must first enable the firewall rule for Distributed Tran
 
 `netsh advfirewall firewall set rule group="Distributed Transaction Coordinator" new enable=yes`
 
-For more information, see [Netsh Command Syntax, Contexts, and Formatting](https://docs.microsoft.com/en-us/windows-server/networking/technologies/netsh/netsh-contexts).
+For more information, see [Netsh Command Syntax, Contexts, and Formatting](/windows-server/networking/technologies/netsh/netsh-contexts).
 
 To enable the rule using PowerShell run the following command:
 
@@ -317,4 +317,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Stop-Dtc](./Stop-Dtc.md)
 
 [Uninstall-Dtc](./Uninstall-Dtc.md)
-

--- a/docset/winserver2012r2-ps/netadapter/Enable-NetAdapterVmq.md
+++ b/docset/winserver2012r2-ps/netadapter/Enable-NetAdapterVmq.md
@@ -70,7 +70,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -255,4 +255,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-NetAdapterVmqQueue](./Get-NetAdapterVmqQueue.md)
 
 [Set-NetAdapterVmq](./Set-NetAdapterVmq.md)
-

--- a/docset/winserver2012r2-ps/netadapter/Get-NetAdapter.md
+++ b/docset/winserver2012r2-ps/netadapter/Get-NetAdapter.md
@@ -153,7 +153,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -276,7 +276,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays Windows Management Instrumentation (WMI) objects.
 The path after the pound sign (`#`) provides the namespace and class name for the underlying WMI object.
 
-[CIM_NetworkAdapter class](https://docs.microsoft.com/windows/win32/cimwin32prov/cim-networkadapter)
+[CIM_NetworkAdapter class](/windows/win32/cimwin32prov/cim-networkadapter)
 
 ## NOTES
 
@@ -295,4 +295,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Restart-NetAdapter](./Restart-NetAdapter.md)
 
 [Set-NetAdapter](./Set-NetAdapter.md)
-

--- a/docset/winserver2012r2-ps/netconnection/Get-NetConnectionProfile.md
+++ b/docset/winserver2012r2-ps/netconnection/Get-NetConnectionProfile.md
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -216,4 +216,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Set-NetConnectionProfile](./Set-NetConnectionProfile.md)
-

--- a/docset/winserver2012r2-ps/netconnection/Set-NetConnectionProfile.md
+++ b/docset/winserver2012r2-ps/netconnection/Set-NetConnectionProfile.md
@@ -66,7 +66,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -285,4 +285,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Get-NetConnectionProfile](./Get-NetConnectionProfile.md)
-

--- a/docset/winserver2012r2-ps/netsecurity/Set-NetFirewallAddressFilter.md
+++ b/docset/winserver2012r2-ps/netsecurity/Set-NetFirewallAddressFilter.md
@@ -93,7 +93,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -354,4 +354,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Set-NetIPSecRule](./Set-NetIPsecRule.md)
 
 [New-GPO](../grouppolicy/New-GPO.md)
-

--- a/docset/winserver2012r2-ps/nettcpip/New-NetRoute.md
+++ b/docset/winserver2012r2-ps/nettcpip/New-NetRoute.md
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/New-CimSession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/Get-CimSession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/New-CimSession) or [Get-CimSession](/powershell/module/cimcmdlets/Get-CimSession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -410,4 +410,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Set-NetRoute](./Set-NetRoute.md)
 
 [Set-NetIPInterface](./Set-NetIPInterface.md)
-

--- a/docset/winserver2012r2-ps/printmanagement/Get-PrintConfiguration.md
+++ b/docset/winserver2012r2-ps/printmanagement/Get-PrintConfiguration.md
@@ -84,7 +84,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -179,4 +179,3 @@ This cmdlet returns a printer configuration object.
 ## RELATED LINKS
 
 [Set-PrintConfiguration](./Set-PrintConfiguration.md)
-

--- a/docset/winserver2012r2-ps/scheduledtasks/New-ScheduledTask.md
+++ b/docset/winserver2012r2-ps/scheduledtasks/New-ScheduledTask.md
@@ -103,7 +103,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2012r2-ps/scheduledtasks/Register-ScheduledTask.md
+++ b/docset/winserver2012r2-ps/scheduledtasks/Register-ScheduledTask.md
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -341,7 +341,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 

--- a/docset/winserver2012r2-ps/scheduledtasks/Register-ScheduledTask.md
+++ b/docset/winserver2012r2-ps/scheduledtasks/Register-ScheduledTask.md
@@ -341,7 +341,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docset/winserver2012r2-ps/smbshare/Get-SmbServerNetworkInterface.md
+++ b/docset/winserver2012r2-ps/smbshare/Get-SmbServerNetworkInterface.md
@@ -185,5 +185,4 @@ The MSFT_SmbServerNetworkInterface object represents the network interfaces of t
 
 ## RELATED LINKS
 
-[Get-SmbClientNetworkInterface](/.Get-SmbClientNetworkInterface.md)
-
+[Get-SmbClientNetworkInterface](./Get-SmbClientNetworkInterface.md)

--- a/docset/winserver2012r2-ps/smbshare/Grant-SmbShareAccess.md
+++ b/docset/winserver2012r2-ps/smbshare/Grant-SmbShareAccess.md
@@ -115,7 +115,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -281,4 +281,3 @@ This cmdlet returns a **MSFT_SmbShareAccessControlEntry** object.
 [Revoke-SmbShareAccess](./Revoke-SmbShareAccess.md)
 
 [Unblock-SmbShareAccess](./Unblock-SmbShareAccess.md)
-

--- a/docset/winserver2012r2-ps/smbshare/Set-SmbServerConfiguration.md
+++ b/docset/winserver2012r2-ps/smbshare/Set-SmbServerConfiguration.md
@@ -34,7 +34,7 @@ Set-SmbServerConfiguration [-AnnounceServer <Boolean>] [-AsynchronousCredits <UI
 ```
 
 ## DESCRIPTION
-The **Set-SmbServerConfiguration** cmdlet sets the Server Message Block (SMB) server configuration. For more information on SMB server and protocol specifications, see [Server Message Block Overview](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh831795(v=ws.11)). For protocol specification, see [[MS-SMB2]: Server Message Block (SMB) Protocol Versions 2 and 3](https://docs.microsoft.com/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962).
+The **Set-SmbServerConfiguration** cmdlet sets the Server Message Block (SMB) server configuration. For more information on SMB server and protocol specifications, see [Server Message Block Overview](/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh831795(v=ws.11)). For protocol specification, see [[MS-SMB2]: Server Message Block (SMB) Protocol Versions 2 and 3](/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962).
 
 ## EXAMPLES
 
@@ -225,7 +225,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2012r2-ps/storage/Get-PhysicalDisk.md
+++ b/docset/winserver2012r2-ps/storage/Get-PhysicalDisk.md
@@ -136,7 +136,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -492,4 +492,3 @@ The Get-PhysicalDisk cmdlet returns objects that represent physical disks.
 [New-VirtualDisk](./New-VirtualDisk.md)
 
 [Get-StorageNode](./Get-StorageNode.md)
-

--- a/docset/winserver2012r2-ps/vpnclient/Add-VpnConnection.md
+++ b/docset/winserver2012r2-ps/vpnclient/Add-VpnConnection.md
@@ -156,7 +156,7 @@ PS C:\> $EAPXml = [xml]Get-Content -Path C:\eap-config.xml
 PS C:\> Add-VpnConnection -Name "Test6" -ServerAddress "10.1.1.1" -TunnelType "L2tp" -EncryptionLevel "Required" -AuthenticationMethod Eap -SplitTunneling -AllUserConnection -RememberCredential -EapConfigXmlStream $EAPXml
 ```
 
-This set of commands adds a VPN connection using an already generated EAP XML configuration. For more information about how to generate EAP XML configuration, see [EAP Configuration](https://docs.microsoft.com/windows/client-management/mdm/eap-configuration).
+This set of commands adds a VPN connection using an already generated EAP XML configuration. For more information about how to generate EAP XML configuration, see [EAP Configuration](/windows/client-management/mdm/eap-configuration).
 
 ## PARAMETERS
 
@@ -573,4 +573,3 @@ The VpnConnection object contains the VpnConnection configuration settings.
 [Remove-VpnConnection](./Remove-VpnConnection.md)
 
 [New-EapConfiguration](./New-EapConfiguration.md)
-

--- a/docset/winserver2012r2-ps/vpnclient/Set-VpnConnectionProxy.md
+++ b/docset/winserver2012r2-ps/vpnclient/Set-VpnConnectionProxy.md
@@ -105,7 +105,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2012r2-ps/webadministration/Get-WebApplication.md
+++ b/docset/winserver2012r2-ps/webadministration/Get-WebApplication.md
@@ -83,4 +83,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-WebApplication](./Remove-WebApplication.md)
 
-[Microsoft.Web.Administration.ConfigurationElement#Application](https://docs.microsoft.com/dotnet/api/microsoft.web.administration.application?view=iis-dotnet)
+[Microsoft.Web.Administration.ConfigurationElement#Application](/dotnet/api/microsoft.web.administration.application?view=iis-dotnet)

--- a/docset/winserver2012r2-ps/webadministration/New-WebAppPool.md
+++ b/docset/winserver2012r2-ps/webadministration/New-WebAppPool.md
@@ -19,7 +19,7 @@ New-WebAppPool [-Name] <String> [-Force] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **New-WebAppPool** cmdlet creates an Internet Information Services (IIS) application pool. For changing different properties of the application pool after creation, see [PowerShell Snap-in: Making Configuration Changes to Websites and App Pools](https://docs.microsoft.com/iis/manage/powershell/powershell-snap-in-making-simple-configuration-changes-to-web-sites-and-application-pools).
+The **New-WebAppPool** cmdlet creates an Internet Information Services (IIS) application pool. For changing different properties of the application pool after creation, see [PowerShell Snap-in: Making Configuration Changes to Websites and App Pools](/iis/manage/powershell/powershell-snap-in-making-simple-configuration-changes-to-web-sites-and-application-pools).
 
 ## EXAMPLES
 

--- a/docset/winserver2012r2-ps/webapplicationproxy/Set-WebApplicationProxyConfiguration.md
+++ b/docset/winserver2012r2-ps/webapplicationproxy/Set-WebApplicationProxyConfiguration.md
@@ -101,7 +101,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -208,4 +208,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Get-WebApplicationProxyConfiguration](./Get-WebApplicationProxyConfiguration.md)
-

--- a/docset/winserver2016-ps/Microsoft.DiagnosticDataViewer/Get-DiagnosticData.md
+++ b/docset/winserver2016-ps/Microsoft.DiagnosticDataViewer/Get-DiagnosticData.md
@@ -165,4 +165,4 @@ Persisted event record.
 Requires Windows 10 version 17134 (1803) or higher
 
 ## RELATED LINKS
-[About Windows Diagnostic Data](https://docs.microsoft.com/en-us/windows/privacy/windows-diagnostic-data)
+[About Windows Diagnostic Data](/windows/privacy/windows-diagnostic-data)

--- a/docset/winserver2016-ps/Microsoft.DiagnosticDataViewer/Get-DiagnosticDataTypes.md
+++ b/docset/winserver2016-ps/Microsoft.DiagnosticDataViewer/Get-DiagnosticDataTypes.md
@@ -48,5 +48,4 @@ Requires Windows 10 version 17134 (1803) or higher
 
 ## RELATED LINKS
 
-[About Windows Diagnostic Data](https://docs.microsoft.com/en-us/windows/privacy/windows-diagnostic-data)
-
+[About Windows Diagnostic Data](/windows/privacy/windows-diagnostic-data)

--- a/docset/winserver2016-ps/activedirectory/ActiveDirectory.md
+++ b/docset/winserver2016-ps/activedirectory/ActiveDirectory.md
@@ -15,7 +15,7 @@ The Active Directory module for Windows PowerShell is a PowerShell module that c
 
 If you don't have the Active Directory module installed on your machine, you need to download the correct Remote Server Administration Tools (RSAT) package for your OS.  If you're running Windows 7, you will also need to run the `import-module ActiveDirectory` command from an elevated PowerShell prompt. For more detail, see [RSAT for Windows operating systems](https://support.microsoft.com/help/2693643/remote-server-administration-tools-rsat-for-windows-operating-systems). Starting with Windows 10 October 2018 Update, RSAT is included as a set of Features on Demand right from Windows 10. Now, instead of downloading an RSAT package you can just go to Manage optional features in Settings and click Add a feature to see the list of available RSAT tools. Select and install the specific RSAT tools you need. To see installation progress, click the Back button to view status on the Manage optional features page.
 
-If you want to use this module in PowerShell 7, please see [PowerShell 7 module compatibility](https://docs.microsoft.com/powershell/scripting/whats-new/module-compatibility).
+If you want to use this module in PowerShell 7, please see [PowerShell 7 module compatibility](/powershell/scripting/whats-new/module-compatibility).
 
 ## ActiveDirectory Cmdlets
 ### [Add-ADCentralAccessPolicyMember](./Add-ADCentralAccessPolicyMember.md)
@@ -458,4 +458,3 @@ Uninstalls an Active Directory managed service account from a computer or remove
 
 ### [Unlock-ADAccount](./Unlock-ADAccount.md)
 Unlocks an Active Directory account.
-

--- a/docset/winserver2016-ps/activedirectory/Get-ADComputer.md
+++ b/docset/winserver2016-ps/activedirectory/Get-ADComputer.md
@@ -45,7 +45,7 @@ You can also set the parameter to a computer object variable, such as `$<localCo
 To search for and retrieve more than one computer, use the *Filter* or *LDAPFilter* parameters.
 The *Filter* parameter uses the PowerShell Expression Language to write query strings for Active Directory.
 PowerShell Expression Language syntax provides rich type conversion support for value types received by the *Filter* parameter.
-For more information about the *Filter* parameter syntax, type `Get-Help` [about_ActiveDirectory_Filter](https://docs.microsoft.com/previous-versions/windows/server/hh531527(v=ws.10)).
+For more information about the *Filter* parameter syntax, type `Get-Help` [about_ActiveDirectory_Filter](/previous-versions/windows/server/hh531527(v=ws.10)).
 If you have existing Lightweight Directory Access Protocol (LDAP) query strings, you can use the *LDAPFilter* parameter.
 
 This cmdlet retrieves a default set of computer object properties.
@@ -257,7 +257,7 @@ Specifies a query string that retrieves Active Directory objects.
 This string uses the Windows PowerShell Expression Language syntax.
 The Windows PowerShell Expression Language syntax provides rich type-conversion support for value types received by the *Filter* parameter.
 The syntax uses an in-order representation, which means that the operator is placed between the operand and the value.
-For more information about the *Filter* parameter, type `Get-Help` [about_ActiveDirectory_Filter](https://docs.microsoft.com/previous-versions/windows/server/hh531527(v=ws.10)).
+For more information about the *Filter* parameter, type `Get-Help` [about_ActiveDirectory_Filter](/previous-versions/windows/server/hh531527(v=ws.10)).
 
 Syntax:
 
@@ -330,7 +330,7 @@ Accept wildcard characters: False
 Specifies an LDAP query string that is used to filter Active Directory objects.
 You can use this parameter to run your existing LDAP queries.
 The *Filter* parameter syntax supports the same functionality as the LDAP syntax.
-For more information, see the *Filter* parameter description or type `Get-Help` [about_ActiveDirectory_Filter](https://docs.microsoft.com/previous-versions/windows/server/hh531527(v=ws.10)).
+For more information, see the *Filter* parameter description or type `Get-Help` [about_ActiveDirectory_Filter](/previous-versions/windows/server/hh531527(v=ws.10)).
 
 ```yaml
 Type: String

--- a/docset/winserver2016-ps/activedirectory/Get-ADUser.md
+++ b/docset/winserver2016-ps/activedirectory/Get-ADUser.md
@@ -190,7 +190,7 @@ The following syntax uses Backus-Naur form to show how to use the PowerShell Exp
 
 For a list of supported types for \<value\>, type `Get-Help about_ActiveDirectory_ObjectModel`.
 
-Note: For String parameter type, PowerShell will cast the filter query to a string while processing the command. When using a string variable as a value in the filter component, make sure that it complies with the [PowerShell Quoting Rules](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_quoting_rules). For example, if the filter expression is double-quoted, the variable should be enclosed using single quotation marks:
+Note: For String parameter type, PowerShell will cast the filter query to a string while processing the command. When using a string variable as a value in the filter component, make sure that it complies with the [PowerShell Quoting Rules](/powershell/module/microsoft.powershell.core/about/about_quoting_rules). For example, if the filter expression is double-quoted, the variable should be enclosed using single quotation marks:
 **Get-ADUser -Filter "Name -like '$UserName'"**. On the contrary, if curly braces are used to enclose the filter, the variable should not be quoted at all: **Get-ADUser -Filter {Name -like $UserName}**.
 
 Note: PowerShell wildcards other than \*, such as ?, are not supported by the *Filter* syntax.

--- a/docset/winserver2016-ps/adcsdeployment/Install-AdcsCertificationAuthority.md
+++ b/docset/winserver2016-ps/adcsdeployment/Install-AdcsCertificationAuthority.md
@@ -53,7 +53,7 @@ You can import the cmdlet by running the following commands from Windows PowerSh
 
 To include the Certification Authority and Certificate Templates consoles in a CA installation, you must use the *IncludeManagementTools* parameter at the end of the `Install-WindowsFeature Adcs-Cert-Authority` command.
 
-Int is equivalent to Int32 in the [.NET Framework](https://docs.microsoft.com/dotnet/csharp/language-reference/builtin-types/built-in-types).
+Int is equivalent to Int32 in the [.NET Framework](/dotnet/csharp/language-reference/builtin-types/built-in-types).
 
 ## EXAMPLES
 

--- a/docset/winserver2016-ps/adfs/Enable-AdfsDeviceRegistration.md
+++ b/docset/winserver2016-ps/adfs/Enable-AdfsDeviceRegistration.md
@@ -21,7 +21,7 @@ Enable-AdfsDeviceRegistration [-Credential <PSCredential>] [-Force] [-WhatIf] [-
 
 ## DESCRIPTION
 This cmdlet has been deprecated for AD FS 2016.
-For more information, see [Configure On-Premises Conditional Access using registered devices](https://docs.microsoft.com/windows-server/identity/ad-fs/operations/configure-device-based-conditional-access-on-premises).
+For more information, see [Configure On-Premises Conditional Access using registered devices](/windows-server/identity/ad-fs/operations/configure-device-based-conditional-access-on-premises).
 
 The **Enable-AdfsDeviceRegistration** cmdlet configures a server in an Active Directory Federation Services (AD FS) farm to host the Device Registration Service.
 To completely enable the Device Registration Service, you must run this command on each AD FS server in your AD FS farm.
@@ -121,4 +121,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Initialize-ADDeviceRegistration](./Initialize-ADDeviceRegistration.md)
 
 [Set-AdfsDeviceRegistration](./Set-AdfsDeviceRegistration.md)
-

--- a/docset/winserver2016-ps/adfs/New-AdfsAzureMfaTenantCertificate.md
+++ b/docset/winserver2016-ps/adfs/New-AdfsAzureMfaTenantCertificate.md
@@ -42,7 +42,7 @@ PS C:\> Set-AdfsAzureMfaTenant -TenantId <your tenant ID> -ClientId 981f26a1-7f4
 These commands create a certificate for Azure MFA, register the certificate in a tenant, and enable Azure MFA on an AD FS farm.
 
 > [!NOTE]
-> Customers are encouraged to use the newer Azure Active Directory PowerShell 2.0 module. For more information about the v2.0 module please see [AzureAD PowerShell 2.0](https://docs.microsoft.com/powershell/module/Azuread/?view=azureadps-2.0).
+> Customers are encouraged to use the newer Azure Active Directory PowerShell 2.0 module. For more information about the v2.0 module please see [AzureAD PowerShell 2.0](/powershell/module/Azuread/?view=azureadps-2.0).
 
 ### Example 2: Determine which certificate Azure MFA is using
 ```

--- a/docset/winserver2016-ps/appx/Remove-AppxPackage.md
+++ b/docset/winserver2016-ps/appx/Remove-AppxPackage.md
@@ -140,7 +140,7 @@ If you specify this parameter, the cmdlet removes the app package for only the u
 > [!NOTE]
 >
 > - This parameter only accepts user SIDs
-> - Use the **whoami /user** command to display the current SID of a user. See [whoami syntax](https://docs.microsoft.com/windows-server/administration/windows-commands/whoami) for details.
+> - Use the **whoami /user** command to display the current SID of a user. See [whoami syntax](/windows-server/administration/windows-commands/whoami) for details.
 
 
 

--- a/docset/winserver2016-ps/bitlocker/Get-BitLockerVolume.md
+++ b/docset/winserver2016-ps/bitlocker/Get-BitLockerVolume.md
@@ -41,9 +41,9 @@ You can also use this cmdlet to view the following information about a BitLocker
 - Protection Status - Whether BitLocker currently uses a key protector to encrypt the volume encryption key.
 - EncryptionMethod - Indicates the encryption algorithm and key size used on the volume.
 
-See [BitLocker Overview](https://docs.microsoft.com/windows/security/information-protection/bitlocker/bitlocker-overview) for more information.
+See [BitLocker Overview](/windows/security/information-protection/bitlocker/bitlocker-overview) for more information.
 
-For an overview of encryption methods, see [GetEncryptionMethod method](https://docs.microsoft.com/windows/win32/secprov/getencryptionmethod-win32-encryptablevolume).
+For an overview of encryption methods, see [GetEncryptionMethod method](/windows/win32/secprov/getencryptionmethod-win32-encryptablevolume).
 
 ## EXAMPLES
 
@@ -134,4 +134,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Enable-BitLocker](./Enable-BitLocker.md)
 
 [Enable-BitLockerAutoUnlock](./Enable-BitLockerAutoUnlock.md)
-

--- a/docset/winserver2016-ps/bitlocker/Remove-BitLockerKeyProtector.md
+++ b/docset/winserver2016-ps/bitlocker/Remove-BitLockerKeyProtector.md
@@ -32,7 +32,7 @@ Any encrypted data on the drive remains encrypted.
 
 We recommend you have at least one recovery password as key protector to a volume in case you need to recover a system.
 
-For an overview of BitLocker, see [Overview of BitLocker Device Encryption](https://docs.microsoft.com/windows/security/information-protection/bitlocker/bitlocker-device-encryption-overview-windows-10).
+For an overview of BitLocker, see [Overview of BitLocker Device Encryption](/windows/security/information-protection/bitlocker/bitlocker-device-encryption-overview-windows-10).
 
 ## EXAMPLES
 

--- a/docset/winserver2016-ps/configci/New-CIPolicy.md
+++ b/docset/winserver2016-ps/configci/New-CIPolicy.md
@@ -321,7 +321,7 @@ Accept wildcard characters: False
 ```
 
 ### -Level
-Specifies the primary level of detail for generated rules. Refer to [WDAC File Rule Levels](https://docs.microsoft.com/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-file-rule-levels) for acceptable parameter values and descriptions.
+Specifies the primary level of detail for generated rules. Refer to [WDAC File Rule Levels](/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-file-rule-levels) for acceptable parameter values and descriptions.
 
 ```yaml
 Type: RuleLevel
@@ -488,4 +488,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Merge-CIPolicy](./Merge-CIPolicy.md)
 
 [New-CIPolicyRule](./New-CIPolicyRule.md)
-

--- a/docset/winserver2016-ps/configci/New-CIPolicyRule.md
+++ b/docset/winserver2016-ps/configci/New-CIPolicyRule.md
@@ -261,7 +261,7 @@ Accept wildcard characters: False
 ```
 
 ### -FilePathRule
-Specifies the path of a folder for generating a rule with level set to FilePath. Refer to [Filepath Rules Info](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#more-information-about-filepath-rules) for acceptable wildcard values and usage. 
+Specifies the path of a folder for generating a rule with level set to FilePath. Refer to [Filepath Rules Info](/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#more-information-about-filepath-rules) for acceptable wildcard values and usage. 
 This cmdlet will not check whether the filepath string is a valid filepath. 
 
 ```yaml
@@ -278,7 +278,7 @@ Accept wildcard characters: True
 ```
 
 ### -Level
-Specifies the primary level of detail for generated rules. Refer to [WDAC File Rule Levels](https://docs.microsoft.com/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-file-rule-levels) for acceptable parameter values and descriptions.
+Specifies the primary level of detail for generated rules. Refer to [WDAC File Rule Levels](/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-file-rule-levels) for acceptable parameter values and descriptions.
 
 ```yaml
 Type: RuleLevel
@@ -309,7 +309,7 @@ Accept wildcard characters: False
 
 ### -SpecificFileNameLevel
 Specifies the attribute of the file off which to base a file name rule. The -Level must be set to FileName for this option. 
-Refer to [File Name Rules Info](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-filename-rules) for a description of the acceptable values. 
+Refer to [File Name Rules Info](/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-filename-rules) for a description of the acceptable values. 
 
 ```yaml
 Type: SwitchParameter
@@ -339,4 +339,3 @@ This cmdlet returns the rules that it creates.
 ## RELATED LINKS
 
 [Get-SystemDriver](./Get-SystemDriver.md)
-

--- a/docset/winserver2016-ps/configci/Set-RuleOption.md
+++ b/docset/winserver2016-ps/configci/Set-RuleOption.md
@@ -130,7 +130,7 @@ Accept wildcard characters: False
 
 ### -Option
 Specifies the index of the rule option that this cmdlet modifies. 
-Specify the **Help** parameter for option information. Refer to [WDAC Policy Rule Options](https://docs.microsoft.com/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-policy-rules) for more detailed descriptions of each option.
+Specify the **Help** parameter for option information. Refer to [WDAC Policy Rule Options](/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-policy-rules) for more detailed descriptions of each option.
 
 ```yaml
 Type: Int32
@@ -156,4 +156,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Set-HVCIOptions](./Set-HVCIOptions.md)
-

--- a/docset/winserver2016-ps/deduplication/Disable-DedupVolume.md
+++ b/docset/winserver2016-ps/deduplication/Disable-DedupVolume.md
@@ -82,7 +82,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -172,4 +172,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Set-DedupVolume](./Set-DedupVolume.md)
 
 [Update-DedupStatus](./Update-DedupStatus.md)
-

--- a/docset/winserver2016-ps/deduplication/Enable-DedupVolume.md
+++ b/docset/winserver2016-ps/deduplication/Enable-DedupVolume.md
@@ -85,7 +85,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -204,4 +204,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DedupVolume](./Get-DedupVolume.md)
 
 [Set-DedupVolume](./Set-DedupVolume.md)
-

--- a/docset/winserver2016-ps/deduplication/Expand-DedupFile.md
+++ b/docset/winserver2016-ps/deduplication/Expand-DedupFile.md
@@ -64,7 +64,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -128,4 +128,3 @@ A value of zero indicates success.
 ## RELATED LINKS
 
 [Get-DedupVolume](./Get-DedupVolume.md)
-

--- a/docset/winserver2016-ps/deduplication/Get-DedupJob.md
+++ b/docset/winserver2016-ps/deduplication/Get-DedupJob.md
@@ -60,7 +60,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -159,4 +159,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Start-DedupJob](./Start-DedupJob.md)
 
 [Stop-DedupJob](./Stop-DedupJob.md)
-

--- a/docset/winserver2016-ps/deduplication/Get-DedupMetadata.md
+++ b/docset/winserver2016-ps/deduplication/Get-DedupMetadata.md
@@ -90,7 +90,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -159,4 +159,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Measure-DedupFileMetadata](./Measure-DedupFileMetadata.md)
-

--- a/docset/winserver2016-ps/deduplication/Get-DedupSchedule.md
+++ b/docset/winserver2016-ps/deduplication/Get-DedupSchedule.md
@@ -74,7 +74,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -171,4 +171,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Remove-DedupSchedule](./Remove-DedupSchedule.md)
 
 [Set-DedupSchedule](./Set-DedupSchedule.md)
-

--- a/docset/winserver2016-ps/deduplication/Get-DedupStatus.md
+++ b/docset/winserver2016-ps/deduplication/Get-DedupStatus.md
@@ -61,7 +61,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -134,4 +134,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Update-DedupStatus](./Update-DedupStatus.md)
-

--- a/docset/winserver2016-ps/deduplication/Get-DedupVolume.md
+++ b/docset/winserver2016-ps/deduplication/Get-DedupVolume.md
@@ -75,7 +75,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -167,4 +167,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Enable-DedupVolume](./Enable-DedupVolume.md)
 
 [Set-DedupVolume](./Set-DedupVolume.md)
-


### PR DESCRIPTION
**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
