### PR TITLE
[BULK] DocuTune - Fix build validation issues: docs-link-absolute (part 7)

### DIFF
--- a/docset/winserver2019-ps/webapplicationproxy/Set-WebApplicationProxyConfiguration.md
+++ b/docset/winserver2019-ps/webapplicationproxy/Set-WebApplicationProxyConfiguration.md
@@ -135,7 +135,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -288,4 +288,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Get-WebApplicationProxyConfiguration](./Get-WebApplicationProxyConfiguration.md)
-

--- a/docset/winserver2019-ps/windowserrorreporting/Disable-WindowsErrorReporting.md
+++ b/docset/winserver2019-ps/windowserrorreporting/Disable-WindowsErrorReporting.md
@@ -27,7 +27,7 @@ Windows Error Reporting generates reports in response to system events, such as 
 
 To get the current WER status, use the [Get-WindowsErrorReporting](./Get-WindowsErrorReporting.md) cmdlet.
 If you disable WER, you can use the [Enable-WindowsErrorReporting](./Enable-WindowsErrorReporting.md) cmdlet to re-enable it.
-After you run this cmdlet, WER again sends information about application failures to Microsoft. To customize the settings of Windows Error Reporting, use registry keys described in [WER Settings](https://docs.microsoft.com/windows/desktop/wer/wer-settings) article.
+After you run this cmdlet, WER again sends information about application failures to Microsoft. To customize the settings of Windows Error Reporting, use registry keys described in [WER Settings](/windows/desktop/wer/wer-settings) article.
 
 ## EXAMPLES
 
@@ -58,4 +58,3 @@ Otherwise, it returns $False.
 [Enable-WindowsErrorReporting](./Enable-WindowsErrorReporting.md)
 
 [Get-WindowsErrorReporting](./Get-WindowsErrorReporting.md)
-

--- a/docset/winserver2022-ps/Microsoft.DiagnosticDataViewer/Get-DiagnosticData.md
+++ b/docset/winserver2022-ps/Microsoft.DiagnosticDataViewer/Get-DiagnosticData.md
@@ -165,4 +165,4 @@ Persisted event record.
 Requires Windows 10 version 17134 (1803) or higher
 
 ## RELATED LINKS
-[About Windows Diagnostic Data](https://docs.microsoft.com/en-us/windows/privacy/windows-diagnostic-data)
+[About Windows Diagnostic Data](/windows/privacy/windows-diagnostic-data)

--- a/docset/winserver2022-ps/Microsoft.DiagnosticDataViewer/Get-DiagnosticDataTypes.md
+++ b/docset/winserver2022-ps/Microsoft.DiagnosticDataViewer/Get-DiagnosticDataTypes.md
@@ -48,5 +48,4 @@ Requires Windows 10 version 17134 (1803) or higher
 
 ## RELATED LINKS
 
-[About Windows Diagnostic Data](https://docs.microsoft.com/en-us/windows/privacy/windows-diagnostic-data)
-
+[About Windows Diagnostic Data](/windows/privacy/windows-diagnostic-data)

--- a/docset/winserver2022-ps/activedirectory/ActiveDirectory.md
+++ b/docset/winserver2022-ps/activedirectory/ActiveDirectory.md
@@ -15,7 +15,7 @@ The Active Directory module for Windows PowerShell is a PowerShell module that c
 
 If you don't have the Active Directory module installed on your machine, you need to download the correct Remote Server Administration Tools (RSAT) package for your OS.  If you're running Windows 7, you will also need to run the `import-module ActiveDirectory` command from an elevated PowerShell prompt. For more detail, see [RSAT for Windows operating systems](https://support.microsoft.com/help/2693643/remote-server-administration-tools-rsat-for-windows-operating-systems). Starting with Windows 10 October 2018 Update, RSAT is included as a set of Features on Demand right from Windows 10. Now, instead of downloading an RSAT package you can just go to Manage optional features in Settings and click Add a feature to see the list of available RSAT tools. Select and install the specific RSAT tools you need. To see installation progress, click the Back button to view status on the Manage optional features page.
 
-If you want to use this module in PowerShell 7, please see [PowerShell 7 module compatibility](https://docs.microsoft.com/powershell/scripting/whats-new/module-compatibility).
+If you want to use this module in PowerShell 7, please see [PowerShell 7 module compatibility](/powershell/scripting/whats-new/module-compatibility).
 
 ## ActiveDirectory Cmdlets
 ### [Add-ADCentralAccessPolicyMember](./Add-ADCentralAccessPolicyMember.md)
@@ -458,4 +458,3 @@ Uninstalls an Active Directory managed service account from a computer or remove
 
 ### [Unlock-ADAccount](./Unlock-ADAccount.md)
 Unlocks an Active Directory account.
-

--- a/docset/winserver2022-ps/activedirectory/ActiveDirectory.md
+++ b/docset/winserver2022-ps/activedirectory/ActiveDirectory.md
@@ -15,7 +15,7 @@ The Active Directory module for Windows PowerShell is a PowerShell module that c
 
 If you don't have the Active Directory module installed on your machine, you need to download the correct Remote Server Administration Tools (RSAT) package for your OS.  If you're running Windows 7, you will also need to run the `import-module ActiveDirectory` command from an elevated PowerShell prompt. For more detail, see [RSAT for Windows operating systems](https://support.microsoft.com/help/2693643/remote-server-administration-tools-rsat-for-windows-operating-systems). Starting with Windows 10 October 2018 Update, RSAT is included as a set of Features on Demand right from Windows 10. Now, instead of downloading an RSAT package you can just go to Manage optional features in Settings and click Add a feature to see the list of available RSAT tools. Select and install the specific RSAT tools you need. To see installation progress, click the Back button to view status on the Manage optional features page.
 
-If you want to use this module in PowerShell 7, please see [PowerShell 7 module compatibility](/powershell/scripting/whats-new/module-compatibility).
+If you want to use this module in PowerShell 7, see [PowerShell 7 module compatibility](/powershell/scripting/whats-new/module-compatibility).
 
 ## ActiveDirectory Cmdlets
 ### [Add-ADCentralAccessPolicyMember](./Add-ADCentralAccessPolicyMember.md)

--- a/docset/winserver2022-ps/activedirectory/Get-ADComputer.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADComputer.md
@@ -45,7 +45,7 @@ You can also set the parameter to a computer object variable, such as `$<localCo
 To search for and retrieve more than one computer, use the *Filter* or *LDAPFilter* parameters.
 The *Filter* parameter uses the PowerShell Expression Language to write query strings for Active Directory.
 PowerShell Expression Language syntax provides rich type conversion support for value types received by the *Filter* parameter.
-For more information about the *Filter* parameter syntax, type `Get-Help` [about_ActiveDirectory_Filter](https://docs.microsoft.com/previous-versions/windows/server/hh531527(v=ws.10)).
+For more information about the *Filter* parameter syntax, type `Get-Help` [about_ActiveDirectory_Filter](/previous-versions/windows/server/hh531527(v=ws.10)).
 If you have existing Lightweight Directory Access Protocol (LDAP) query strings, you can use the *LDAPFilter* parameter.
 
 This cmdlet retrieves a default set of computer object properties.
@@ -257,7 +257,7 @@ Specifies a query string that retrieves Active Directory objects.
 This string uses the Windows PowerShell Expression Language syntax.
 The Windows PowerShell Expression Language syntax provides rich type-conversion support for value types received by the *Filter* parameter.
 The syntax uses an in-order representation, which means that the operator is placed between the operand and the value.
-For more information about the *Filter* parameter, type `Get-Help` [about_ActiveDirectory_Filter](https://docs.microsoft.com/previous-versions/windows/server/hh531527(v=ws.10)).
+For more information about the *Filter* parameter, type `Get-Help` [about_ActiveDirectory_Filter](/previous-versions/windows/server/hh531527(v=ws.10)).
 
 Syntax:
 
@@ -330,7 +330,7 @@ Accept wildcard characters: False
 Specifies an LDAP query string that is used to filter Active Directory objects.
 You can use this parameter to run your existing LDAP queries.
 The *Filter* parameter syntax supports the same functionality as the LDAP syntax.
-For more information, see the *Filter* parameter description or type `Get-Help` [about_ActiveDirectory_Filter](https://docs.microsoft.com/previous-versions/windows/server/hh531527(v=ws.10)).
+For more information, see the *Filter* parameter description or type `Get-Help` [about_ActiveDirectory_Filter](/previous-versions/windows/server/hh531527(v=ws.10)).
 
 ```yaml
 Type: String

--- a/docset/winserver2022-ps/activedirectory/Get-ADUser.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADUser.md
@@ -190,7 +190,7 @@ The following syntax uses Backus-Naur form to show how to use the PowerShell Exp
 
 For a list of supported types for \<value\>, type `Get-Help about_ActiveDirectory_ObjectModel`.
 
-Note: For String parameter type, PowerShell will cast the filter query to a string while processing the command. When using a string variable as a value in the filter component, make sure that it complies with the [PowerShell Quoting Rules](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_quoting_rules). For example, if the filter expression is double-quoted, the variable should be enclosed using single quotation marks:
+Note: For String parameter type, PowerShell will cast the filter query to a string while processing the command. When using a string variable as a value in the filter component, make sure that it complies with the [PowerShell Quoting Rules](/powershell/module/microsoft.powershell.core/about/about_quoting_rules). For example, if the filter expression is double-quoted, the variable should be enclosed using single quotation marks:
 **Get-ADUser -Filter "Name -like '$UserName'"**. On the contrary, if curly braces are used to enclose the filter, the variable should not be quoted at all: **Get-ADUser -Filter {Name -like $UserName}**.
 
 Note: PowerShell wildcards other than \*, such as ?, are not supported by the *Filter* syntax.

--- a/docset/winserver2022-ps/adcsdeployment/Install-AdcsCertificationAuthority.md
+++ b/docset/winserver2022-ps/adcsdeployment/Install-AdcsCertificationAuthority.md
@@ -53,7 +53,7 @@ You can import the cmdlet by running the following commands from Windows PowerSh
 
 To include the Certification Authority and Certificate Templates consoles in a CA installation, you must use the *IncludeManagementTools* parameter at the end of the `Install-WindowsFeature Adcs-Cert-Authority` command.
 
-Int is equivalent to Int32 in the [.NET Framework](https://docs.microsoft.com/dotnet/csharp/language-reference/builtin-types/built-in-types).
+Int is equivalent to Int32 in the [.NET Framework](/dotnet/csharp/language-reference/builtin-types/built-in-types).
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/adfs/Enable-AdfsDeviceRegistration.md
+++ b/docset/winserver2022-ps/adfs/Enable-AdfsDeviceRegistration.md
@@ -21,7 +21,7 @@ Enable-AdfsDeviceRegistration [-Credential <PSCredential>] [-Force] [-WhatIf] [-
 
 ## DESCRIPTION
 This cmdlet has been deprecated for AD FS 2016.
-For more information, see [Configure On-Premises Conditional Access using registered devices](https://docs.microsoft.com/windows-server/identity/ad-fs/operations/configure-device-based-conditional-access-on-premises).
+For more information, see [Configure On-Premises Conditional Access using registered devices](/windows-server/identity/ad-fs/operations/configure-device-based-conditional-access-on-premises).
 
 The **Enable-AdfsDeviceRegistration** cmdlet configures a server in an Active Directory Federation Services (AD FS) farm to host the Device Registration Service.
 To completely enable the Device Registration Service, you must run this command on each AD FS server in your AD FS farm.
@@ -121,4 +121,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Initialize-ADDeviceRegistration](./Initialize-ADDeviceRegistration.md)
 
 [Set-AdfsDeviceRegistration](./Set-AdfsDeviceRegistration.md)
-

--- a/docset/winserver2022-ps/adfs/New-AdfsAzureMfaTenantCertificate.md
+++ b/docset/winserver2022-ps/adfs/New-AdfsAzureMfaTenantCertificate.md
@@ -42,7 +42,7 @@ PS C:\> Set-AdfsAzureMfaTenant -TenantId <your tenant ID> -ClientId 981f26a1-7f4
 These commands create a certificate for Azure MFA, register the certificate in a tenant, and enable Azure MFA on an AD FS farm.
 
 > [!NOTE]
-> Customers are encouraged to use the newer Azure Active Directory PowerShell 2.0 module. For more information about the v2.0 module please see [AzureAD PowerShell 2.0](https://docs.microsoft.com/powershell/module/Azuread/?view=azureadps-2.0).
+> Customers are encouraged to use the newer Azure Active Directory PowerShell 2.0 module. For more information about the v2.0 module please see [AzureAD PowerShell 2.0](/powershell/module/Azuread/?view=azureadps-2.0).
 
 ### Example 2: Determine which certificate Azure MFA is using
 ```

--- a/docset/winserver2022-ps/adfs/New-AdfsAzureMfaTenantCertificate.md
+++ b/docset/winserver2022-ps/adfs/New-AdfsAzureMfaTenantCertificate.md
@@ -42,7 +42,7 @@ PS C:\> Set-AdfsAzureMfaTenant -TenantId <your tenant ID> -ClientId 981f26a1-7f4
 These commands create a certificate for Azure MFA, register the certificate in a tenant, and enable Azure MFA on an AD FS farm.
 
 > [!NOTE]
-> Customers are encouraged to use the newer Azure Active Directory PowerShell 2.0 module. For more information about the v2.0 module please see [AzureAD PowerShell 2.0](/powershell/module/Azuread/?view=azureadps-2.0).
+> Customers are encouraged to use the newer Azure Active Directory PowerShell 2.0 module. For more information about the v2.0 module, see [AzureAD PowerShell 2.0](/powershell/module/Azuread/?view=azureadps-2.0).
 
 ### Example 2: Determine which certificate Azure MFA is using
 ```

--- a/docset/winserver2022-ps/appx/Remove-AppxPackage.md
+++ b/docset/winserver2022-ps/appx/Remove-AppxPackage.md
@@ -163,7 +163,7 @@ If you specify this parameter, the cmdlet removes the app package for only the u
 > [!NOTE]
 >
 > - This parameter only accepts user SIDs
-> - Use the **whoami /user** command to display the current SID of a user. See [whoami syntax](https://docs.microsoft.com/windows-server/administration/windows-commands/whoami) for details.
+> - Use the **whoami /user** command to display the current SID of a user. See [whoami syntax](/windows-server/administration/windows-commands/whoami) for details.
 
 
 

--- a/docset/winserver2022-ps/bitlocker/Get-BitLockerVolume.md
+++ b/docset/winserver2022-ps/bitlocker/Get-BitLockerVolume.md
@@ -41,9 +41,9 @@ You can also use this cmdlet to view the following information about a BitLocker
 - Protection Status - Whether BitLocker currently uses a key protector to encrypt the volume encryption key.
 - EncryptionMethod - Indicates the encryption algorithm and key size used on the volume.
 
-See [BitLocker Overview](https://docs.microsoft.com/windows/security/information-protection/bitlocker/bitlocker-overview) for more information.
+See [BitLocker Overview](/windows/security/information-protection/bitlocker/bitlocker-overview) for more information.
 
-For an overview of encryption methods, see [GetEncryptionMethod method](https://docs.microsoft.com/windows/win32/secprov/getencryptionmethod-win32-encryptablevolume).
+For an overview of encryption methods, see [GetEncryptionMethod method](/windows/win32/secprov/getencryptionmethod-win32-encryptablevolume).
 
 ## EXAMPLES
 
@@ -134,4 +134,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Enable-BitLocker](./Enable-BitLocker.md)
 
 [Enable-BitLockerAutoUnlock](./Enable-BitLockerAutoUnlock.md)
-

--- a/docset/winserver2022-ps/bitlocker/Remove-BitLockerKeyProtector.md
+++ b/docset/winserver2022-ps/bitlocker/Remove-BitLockerKeyProtector.md
@@ -32,7 +32,7 @@ Any encrypted data on the drive remains encrypted.
 
 We recommend you have at least one recovery password as key protector to a volume in case you need to recover a system.
 
-For an overview of BitLocker, see [Overview of BitLocker Device Encryption](https://docs.microsoft.com/windows/security/information-protection/bitlocker/bitlocker-device-encryption-overview-windows-10).
+For an overview of BitLocker, see [Overview of BitLocker Device Encryption](/windows/security/information-protection/bitlocker/bitlocker-device-encryption-overview-windows-10).
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/configci/New-CIPolicy.md
+++ b/docset/winserver2022-ps/configci/New-CIPolicy.md
@@ -460,7 +460,7 @@ Accept wildcard characters: False
 ```
 
 ### -Level
-Specifies the primary level of detail for generated rules. Refer to [WDAC File Rule Levels](https://docs.microsoft.com/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-file-rule-levels) for acceptable parameter values and descriptions.
+Specifies the primary level of detail for generated rules. Refer to [WDAC File Rule Levels](/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-file-rule-levels) for acceptable parameter values and descriptions.
 
 ```yaml
 Type: RuleLevel
@@ -674,4 +674,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Merge-CIPolicy](./Merge-CIPolicy.md)
 
 [New-CIPolicyRule](./New-CIPolicyRule.md)
-

--- a/docset/winserver2022-ps/configci/New-CIPolicyRule.md
+++ b/docset/winserver2022-ps/configci/New-CIPolicyRule.md
@@ -385,7 +385,7 @@ Accept wildcard characters: False
 ```
 
 ### -FilePathRule
-Specifies the path of a folder for generating a rule with level set to FilePath. Refer to [Filepath Rules Info](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#more-information-about-filepath-rules) for acceptable wildcard values and usage. 
+Specifies the path of a folder for generating a rule with level set to FilePath. Refer to [Filepath Rules Info](/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#more-information-about-filepath-rules) for acceptable wildcard values and usage. 
 This cmdlet will not check whether the filepath string is a valid filepath. 
 
 ```yaml
@@ -492,4 +492,3 @@ This cmdlet returns the rules that it creates.
 ## RELATED LINKS
 
 [Get-SystemDriver](./Get-SystemDriver.md)
-

--- a/docset/winserver2022-ps/configci/Set-RuleOption.md
+++ b/docset/winserver2022-ps/configci/Set-RuleOption.md
@@ -130,7 +130,7 @@ Accept wildcard characters: False
 
 ### -Option
 Specifies the index of the rule option that this cmdlet modifies. 
-Specify the **Help** parameter for option information. Refer to [WDAC Policy Rule Options](https://docs.microsoft.com/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-policy-rules) for more detailed descriptions of each option.
+Specify the **Help** parameter for option information. Refer to [WDAC Policy Rule Options](/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-policy-rules) for more detailed descriptions of each option.
 
 ```yaml
 Type: Int32
@@ -156,4 +156,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Set-HVCIOptions](./Set-HVCIOptions.md)
-

--- a/docset/winserver2022-ps/deduplication/Disable-DedupVolume.md
+++ b/docset/winserver2022-ps/deduplication/Disable-DedupVolume.md
@@ -82,7 +82,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -172,4 +172,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Set-DedupVolume](./Set-DedupVolume.md)
 
 [Update-DedupStatus](./Update-DedupStatus.md)
-

--- a/docset/winserver2022-ps/deduplication/Enable-DedupVolume.md
+++ b/docset/winserver2022-ps/deduplication/Enable-DedupVolume.md
@@ -85,7 +85,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -204,4 +204,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DedupVolume](./Get-DedupVolume.md)
 
 [Set-DedupVolume](./Set-DedupVolume.md)
-

--- a/docset/winserver2022-ps/deduplication/Expand-DedupFile.md
+++ b/docset/winserver2022-ps/deduplication/Expand-DedupFile.md
@@ -64,7 +64,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -128,4 +128,3 @@ A value of zero indicates success.
 ## RELATED LINKS
 
 [Get-DedupVolume](./Get-DedupVolume.md)
-

--- a/docset/winserver2022-ps/deduplication/Get-DedupJob.md
+++ b/docset/winserver2022-ps/deduplication/Get-DedupJob.md
@@ -60,7 +60,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -159,4 +159,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Start-DedupJob](./Start-DedupJob.md)
 
 [Stop-DedupJob](./Stop-DedupJob.md)
-

--- a/docset/winserver2022-ps/deduplication/Get-DedupMetadata.md
+++ b/docset/winserver2022-ps/deduplication/Get-DedupMetadata.md
@@ -90,7 +90,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -159,4 +159,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Measure-DedupFileMetadata](./Measure-DedupFileMetadata.md)
-

--- a/docset/winserver2022-ps/deduplication/Get-DedupSchedule.md
+++ b/docset/winserver2022-ps/deduplication/Get-DedupSchedule.md
@@ -74,7 +74,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -171,4 +171,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Remove-DedupSchedule](./Remove-DedupSchedule.md)
 
 [Set-DedupSchedule](./Set-DedupSchedule.md)
-

--- a/docset/winserver2022-ps/deduplication/Get-DedupStatus.md
+++ b/docset/winserver2022-ps/deduplication/Get-DedupStatus.md
@@ -61,7 +61,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -134,4 +134,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Update-DedupStatus](./Update-DedupStatus.md)
-

--- a/docset/winserver2022-ps/deduplication/Get-DedupVolume.md
+++ b/docset/winserver2022-ps/deduplication/Get-DedupVolume.md
@@ -75,7 +75,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -167,4 +167,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Enable-DedupVolume](./Enable-DedupVolume.md)
 
 [Set-DedupVolume](./Set-DedupVolume.md)
-

--- a/docset/winserver2022-ps/deduplication/Measure-DedupFileMetadata.md
+++ b/docset/winserver2022-ps/deduplication/Measure-DedupFileMetadata.md
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -121,4 +121,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Update-DedupStatus](./Update-DedupStatus.md)
-

--- a/docset/winserver2022-ps/deduplication/New-DedupSchedule.md
+++ b/docset/winserver2022-ps/deduplication/New-DedupSchedule.md
@@ -101,7 +101,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -422,4 +422,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Remove-DedupSchedule](./Remove-DedupSchedule.md)
 
 [Set-DedupSchedule](./Set-DedupSchedule.md)
-

--- a/docset/winserver2022-ps/deduplication/Remove-DedupSchedule.md
+++ b/docset/winserver2022-ps/deduplication/Remove-DedupSchedule.md
@@ -67,7 +67,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -175,4 +175,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [New-DedupSchedule](./New-DedupSchedule.md)
 
 [Set-DedupSchedule](./Set-DedupSchedule.md)
-

--- a/docset/winserver2022-ps/deduplication/Set-DedupSchedule.md
+++ b/docset/winserver2022-ps/deduplication/Set-DedupSchedule.md
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -441,4 +441,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [New-DedupSchedule](./New-DedupSchedule.md)
 
 [Remove-DedupSchedule](./Remove-DedupSchedule.md)
-

--- a/docset/winserver2022-ps/deduplication/Set-DedupVolume.md
+++ b/docset/winserver2022-ps/deduplication/Set-DedupVolume.md
@@ -124,7 +124,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -440,4 +440,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Enable-DedupVolume](./Enable-DedupVolume.md)
 
 [Get-DedupVolume](./Get-DedupVolume.md)
-

--- a/docset/winserver2022-ps/deduplication/Start-DedupJob.md
+++ b/docset/winserver2022-ps/deduplication/Start-DedupJob.md
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -361,4 +361,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DedupJob](./Get-DedupJob.md)
 
 [Stop-DedupJob](./Stop-DedupJob.md)
-

--- a/docset/winserver2022-ps/deduplication/Stop-DedupJob.md
+++ b/docset/winserver2022-ps/deduplication/Stop-DedupJob.md
@@ -73,7 +73,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -223,4 +223,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DedupJob](./Get-DedupJob.md)
 
 [Start-DedupJob](./Start-DedupJob.md)
-

--- a/docset/winserver2022-ps/deduplication/Update-DedupStatus.md
+++ b/docset/winserver2022-ps/deduplication/Update-DedupStatus.md
@@ -99,7 +99,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -168,4 +168,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Get-DedupStatus](./Get-DedupStatus.md)
-

--- a/docset/winserver2022-ps/defender/Get-MpComputerStatus.md
+++ b/docset/winserver2022-ps/defender/Get-MpComputerStatus.md
@@ -130,4 +130,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-[Get-MpComputerStatus Properties](https://docs.microsoft.com/previous-versions/windows/desktop/defender/msft-mpcomputerstatus#properties)
+[Get-MpComputerStatus Properties](/previous-versions/windows/desktop/defender/msft-mpcomputerstatus#properties)

--- a/docset/winserver2022-ps/defender/Get-MpPreference.md
+++ b/docset/winserver2022-ps/defender/Get-MpPreference.md
@@ -20,7 +20,7 @@ Get-MpPreference [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] 
 ```
 
 ## DESCRIPTION
-The **Get-MpPreference** cmdlet gets preferences for the Windows Defender scans and updates. For more information about the preferences that this cmdlet retrieves, see [Windows Defender Preferences Class](https://docs.microsoft.com/previous-versions/windows/desktop/legacy/dn455323(v=vs.85))
+The **Get-MpPreference** cmdlet gets preferences for the Windows Defender scans and updates. For more information about the preferences that this cmdlet retrieves, see [Windows Defender Preferences Class](/previous-versions/windows/desktop/legacy/dn455323(v=vs.85))
 
 ## EXAMPLES
 
@@ -108,4 +108,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-MpPreference](./Remove-MpPreference.md)
 
 [Set-MpPreference](./Set-MpPreference.md)
-

--- a/docset/winserver2022-ps/defender/Get-MpPreference.md
+++ b/docset/winserver2022-ps/defender/Get-MpPreference.md
@@ -20,7 +20,7 @@ Get-MpPreference [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] 
 ```
 
 ## DESCRIPTION
-The **Get-MpPreference** cmdlet gets preferences for the Windows Defender scans and updates. For more information about the preferences that this cmdlet retrieves, see [Windows Defender Preferences Class](/previous-versions/windows/desktop/legacy/dn455323(v=vs.85))
+The **Get-MpPreference** cmdlet gets preferences for the Windows Defender scans and updates. For more information about the preferences that this cmdlet retrieves, see [Windows Defender Preferences Class](/previous-versions/windows/desktop/legacy/dn455323(v=vs.85)).
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/defender/Get-MpThreatDetection.md
+++ b/docset/winserver2022-ps/defender/Get-MpThreatDetection.md
@@ -43,7 +43,7 @@ This command returns the list of past malware detections for the local computer.
 
 The following table lists the hexadecimal and decimal error codes for this cmdlet. Each hexadecimal error code has a 0x8050 prefix. Therefore, an ERROR_MP_BAD_SCANID error corresponds to error code 0x80508012. Additionally, an ERR_MP_REMOVE_FAILED error corresponds to error code 0x80508017. 
 
-For a list of error codes, along with possible reasons and resolutions, see [Windows Defender Antivirus client error codes](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus#windows-defender-antivirus-client-error-codes) in the topic [Review event logs and error codes to troubleshoot issues with Windows Defender Antivirus](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus#windows-defender-antivirus-client-error-codes).
+For a list of error codes, along with possible reasons and resolutions, see [Windows Defender Antivirus client error codes](/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus#windows-defender-antivirus-client-error-codes) in the topic [Review event logs and error codes to troubleshoot issues with Windows Defender Antivirus](/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus#windows-defender-antivirus-client-error-codes).
 
 |Symbolic Name                       | Error Number (hexadecimal) | Error number (decimal) |
 |------------------------------------|----------------------------|------------------------|
@@ -174,4 +174,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-MpThreat](./Remove-MpThreat.md)
 
 [Get-MpThreatCatalog](./Get-MpThreatCatalog.md)
-

--- a/docset/winserver2022-ps/dfsn/Get-DfsnFolderTarget.md
+++ b/docset/winserver2022-ps/dfsn/Get-DfsnFolderTarget.md
@@ -25,7 +25,7 @@ The **Get-DfsnFolderTarget** cmdlet gets settings for targets of a Distributed F
 You can specify a DFS namespace folder path to see all the targets for that path.
 You can specify a namespace path and a target path to see settings for a particular target.
 
-For more information about DFS namespaces, see [DFS Namespaces overview](https://docs.microsoft.com/windows-server/storage/dfs-namespaces/dfs-overview).
+For more information about DFS namespaces, see [DFS Namespaces overview](/windows-server/storage/dfs-namespaces/dfs-overview).
 
 ## EXAMPLES
 
@@ -68,7 +68,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -151,4 +151,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-DfsnFolderTarget](./Remove-DfsnFolderTarget.md)
 
 [Set-DfsnFolderTarget](./Set-DfsnFolderTarget.md)
-

--- a/docset/winserver2022-ps/dhcpserver/Get-DhcpServerVersion.md
+++ b/docset/winserver2022-ps/dhcpserver/Get-DhcpServerVersion.md
@@ -57,7 +57,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -126,4 +126,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DhcpServerDatabase](./Get-DhcpServerDatabase.md)
 
 [Get-DhcpServerSetting](./Get-DhcpServerSetting.md)
-

--- a/docset/winserver2022-ps/dhcpserver/Get-DhcpServerv4FreeIPAddress.md
+++ b/docset/winserver2022-ps/dhcpserver/Get-DhcpServerv4FreeIPAddress.md
@@ -90,7 +90,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -215,4 +215,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Get-DhcpServerv6FreeIPAddress](./Get-DhcpServerv6FreeIPAddress.md)
-

--- a/docset/winserver2022-ps/dhcpserver/Get-DhcpServerv4Lease.md
+++ b/docset/winserver2022-ps/dhcpserver/Get-DhcpServerv4Lease.md
@@ -157,7 +157,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -285,4 +285,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DhcpServerv4Scope](./Get-DhcpServerv4Scope.md)
 
 [Remove-DhcpServerv4Lease](./Remove-DhcpServerv4Lease.md)
-

--- a/docset/winserver2022-ps/dhcpserver/Get-DhcpServerv6FreeIPAddress.md
+++ b/docset/winserver2022-ps/dhcpserver/Get-DhcpServerv6FreeIPAddress.md
@@ -90,7 +90,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 
 ```yaml
 Type: CimSession[]
@@ -214,4 +214,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Get-DhcpServerv4FreeIPAddress](./Get-DhcpServerv4FreeIPAddress.md)
-

--- a/docset/winserver2022-ps/dhcpserver/Get-DhcpServerv6Statistics.md
+++ b/docset/winserver2022-ps/dhcpserver/Get-DhcpServerv6Statistics.md
@@ -57,7 +57,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -122,4 +122,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 ## RELATED LINKS
 
 [Get-DhcpServerv6ScopeStatistics](./Get-DhcpServerv6ScopeStatistics.md)
-

--- a/docset/winserver2022-ps/dhcpserver/Import-DhcpServer.md
+++ b/docset/winserver2022-ps/dhcpserver/Import-DhcpServer.md
@@ -155,7 +155,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -357,4 +357,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Export-DhcpServer](./Export-DhcpServer.md)
 
 [Restore-DhcpServer](./Restore-DhcpServer.md)
-

--- a/docset/winserver2022-ps/dism/Add-AppxProvisionedPackage.md
+++ b/docset/winserver2022-ps/dism/Add-AppxProvisionedPackage.md
@@ -41,7 +41,7 @@ For example, you must install the x86 dependency on the x86 image.
 You cannot install an app package (.appx) on an operating system that does not support Windows 8 apps.
 Apps are not supported on Server Core installations of Windows Server 2012, Windows Preinstallation Environment (Windows PE) 4.0, or on any versions of Windows older than Windows 8 and Windows Server 2012.
 
-To install and run apps on Windows Server 2016, you must install the [Install Server with Desktop Experience](https://docs.microsoft.com/windows-server/get-started/getting-started-with-server-with-desktop-experience).
+To install and run apps on Windows Server 2016, you must install the [Install Server with Desktop Experience](/windows-server/get-started/getting-started-with-server-with-desktop-experience).
 
 Use the *Online* parameter to specify the running operating system on your local computer, or use the *Path* parameter to specify the location of a mounted Windows image.
 
@@ -52,7 +52,7 @@ Use the *FolderPath* parameter to specify the location of a folder of unpacked a
 
 To add an app package (.appx) for a particular user, or to test a package while developing your app, use the **Add-AppxPackage** cmdlet instead.
 
-For more information, including requirements for app package provisioning, see [Sideload Apps with DISM](https://docs.microsoft.com/windows-hardware/manufacture/desktop/sideload-apps-with-dism-s14) and [How to develop an OEM app that uses a custom file](https://docs.microsoft.com/windows/win32/appxpkg/how-to-develop-oem-app-with-custom-file) in MicrosoftDocs.
+For more information, including requirements for app package provisioning, see [Sideload Apps with DISM](/windows-hardware/manufacture/desktop/sideload-apps-with-dism-s14) and [How to develop an OEM app that uses a custom file](/windows/win32/appxpkg/how-to-develop-oem-app-with-custom-file) in MicrosoftDocs.
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/dism/Add-WindowsCapability.md
+++ b/docset/winserver2022-ps/dism/Add-WindowsCapability.md
@@ -240,10 +240,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-As of Windows 10 version 1709, you cannot use Windows Server Update Services (WSUS) to host Features on Demand (FOD) and language packs for Windows 10 clients. Instead, you can enforce a Group Policy setting that tells the clients to download them directly from Windows Update. You can also host FOD and language packs on a network share, but starting with Windows 10 version 1809, FOD and language packs can only be installed from Windows Update. For more information, see [How to make Features on Demand and language packs available when you're using WSUS/Configuration Manager](https://docs.microsoft.com/windows/deployment/update/fod-and-lang-packs).
+As of Windows 10 version 1709, you cannot use Windows Server Update Services (WSUS) to host Features on Demand (FOD) and language packs for Windows 10 clients. Instead, you can enforce a Group Policy setting that tells the clients to download them directly from Windows Update. You can also host FOD and language packs on a network share, but starting with Windows 10 version 1809, FOD and language packs can only be installed from Windows Update. For more information, see [How to make Features on Demand and language packs available when you're using WSUS/Configuration Manager](/windows/deployment/update/fod-and-lang-packs).
 
 ## RELATED LINKS
 
 [Get-WindowsCapability](./Get-WindowsCapability.md)
 [Remove-WindowsCapability](./Remove-WindowsCapability.md)
-

--- a/docset/winserver2022-ps/dism/Set-WindowsReservedStorageState.md
+++ b/docset/winserver2022-ps/dism/Set-WindowsReservedStorageState.md
@@ -18,7 +18,7 @@ Set-WindowsReservedStorageState -State <ReservedStorageState> [-LogPath <String>
 ```
 
 ## DESCRIPTION
-Sets the state of reserved storage. This command line option is only supported for online Windows images. If reserved storage is in use, it may not be disabled, and the following error is returned: <i>This operation is not supported when reserved storage is in use. Please wait for any servicing operations to complete and then try again later. </i>Changes to reserved storage state are reflected in Sysprep generalized Windows images. For more information see [Sysprep (Generalize) a Windows installation](https://docs.microsoft.com/windows-hardware/manufacture/desktop/sysprep--system-preparation--overview)
+Sets the state of reserved storage. This command line option is only supported for online Windows images. If reserved storage is in use, it may not be disabled, and the following error is returned: <i>This operation is not supported when reserved storage is in use. Please wait for any servicing operations to complete and then try again later. </i>Changes to reserved storage state are reflected in Sysprep generalized Windows images. For more information see [Sysprep (Generalize) a Windows installation](/windows-hardware/manufacture/desktop/sysprep--system-preparation--overview)
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/dism/Set-WindowsReservedStorageState.md
+++ b/docset/winserver2022-ps/dism/Set-WindowsReservedStorageState.md
@@ -18,7 +18,7 @@ Set-WindowsReservedStorageState -State <ReservedStorageState> [-LogPath <String>
 ```
 
 ## DESCRIPTION
-Sets the state of reserved storage. This command line option is only supported for online Windows images. If reserved storage is in use, it may not be disabled, and the following error is returned: <i>This operation is not supported when reserved storage is in use. Please wait for any servicing operations to complete and then try again later. </i>Changes to reserved storage state are reflected in Sysprep generalized Windows images. For more information see [Sysprep (Generalize) a Windows installation](/windows-hardware/manufacture/desktop/sysprep--system-preparation--overview)
+Sets the state of reserved storage. This command line option is only supported for online Windows images. If reserved storage is in use, it may not be disabled, and the following error is returned: <i>This operation is not supported when reserved storage is in use. Please wait for any servicing operations to complete and then try again later. </i>Changes to reserved storage state are reflected in Sysprep generalized Windows images. For more information see [Sysprep (Generalize) a Windows installation](/windows-hardware/manufacture/desktop/sysprep--system-preparation--overview).
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/dnsclient/Set-DnsClient.md
+++ b/docset/winserver2022-ps/dnsclient/Set-DnsClient.md
@@ -78,7 +78,7 @@ Accept wildcard characters: False
 ### -CimSession
 
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -299,4 +299,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-DnsClient](./Get-DnsClient.md)
 
 [Register-DnsClient](./Register-DnsClient.md)
-

--- a/docset/winserver2022-ps/dnsserver/Get-DnsServer.md
+++ b/docset/winserver2022-ps/dnsserver/Get-DnsServer.md
@@ -26,7 +26,7 @@ The **Get-DnsServer** cmdlet retrieves a Domain Name System (DNS) server configu
 You can pass the output of the **Get-DnsServer** cmdlet to the **Export-Clixml** cmdlet by using the pipeline operator.
 That cmdlet generates an XML file of the configuration.
 You can use the XML file to back up or transfer DNS settings between computers.
-For more information about **Export-Clixml**, see [Using the Export-Clixml cmdlet](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/export-clixml).
+For more information about **Export-Clixml**, see [Using the Export-Clixml cmdlet](/powershell/module/microsoft.powershell.utility/export-clixml).
 
 ## EXAMPLES
 
@@ -134,4 +134,3 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 [Set-DnsServer](./Set-DnsServer.md)
 
 [Test-DnsServer](./Test-DnsServer.md)
-

--- a/docset/winserver2022-ps/hyper-v/Debug-VM.md
+++ b/docset/winserver2022-ps/hyper-v/Debug-VM.md
@@ -230,4 +230,4 @@ Shielded virtual machines do not support debugging or nonmaskable interrupts.
 
 ## RELATED LINKS
 
-[Configuring Automatic Debugging](https://docs.microsoft.com/windows/win32/debug/configuring-automatic-debugging)
+[Configuring Automatic Debugging](/windows/win32/debug/configuring-automatic-debugging)

--- a/docset/winserver2022-ps/hyper-v/Mount-VHD.md
+++ b/docset/winserver2022-ps/hyper-v/Mount-VHD.md
@@ -219,4 +219,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-[Mount-DiskImage](https://docs.microsoft.com/powershell/module/storage/mount-diskimage)
+[Mount-DiskImage](/powershell/module/storage/mount-diskimage)

--- a/docset/winserver2022-ps/hyper-v/Move-VM.md
+++ b/docset/winserver2022-ps/hyper-v/Move-VM.md
@@ -127,7 +127,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -479,4 +479,3 @@ None, by default.
 ## NOTES
 
 ## RELATED LINKS
-


### PR DESCRIPTION
**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
