### PR TITLE
[BULK] DocuTune - Fix build validation issues: docs-link-absolute (part 4)

### DIFF
--- a/docset/winserver2016-ps/deduplication/Measure-DedupFileMetadata.md
+++ b/docset/winserver2016-ps/deduplication/Measure-DedupFileMetadata.md
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -121,4 +121,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Update-DedupStatus](./Update-DedupStatus.md)
-

--- a/docset/winserver2016-ps/deduplication/New-DedupSchedule.md
+++ b/docset/winserver2016-ps/deduplication/New-DedupSchedule.md
@@ -101,7 +101,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -422,4 +422,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Remove-DedupSchedule](./Remove-DedupSchedule.md)
 
 [Set-DedupSchedule](./Set-DedupSchedule.md)
-

--- a/docset/winserver2016-ps/deduplication/Remove-DedupSchedule.md
+++ b/docset/winserver2016-ps/deduplication/Remove-DedupSchedule.md
@@ -67,7 +67,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -175,4 +175,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [New-DedupSchedule](./New-DedupSchedule.md)
 
 [Set-DedupSchedule](./Set-DedupSchedule.md)
-

--- a/docset/winserver2016-ps/deduplication/Set-DedupSchedule.md
+++ b/docset/winserver2016-ps/deduplication/Set-DedupSchedule.md
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -441,4 +441,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [New-DedupSchedule](./New-DedupSchedule.md)
 
 [Remove-DedupSchedule](./Remove-DedupSchedule.md)
-

--- a/docset/winserver2016-ps/deduplication/Set-DedupVolume.md
+++ b/docset/winserver2016-ps/deduplication/Set-DedupVolume.md
@@ -124,7 +124,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -440,4 +440,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Enable-DedupVolume](./Enable-DedupVolume.md)
 
 [Get-DedupVolume](./Get-DedupVolume.md)
-

--- a/docset/winserver2016-ps/deduplication/Start-DedupJob.md
+++ b/docset/winserver2016-ps/deduplication/Start-DedupJob.md
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -361,4 +361,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DedupJob](./Get-DedupJob.md)
 
 [Stop-DedupJob](./Stop-DedupJob.md)
-

--- a/docset/winserver2016-ps/deduplication/Stop-DedupJob.md
+++ b/docset/winserver2016-ps/deduplication/Stop-DedupJob.md
@@ -73,7 +73,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -223,4 +223,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DedupJob](./Get-DedupJob.md)
 
 [Start-DedupJob](./Start-DedupJob.md)
-

--- a/docset/winserver2016-ps/deduplication/Update-DedupStatus.md
+++ b/docset/winserver2016-ps/deduplication/Update-DedupStatus.md
@@ -99,7 +99,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -168,4 +168,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Get-DedupStatus](./Get-DedupStatus.md)
-

--- a/docset/winserver2016-ps/defender/Add-MpPreference.md
+++ b/docset/winserver2016-ps/defender/Add-MpPreference.md
@@ -120,7 +120,7 @@ Specifies an array of processes, as paths to process images.
 This cmdlet excludes any files opened by the processes that you specify from scheduled and real-time scanning.
 Specifying this parameter excludes files opened by executable programs only.
 The cmdlet does not exclude the processes themselves.
-For more details, see [Configure exclusions for files opened by processes](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-antivirus/configure-process-opened-file-exclusions-microsoft-defender-antivirus).
+For more details, see [Configure exclusions for files opened by processes](/windows/security/threat-protection/microsoft-defender-antivirus/configure-process-opened-file-exclusions-microsoft-defender-antivirus).
 
 ```yaml
 Type: String[]

--- a/docset/winserver2016-ps/defender/Get-MpComputerStatus.md
+++ b/docset/winserver2016-ps/defender/Get-MpComputerStatus.md
@@ -130,4 +130,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-[Get-MpComputerStatus Properties](https://docs.microsoft.com/previous-versions/windows/desktop/defender/msft-mpcomputerstatus#properties)
+[Get-MpComputerStatus Properties](/previous-versions/windows/desktop/defender/msft-mpcomputerstatus#properties)

--- a/docset/winserver2016-ps/defender/Get-MpPreference.md
+++ b/docset/winserver2016-ps/defender/Get-MpPreference.md
@@ -20,7 +20,7 @@ Get-MpPreference [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] 
 ```
 
 ## DESCRIPTION
-The **Get-MpPreference** cmdlet gets preferences for the Windows Defender scans and updates. For more information about the preferences that this cmdlet retrieves, see [Windows Defender Preferences Class](https://docs.microsoft.com/previous-versions/windows/desktop/legacy/dn455323(v=vs.85))
+The **Get-MpPreference** cmdlet gets preferences for the Windows Defender scans and updates. For more information about the preferences that this cmdlet retrieves, see [Windows Defender Preferences Class](/previous-versions/windows/desktop/legacy/dn455323(v=vs.85))
 
 ## EXAMPLES
 
@@ -108,4 +108,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-MpPreference](./Remove-MpPreference.md)
 
 [Set-MpPreference](./Set-MpPreference.md)
-

--- a/docset/winserver2016-ps/defender/Get-MpPreference.md
+++ b/docset/winserver2016-ps/defender/Get-MpPreference.md
@@ -20,7 +20,7 @@ Get-MpPreference [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] 
 ```
 
 ## DESCRIPTION
-The **Get-MpPreference** cmdlet gets preferences for the Windows Defender scans and updates. For more information about the preferences that this cmdlet retrieves, see [Windows Defender Preferences Class](/previous-versions/windows/desktop/legacy/dn455323(v=vs.85))
+The **Get-MpPreference** cmdlet gets preferences for the Windows Defender scans and updates. For more information about the preferences that this cmdlet retrieves, see [Windows Defender Preferences Class](/previous-versions/windows/desktop/legacy/dn455323(v=vs.85)).
 
 ## EXAMPLES
 

--- a/docset/winserver2016-ps/defender/Get-MpThreatDetection.md
+++ b/docset/winserver2016-ps/defender/Get-MpThreatDetection.md
@@ -43,7 +43,7 @@ This command returns the list of past malware detections for the local computer.
 
 The following table lists the hexadecimal and decimal error codes for this cmdlet. Each hexadecimal error code has a 0x8050 prefix. Therefore, an ERROR_MP_BAD_SCANID error corresponds to error code 0x80508012. Additionally, an ERR_MP_REMOVE_FAILED error corresponds to error code 0x80508017. 
 
-For a list of error codes, along with possible reasons and resolutions, see [Windows Defender Antivirus client error codes](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus#windows-defender-antivirus-client-error-codes) in the topic [Review event logs and error codes to troubleshoot issues with Windows Defender Antivirus](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus#windows-defender-antivirus-client-error-codes).
+For a list of error codes, along with possible reasons and resolutions, see [Windows Defender Antivirus client error codes](/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus#windows-defender-antivirus-client-error-codes) in the topic [Review event logs and error codes to troubleshoot issues with Windows Defender Antivirus](/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus#windows-defender-antivirus-client-error-codes).
 
 |Symbolic Name                       | Error Number (hexadecimal) | Error number (decimal) |
 |------------------------------------|----------------------------|------------------------|
@@ -174,4 +174,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-MpThreat](./Remove-MpThreat.md)
 
 [Get-MpThreatCatalog](./Get-MpThreatCatalog.md)
-

--- a/docset/winserver2016-ps/defender/Remove-MpPreference.md
+++ b/docset/winserver2016-ps/defender/Remove-MpPreference.md
@@ -71,7 +71,7 @@ Accept wildcard characters: False
 ### -AttackSurfaceReductionOnlyExclusions
 Exclude files and paths from Attack Surface Reduction (ASR) rules. Specify the folders or files and resources that should be excluded from ASR rules. Enter a folder path or a fully qualified resource name. For example, ""C:\Windows"" will exclude all files in that directory. ""C:\Windows\App.exe"" will exclude only that specific file in that specific folder.
 
-For more information about excluding files and folders from [ASR rules](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/enable-attack-surface-reduction#exclude-files-and-folders-from-asr-rules).
+For more information about excluding files and folders from [ASR rules](/windows/security/threat-protection/microsoft-defender-atp/enable-attack-surface-reduction#exclude-files-and-folders-from-asr-rules).
 
 ```yaml
 Type: String[]

--- a/docset/winserver2016-ps/dfsn/Get-DfsnFolderTarget.md
+++ b/docset/winserver2016-ps/dfsn/Get-DfsnFolderTarget.md
@@ -25,7 +25,7 @@ The **Get-DfsnFolderTarget** cmdlet gets settings for targets of a Distributed F
 You can specify a DFS namespace folder path to see all the targets for that path.
 You can specify a namespace path and a target path to see settings for a particular target.
 
-For more information about DFS namespaces, see [DFS Namespaces overview](https://docs.microsoft.com/windows-server/storage/dfs-namespaces/dfs-overview).
+For more information about DFS namespaces, see [DFS Namespaces overview](/windows-server/storage/dfs-namespaces/dfs-overview).
 
 ## EXAMPLES
 
@@ -68,7 +68,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-DfsnFolderTarget](./Remove-DfsnFolderTarget.md)
 
 [Set-DfsnFolderTarget](./Set-DfsnFolderTarget.md)
-

--- a/docset/winserver2016-ps/dhcpserver/Get-DhcpServerVersion.md
+++ b/docset/winserver2016-ps/dhcpserver/Get-DhcpServerVersion.md
@@ -57,7 +57,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -126,4 +126,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DhcpServerDatabase](./Get-DhcpServerDatabase.md)
 
 [Get-DhcpServerSetting](./Get-DhcpServerSetting.md)
-

--- a/docset/winserver2016-ps/dhcpserver/Get-DhcpServerv4FreeIPAddress.md
+++ b/docset/winserver2016-ps/dhcpserver/Get-DhcpServerv4FreeIPAddress.md
@@ -90,7 +90,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -215,4 +215,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Get-DhcpServerv6FreeIPAddress](./Get-DhcpServerv6FreeIPAddress.md)
-

--- a/docset/winserver2016-ps/dhcpserver/Get-DhcpServerv4Lease.md
+++ b/docset/winserver2016-ps/dhcpserver/Get-DhcpServerv4Lease.md
@@ -157,7 +157,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -285,4 +285,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DhcpServerv4Scope](./Get-DhcpServerv4Scope.md)
 
 [Remove-DhcpServerv4Lease](./Remove-DhcpServerv4Lease.md)
-

--- a/docset/winserver2016-ps/dhcpserver/Get-DhcpServerv6FreeIPAddress.md
+++ b/docset/winserver2016-ps/dhcpserver/Get-DhcpServerv6FreeIPAddress.md
@@ -90,7 +90,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 
 ```yaml
 Type: CimSession[]
@@ -214,4 +214,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Get-DhcpServerv4FreeIPAddress](./Get-DhcpServerv4FreeIPAddress.md)
-

--- a/docset/winserver2016-ps/dhcpserver/Get-DhcpServerv6Statistics.md
+++ b/docset/winserver2016-ps/dhcpserver/Get-DhcpServerv6Statistics.md
@@ -57,7 +57,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -122,4 +122,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Get-DhcpServerv6ScopeStatistics](./Get-DhcpServerv6ScopeStatistics.md)
-

--- a/docset/winserver2016-ps/dhcpserver/Import-DhcpServer.md
+++ b/docset/winserver2016-ps/dhcpserver/Import-DhcpServer.md
@@ -155,7 +155,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -357,4 +357,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Export-DhcpServer](./Export-DhcpServer.md)
 
 [Restore-DhcpServer](./Restore-DhcpServer.md)
-

--- a/docset/winserver2016-ps/dism/Add-AppxProvisionedPackage.md
+++ b/docset/winserver2016-ps/dism/Add-AppxProvisionedPackage.md
@@ -39,7 +39,7 @@ For example, you must install the x86 dependency on the x86 image.
 You cannot install an app package (.appx) on an operating system that does not support Windows 8 apps.
 Apps are not supported on Server Core installations of Windows Server 2012, Windows Preinstallation Environment (Windows PE) 4.0, or on any versions of Windows older than Windows 8 and Windows Server 2012.
 
-To install and run apps on Windows Server 2016, you must install the [Install Server with Desktop Experience](https://docs.microsoft.com/windows-server/get-started/getting-started-with-server-with-desktop-experience).
+To install and run apps on Windows Server 2016, you must install the [Install Server with Desktop Experience](/windows-server/get-started/getting-started-with-server-with-desktop-experience).
 
 Use the *Online* parameter to specify the running operating system on your local computer, or use the *Path* parameter to specify the location of a mounted Windows image.
 
@@ -50,7 +50,7 @@ Use the *FolderPath* parameter to specify the location of a folder of unpacked a
 
 To add an app package (.appx) for a particular user, or to test a package while developing your app, use the **Add-AppxPackage** cmdlet instead.
 
-For more information, including requirements for app package provisioning, see [Sideload Apps with DISM](https://docs.microsoft.com/windows-hardware/manufacture/desktop/sideload-apps-with-dism-s14) and [How to develop an OEM app that uses a custom file](https://docs.microsoft.com/windows/win32/appxpkg/how-to-develop-oem-app-with-custom-file) in MicrosoftDocs.
+For more information, including requirements for app package provisioning, see [Sideload Apps with DISM](/windows-hardware/manufacture/desktop/sideload-apps-with-dism-s14) and [How to develop an OEM app that uses a custom file](/windows/win32/appxpkg/how-to-develop-oem-app-with-custom-file) in MicrosoftDocs.
 
 ## EXAMPLES
 

--- a/docset/winserver2016-ps/dism/Add-WindowsCapability.md
+++ b/docset/winserver2016-ps/dism/Add-WindowsCapability.md
@@ -239,10 +239,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-As of Windows 10 version 1709, you cannot use Windows Server Update Services (WSUS) to host Features on Demand (FOD) and language packs for Windows 10 clients. Instead, you can enforce a Group Policy setting that tells the clients to download them directly from Windows Update. You can also host FOD and language packs on a network share, but starting with Windows 10 version 1809, FOD and language packs can only be installed from Windows Update. For more information, see [How to make Features on Demand and language packs available when you're using WSUS/Configuration Manager](https://docs.microsoft.com/windows/deployment/update/fod-and-lang-packs).
+As of Windows 10 version 1709, you cannot use Windows Server Update Services (WSUS) to host Features on Demand (FOD) and language packs for Windows 10 clients. Instead, you can enforce a Group Policy setting that tells the clients to download them directly from Windows Update. You can also host FOD and language packs on a network share, but starting with Windows 10 version 1809, FOD and language packs can only be installed from Windows Update. For more information, see [How to make Features on Demand and language packs available when you're using WSUS/Configuration Manager](/windows/deployment/update/fod-and-lang-packs).
 
 ## RELATED LINKS
 
 [Get-WindowsCapability](./Get-WindowsCapability.md)
 [Remove-WindowsCapability](./Remove-WindowsCapability.md)
-

--- a/docset/winserver2016-ps/dism/Set-WindowsReservedStorageState.md
+++ b/docset/winserver2016-ps/dism/Set-WindowsReservedStorageState.md
@@ -18,7 +18,7 @@ Set-WindowsReservedStorageState -State <ReservedStorageState> [-LogPath <String>
 ```
 
 ## DESCRIPTION
-Sets the state of reserved storage. This command line option is only supported for online Windows images. If reserved storage is in use, it may not be disabled, and the following error is returned: <i>This operation is not supported when reserved storage is in use. Please wait for any servicing operations to complete and then try again later. </i>Changes to reserved storage state are reflected in Sysprep generalized Windows images. For more information see [Sysprep (Generalize) a Windows installation](https://docs.microsoft.com/windows-hardware/manufacture/desktop/sysprep--system-preparation--overview)
+Sets the state of reserved storage. This command line option is only supported for online Windows images. If reserved storage is in use, it may not be disabled, and the following error is returned: <i>This operation is not supported when reserved storage is in use. Please wait for any servicing operations to complete and then try again later. </i>Changes to reserved storage state are reflected in Sysprep generalized Windows images. For more information see [Sysprep (Generalize) a Windows installation](/windows-hardware/manufacture/desktop/sysprep--system-preparation--overview)
 
 ## EXAMPLES
 

--- a/docset/winserver2016-ps/dism/Set-WindowsReservedStorageState.md
+++ b/docset/winserver2016-ps/dism/Set-WindowsReservedStorageState.md
@@ -18,7 +18,8 @@ Set-WindowsReservedStorageState -State <ReservedStorageState> [-LogPath <String>
 ```
 
 ## DESCRIPTION
-Sets the state of reserved storage. This command line option is only supported for online Windows images. If reserved storage is in use, it may not be disabled, and the following error is returned: <i>This operation is not supported when reserved storage is in use. Please wait for any servicing operations to complete and then try again later. </i>Changes to reserved storage state are reflected in Sysprep generalized Windows images. For more information see [Sysprep (Generalize) a Windows installation](/windows-hardware/manufacture/desktop/sysprep--system-preparation--overview)
+Sets the state of reserved storage. This command line option is only supported for online Windows images. If reserved storage is in use, it may not be disabled, and the following error is returned: <i>This operation is not supported when reserved storage is in use. Please wait for any servicing operations to complete and then try again later. </i>Changes to reserved storage state are reflected in Sysprep generalized Windows images. For more information, see [Sysprep (Generalize) a Windows installation](/windows-hardware/manufacture/desktop/sysprep--system-preparation--overview).
+
 
 ## EXAMPLES
 

--- a/docset/winserver2016-ps/dnsclient/Set-DnsClient.md
+++ b/docset/winserver2016-ps/dnsclient/Set-DnsClient.md
@@ -78,7 +78,7 @@ Accept wildcard characters: False
 ### -CimSession
 
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -299,4 +299,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DnsClient](./Get-DnsClient.md)
 
 [Register-DnsClient](./Register-DnsClient.md)
-

--- a/docset/winserver2016-ps/dnsserver/Get-DnsServer.md
+++ b/docset/winserver2016-ps/dnsserver/Get-DnsServer.md
@@ -26,7 +26,7 @@ The **Get-DnsServer** cmdlet retrieves a Domain Name System (DNS) server configu
 You can pass the output of the **Get-DnsServer** cmdlet to the **Export-Clixml** cmdlet by using the pipeline operator.
 That cmdlet generates an XML file of the configuration.
 You can use the XML file to back up or transfer DNS settings between computers.
-For more information about **Export-Clixml**, see [Using the Export-Clixml cmdlet](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/export-clixml).
+For more information about **Export-Clixml**, see [Using the Export-Clixml cmdlet](/powershell/module/microsoft.powershell.utility/export-clixml).
 
 ## EXAMPLES
 
@@ -134,4 +134,3 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 [Set-DnsServer](./Set-DnsServer.md)
 
 [Test-DnsServer](./Test-DnsServer.md)
-

--- a/docset/winserver2016-ps/hyper-v/Debug-VM.md
+++ b/docset/winserver2016-ps/hyper-v/Debug-VM.md
@@ -230,4 +230,4 @@ Shielded virtual machines do not support debugging or nonmaskable interrupts.
 
 ## RELATED LINKS
 
-[Configuring Automatic Debugging](https://docs.microsoft.com/windows/win32/debug/configuring-automatic-debugging)
+[Configuring Automatic Debugging](/windows/win32/debug/configuring-automatic-debugging)

--- a/docset/winserver2016-ps/hyper-v/Mount-VHD.md
+++ b/docset/winserver2016-ps/hyper-v/Mount-VHD.md
@@ -219,4 +219,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-[Mount-DiskImage](https://docs.microsoft.com/powershell/module/storage/mount-diskimage)
+[Mount-DiskImage](/powershell/module/storage/mount-diskimage)

--- a/docset/winserver2016-ps/hyper-v/Move-VM.md
+++ b/docset/winserver2016-ps/hyper-v/Move-VM.md
@@ -127,7 +127,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -479,4 +479,3 @@ None, by default.
 ## NOTES
 
 ## RELATED LINKS
-

--- a/docset/winserver2016-ps/hyper-v/New-VM.md
+++ b/docset/winserver2016-ps/hyper-v/New-VM.md
@@ -147,7 +147,7 @@ Accept wildcard characters: False
 ### -CimSession
 
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2016-ps/hyper-v/Remove-VMHardDiskDrive.md
+++ b/docset/winserver2016-ps/hyper-v/Remove-VMHardDiskDrive.md
@@ -51,7 +51,7 @@ Removes all virtual hard drives on IDE controller 1 from virtual machine TestVM.
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -243,4 +243,3 @@ If **-PassThru** is specified.
 ## NOTES
 
 ## RELATED LINKS
-

--- a/docset/winserver2016-ps/hyper-v/Set-VMNetworkAdapterVlan.md
+++ b/docset/winserver2016-ps/hyper-v/Set-VMNetworkAdapterVlan.md
@@ -485,4 +485,4 @@ If **-PassThru** is specified.
 ## NOTES
 
 ## RELATED LINKS
-[Configure and View VLAN Settings on Hyper-V Virtual Switch Ports](https://docs.microsoft.com/windows-server/virtualization/hyper-v-virtual-switch/configure-and-view-vlan-settings-on-hyper-v-virtual-switch-ports)
+[Configure and View VLAN Settings on Hyper-V Virtual Switch Ports](/windows-server/virtualization/hyper-v-virtual-switch/configure-and-view-vlan-settings-on-hyper-v-virtual-switch-ports)

--- a/docset/winserver2016-ps/hyper-v/Set-VMProcessor.md
+++ b/docset/winserver2016-ps/hyper-v/Set-VMProcessor.md
@@ -234,7 +234,7 @@ Accept wildcard characters: False
 ### -HwThreadCountPerCore
 Specifies the number of virtual SMT threads exposed to the virtual machine. Setting this value to 0 indicates the virtual machine will inherit the host's number of threads per core. This setting may not exceed the host's number of threads per core.
 
-Note: Windows Server 2016 does not support setting HwThreadCountPerCore to 0. For more details, see [Configuring VM SMT settings using PowerShell](https://docs.microsoft.com/windows-server/virtualization/hyper-v/manage/about-hyper-v-scheduler-type-selection#configuring-vm-smt-settings-using-powershell).
+Note: Windows Server 2016 does not support setting HwThreadCountPerCore to 0. For more details, see [Configuring VM SMT settings using PowerShell](/windows-server/virtualization/hyper-v/manage/about-hyper-v-scheduler-type-selection#configuring-vm-smt-settings-using-powershell).
 
 ```yaml
 Type: Int64
@@ -295,7 +295,7 @@ Accept wildcard characters: False
 ```
 
 ### -Perfmon
-Specifies the hardware to be Exposed for Performance Monitoring. For more information about requirements, visit [Enable Intel Performance Monitoring Hardware in a Hyper-V virtual machine](https://docs.microsoft.com/windows-server/virtualization/hyper-v/manage/performance-monitoring-hardware).
+Specifies the hardware to be Exposed for Performance Monitoring. For more information about requirements, visit [Enable Intel Performance Monitoring Hardware in a Hyper-V virtual machine](/windows-server/virtualization/hyper-v/manage/performance-monitoring-hardware).
 
 
 ```yaml

--- a/docset/winserver2016-ps/hyper-v/Set-VMReplicationServer.md
+++ b/docset/winserver2016-ps/hyper-v/Set-VMReplicationServer.md
@@ -146,7 +146,7 @@ To display a list of certificates in the computer's My store and the thumbprint 
 
 `PS C:\\\> dir | format-list`
 
-For more information about certificate stores, see [Certificate stores](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2003/cc757138(v=ws.10).
+For more information about certificate stores, see [Certificate stores](/previous-versions/windows/it-pro/windows-server-2003/cc757138(v=ws.10)).
 
 ```yaml
 Type: String
@@ -162,7 +162,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2016-ps/international/Set-WinDefaultInputMethodOverride.md
+++ b/docset/winserver2016-ps/international/Set-WinDefaultInputMethodOverride.md
@@ -56,7 +56,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### InputTIP
-You can pipe a locale ID and a keyboard language ID (KLID). See [Default Input Profiles (Input Locales) in Windows](/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs)
+You can pipe a locale ID and a keyboard language ID (KLID). See [Default Input Profiles (Input Locales) in Windows](/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs).
 
 ## OUTPUTS
 

--- a/docset/winserver2016-ps/international/Set-WinDefaultInputMethodOverride.md
+++ b/docset/winserver2016-ps/international/Set-WinDefaultInputMethodOverride.md
@@ -56,7 +56,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### InputTIP
-You can pipe a locale ID and a keyboard language ID (KLID). See [Default Input Profiles (Input Locales) in Windows](https://docs.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs)
+You can pipe a locale ID and a keyboard language ID (KLID). See [Default Input Profiles (Input Locales) in Windows](/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs)
 
 ## OUTPUTS
 
@@ -65,4 +65,3 @@ You can pipe a locale ID and a keyboard language ID (KLID). See [Default Input P
 ## RELATED LINKS
 
 [Get-WinDefaultInputMethodOverride](./Get-WinDefaultInputMethodOverride.md)
-

--- a/docset/winserver2016-ps/msdtc/Test-Dtc.md
+++ b/docset/winserver2016-ps/msdtc/Test-Dtc.md
@@ -33,7 +33,7 @@ To run this cmdlet, you must first enable the firewall rule for Distributed Tran
 
 `netsh advfirewall firewall set rule group="Distributed Transaction Coordinator" new enable=yes`
 
-For more information, see [Netsh Command Syntax, Contexts, and Formatting](https://docs.microsoft.com/en-us/windows-server/networking/technologies/netsh/netsh-contexts).
+For more information, see [Netsh Command Syntax, Contexts, and Formatting](/windows-server/networking/technologies/netsh/netsh-contexts).
 
 To enable the rule using PowerShell run the following command:
 
@@ -318,4 +318,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Stop-Dtc](./Stop-Dtc.md)
 
 [Uninstall-Dtc](./Uninstall-Dtc.md)
-

--- a/docset/winserver2016-ps/netadapter/Enable-NetAdapterVmq.md
+++ b/docset/winserver2016-ps/netadapter/Enable-NetAdapterVmq.md
@@ -71,7 +71,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -255,4 +255,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-NetAdapterVmqQueue](./Get-NetAdapterVmqQueue.md)
 
 [Set-NetAdapterVmq](./Set-NetAdapterVmq.md)
-

--- a/docset/winserver2016-ps/netadapter/Get-NetAdapter.md
+++ b/docset/winserver2016-ps/netadapter/Get-NetAdapter.md
@@ -155,7 +155,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -278,7 +278,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays Windows Management Instrumentation (WMI) objects.
 The path after the pound sign (`#`) provides the namespace and class name for the underlying WMI object.
 
-[CIM_NetworkAdapter class](https://docs.microsoft.com/windows/win32/cimwin32prov/cim-networkadapter)
+[CIM_NetworkAdapter class](/windows/win32/cimwin32prov/cim-networkadapter)
 
 ## NOTES
 
@@ -293,4 +293,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Restart-NetAdapter](./Restart-NetAdapter.md)
 
 [Set-NetAdapter](./Set-NetAdapter.md)
-

--- a/docset/winserver2016-ps/netconnection/Set-NetConnectionProfile.md
+++ b/docset/winserver2016-ps/netconnection/Set-NetConnectionProfile.md
@@ -67,7 +67,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -288,4 +288,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Get-NetConnectionProfile](./Get-NetConnectionProfile.md)
-

--- a/docset/winserver2016-ps/netlldpagent/NetLldpAgent.md
+++ b/docset/winserver2016-ps/netlldpagent/NetLldpAgent.md
@@ -11,7 +11,7 @@ title: NetLldpAgent
 
 # NetLldpAgent Module
 ## Description
-This reference provides cmdlet descriptions and syntax for the Network Logical Link Discovery Protocol (LLDP) Agent. Use of the NetLldpAgent module requires the [DataCenterBridging](https://docs.microsoft.com/windows-server/networking/technologies/dcb/dcb-install) feature to be installed. The following cmdlets are covered by this reference:
+This reference provides cmdlet descriptions and syntax for the Network Logical Link Discovery Protocol (LLDP) Agent. Use of the NetLldpAgent module requires the [DataCenterBridging](/windows-server/networking/technologies/dcb/dcb-install) feature to be installed. The following cmdlets are covered by this reference:
 
 ## NetLldpAgent Cmdlets
 ### [Disable-NetLldpAgent](./Disable-NetLldpAgent.md)
@@ -22,5 +22,3 @@ Enables LLDP on a network interface on a computer.
 
 ### [Get-NetLldpAgent](./Get-NetLldpAgent.md)
 Gets the settings of the LLDP agent on a network interface on a host computer.
-
-

--- a/docset/winserver2016-ps/netsecurity/Set-NetFirewallAddressFilter.md
+++ b/docset/winserver2016-ps/netsecurity/Set-NetFirewallAddressFilter.md
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -350,4 +350,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-NetIPsecMainModeRule](./Get-NetIPsecMainModeRule.md)
 
 [Set-NetIPsecRule](./Set-NetIPsecRule.md)
-

--- a/docset/winserver2016-ps/nettcpip/New-NetRoute.md
+++ b/docset/winserver2016-ps/nettcpip/New-NetRoute.md
@@ -103,7 +103,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/New-CimSession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/Get-CimSession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/New-CimSession) or [Get-CimSession](/powershell/module/cimcmdlets/Get-CimSession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -408,4 +408,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Set-NetRoute](./Set-NetRoute.md)
 
 [Set-NetIPInterface](./Set-NetIPInterface.md)
-

--- a/docset/winserver2016-ps/pki/Get-Certificate.md
+++ b/docset/winserver2016-ps/pki/Get-Certificate.md
@@ -274,5 +274,4 @@ The EnrollmentResult object contains the results of enrollment.
 
 [Set-Location](https://go.microsoft.com/fwlink/p/?LinkId=293912)
 
-[System Store Locations](https://docs.microsoft.com/windows/desktop/seccrypto/system-store-locations)
-
+[System Store Locations](/windows/desktop/seccrypto/system-store-locations)

--- a/docset/winserver2016-ps/pki/Import-Certificate.md
+++ b/docset/winserver2016-ps/pki/Import-Certificate.md
@@ -137,4 +137,4 @@ The output is an array of **X509Certificate2\[\]** objects.
 
 [Export-Certificate](./Export-Certificate.md)
 
-[System Store Locations](https://docs.microsoft.com/windows/desktop/seccrypto/system-store-locations)
+[System Store Locations](/windows/desktop/seccrypto/system-store-locations)

--- a/docset/winserver2016-ps/pki/Import-PfxCertificate.md
+++ b/docset/winserver2016-ps/pki/Import-PfxCertificate.md
@@ -176,4 +176,4 @@ The imported **X509Certificate2** object contained in the PFX file that is assoc
 
 [Export-PfxCertificate](./Export-PfxCertificate.md)
 
-[System Store Locations](https://docs.microsoft.com/windows/desktop/seccrypto/system-store-locations)
+[System Store Locations](/windows/desktop/seccrypto/system-store-locations)

--- a/docset/winserver2016-ps/pki/New-SelfSignedCertificate.md
+++ b/docset/winserver2016-ps/pki/New-SelfSignedCertificate.md
@@ -623,7 +623,7 @@ Accept wildcard characters: False
 ```
 
 ### -Provider
-Specifies the name of the KSP or CSP that this cmdlet uses to create the certificate. See [Cryptographic Providers](https://docs.microsoft.com/en-us/windows/desktop/SecCertEnroll/understanding-cryptographic-providers) for more information.
+Specifies the name of the KSP or CSP that this cmdlet uses to create the certificate. See [Cryptographic Providers](/windows/desktop/SecCertEnroll/understanding-cryptographic-providers) for more information.
 Some acceptable values include:
 
 - Microsoft Software Key Storage Provider
@@ -1010,4 +1010,4 @@ An **X509Certificate2** object for the certificate that has been created.
 
 ## RELATED LINKS
 
-[System Store Locations](https://docs.microsoft.com/windows/desktop/seccrypto/system-store-locations)
+[System Store Locations](/windows/desktop/seccrypto/system-store-locations)

--- a/docset/winserver2016-ps/printmanagement/Get-PrintConfiguration.md
+++ b/docset/winserver2016-ps/printmanagement/Get-PrintConfiguration.md
@@ -85,7 +85,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -180,4 +180,3 @@ This cmdlet returns a printer configuration object.
 ## RELATED LINKS
 
 [Set-PrintConfiguration](./Set-PrintConfiguration.md)
-

--- a/docset/winserver2016-ps/remotedesktop/Set-RDCertificate.md
+++ b/docset/winserver2016-ps/remotedesktop/Set-RDCertificate.md
@@ -46,7 +46,7 @@ PS C:\>$Password = ConvertTo-SecureString -String "Cups34Horses&&" -AsPlainText 
 PS C:\>Set-RDCertificate -Role RDRedirector -ImportPath "C:\Certificates\Redirector07.pfx" -Password $Password -ConnectionBroker "RDCB.Contoso.com"
 ```
 
-The first part of the example uses the **ConvertTo-SecureString** cmdlet to create a secure string based on a string that the user supplies and stores it in the **$Password** variable. For more information, see [ConvertTo-SecureString](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/ConvertTo-SecureString?view=powershell-6). You can also enter the `Get-Help ConvertTo-SecureString` cmdlet into your PowerShell window.
+The first part of the example uses the **ConvertTo-SecureString** cmdlet to create a secure string based on a string that the user supplies and stores it in the **$Password** variable. For more information, see [ConvertTo-SecureString](/powershell/module/microsoft.powershell.security/ConvertTo-SecureString?view=powershell-6). You can also enter the `Get-Help ConvertTo-SecureString` cmdlet into your PowerShell window.
 
 The second part of the example specifies the file name of the certificate to use for the redirector role for the RD Connection Broker named RDCB.Contoso.com. The cmdlet uses the secure string stored in the **$Password** variable to help secure the certificate.
 
@@ -178,7 +178,7 @@ Accept wildcard characters: False
 ### CommonParameters
 This cmdlet supports the following common parameters: *-Debug*, *-ErrorAction*, *-ErrorVariable*, *-InformationAction*, *-InformationVariable*, *-OutVariable*, *-OutBuffer*, *-PipelineVariable*, *-Verbose*, *-WarningAction*, and *-WarningVariable*.
 
-For more information, see [about_CommonParameters](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-6).
+For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-6).
 
 ## Inputs
 
@@ -196,4 +196,4 @@ For more information, see [about_CommonParameters](https://docs.microsoft.com/po
 
 [New-RDCertificate](./New-RDCertificate.md)
 
-[about_CommonParameters](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-6)
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-6)

--- a/docset/winserver2016-ps/remotedesktop/Set-RDCertificate.md
+++ b/docset/winserver2016-ps/remotedesktop/Set-RDCertificate.md
@@ -46,7 +46,7 @@ PS C:\>$Password = ConvertTo-SecureString -String "Cups34Horses&&" -AsPlainText 
 PS C:\>Set-RDCertificate -Role RDRedirector -ImportPath "C:\Certificates\Redirector07.pfx" -Password $Password -ConnectionBroker "RDCB.Contoso.com"
 ```
 
-The first part of the example uses the **ConvertTo-SecureString** cmdlet to create a secure string based on a string that the user supplies and stores it in the **$Password** variable. For more information, see [ConvertTo-SecureString](/powershell/module/microsoft.powershell.security/ConvertTo-SecureString?view=powershell-6). You can also enter the `Get-Help ConvertTo-SecureString` cmdlet into your PowerShell window.
+The first part of the example uses the **ConvertTo-SecureString** cmdlet to create a secure string based on a string that the user supplies and stores it in the **$Password** variable. For more information, see [ConvertTo-SecureString](/powershell/module/microsoft.powershell.security/ConvertTo-SecureString). You can also enter the `Get-Help ConvertTo-SecureString` cmdlet into your PowerShell window.
 
 The second part of the example specifies the file name of the certificate to use for the redirector role for the RD Connection Broker named RDCB.Contoso.com. The cmdlet uses the secure string stored in the **$Password** variable to help secure the certificate.
 

--- a/docset/winserver2016-ps/remotedesktop/Set-RDCertificate.md
+++ b/docset/winserver2016-ps/remotedesktop/Set-RDCertificate.md
@@ -198,4 +198,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-RDCertificate](./New-RDCertificate.md)
 
-[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-6)
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216)
+

--- a/docset/winserver2016-ps/remotedesktop/Set-RDCertificate.md
+++ b/docset/winserver2016-ps/remotedesktop/Set-RDCertificate.md
@@ -176,9 +176,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the following common parameters: *-Debug*, *-ErrorAction*, *-ErrorVariable*, *-InformationAction*, *-InformationVariable*, *-OutVariable*, *-OutBuffer*, *-PipelineVariable*, *-Verbose*, *-WarningAction*, and *-WarningVariable*.
 
-For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-6).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 

--- a/docset/winserver2016-ps/scheduledtasks/New-ScheduledTask.md
+++ b/docset/winserver2016-ps/scheduledtasks/New-ScheduledTask.md
@@ -104,7 +104,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2016-ps/scheduledtasks/New-ScheduledTaskSettingsSet.md
+++ b/docset/winserver2016-ps/scheduledtasks/New-ScheduledTaskSettingsSet.md
@@ -144,7 +144,7 @@ The second command creates scheduled task settings that specify if the task is n
 
 The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.
 
-Without the ExecutionTimeLimit setting defined, the time limit set to it's default of three days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan).
+Without the ExecutionTimeLimit setting defined, the time limit set to it's default of three days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](/powershell/module/microsoft.powershell.utility/new-timespan).
 
 
 ## PARAMETERS
@@ -651,4 +651,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Start-ScheduledTask](./Start-ScheduledTask.md)
 
 [Unregister-ScheduledTask](./Unregister-ScheduledTask.md)
-

--- a/docset/winserver2016-ps/scheduledtasks/Register-ScheduledTask.md
+++ b/docset/winserver2016-ps/scheduledtasks/Register-ScheduledTask.md
@@ -342,7 +342,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docset/winserver2016-ps/scheduledtasks/Register-ScheduledTask.md
+++ b/docset/winserver2016-ps/scheduledtasks/Register-ScheduledTask.md
@@ -110,7 +110,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -342,7 +342,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 


### PR DESCRIPTION
**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
