### PR TITLE
[BULK] DocuTune - Fix build validation issues: docs-link-absolute (part 8)

### DIFF
--- a/docset/winserver2022-ps/hyper-v/New-VM.md
+++ b/docset/winserver2022-ps/hyper-v/New-VM.md
@@ -147,7 +147,7 @@ Accept wildcard characters: False
 ### -CimSession
 
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2022-ps/hyper-v/Remove-VMHardDiskDrive.md
+++ b/docset/winserver2022-ps/hyper-v/Remove-VMHardDiskDrive.md
@@ -51,7 +51,7 @@ Removes all virtual hard drives on IDE controller 1 from virtual machine TestVM.
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -243,4 +243,3 @@ If **-PassThru** is specified.
 ## NOTES
 
 ## RELATED LINKS
-

--- a/docset/winserver2022-ps/hyper-v/Set-VMNetworkAdapterVlan.md
+++ b/docset/winserver2022-ps/hyper-v/Set-VMNetworkAdapterVlan.md
@@ -485,4 +485,4 @@ If **-PassThru** is specified.
 ## NOTES
 
 ## RELATED LINKS
-[Configure and View VLAN Settings on Hyper-V Virtual Switch Ports](https://docs.microsoft.com/windows-server/virtualization/hyper-v-virtual-switch/configure-and-view-vlan-settings-on-hyper-v-virtual-switch-ports)
+[Configure and View VLAN Settings on Hyper-V Virtual Switch Ports](/windows-server/virtualization/hyper-v-virtual-switch/configure-and-view-vlan-settings-on-hyper-v-virtual-switch-ports)

--- a/docset/winserver2022-ps/hyper-v/Set-VMProcessor.md
+++ b/docset/winserver2022-ps/hyper-v/Set-VMProcessor.md
@@ -234,7 +234,7 @@ Accept wildcard characters: False
 ### -HwThreadCountPerCore
 Specifies the number of virtual SMT threads exposed to the virtual machine. Setting this value to 0 indicates the virtual machine will inherit the host's number of threads per core. This setting may not exceed the host's number of threads per core.
 
-Note: Windows Server 2016 does not support setting HwThreadCountPerCore to 0. For more details, see [Configuring VM SMT settings using PowerShell](https://docs.microsoft.com/windows-server/virtualization/hyper-v/manage/about-hyper-v-scheduler-type-selection#configuring-vm-smt-settings-using-powershell).
+Note: Windows Server 2016 does not support setting HwThreadCountPerCore to 0. For more details, see [Configuring VM SMT settings using PowerShell](/windows-server/virtualization/hyper-v/manage/about-hyper-v-scheduler-type-selection#configuring-vm-smt-settings-using-powershell).
 
 ```yaml
 Type: Int64
@@ -295,7 +295,7 @@ Accept wildcard characters: False
 ```
 
 ### -Perfmon
-Specifies the hardware to be Exposed for Performance Monitoring. For more information about requirements, visit [Enable Intel Performance Monitoring Hardware in a Hyper-V virtual machine](https://docs.microsoft.com/windows-server/virtualization/hyper-v/manage/performance-monitoring-hardware).
+Specifies the hardware to be Exposed for Performance Monitoring. For more information about requirements, visit [Enable Intel Performance Monitoring Hardware in a Hyper-V virtual machine](/windows-server/virtualization/hyper-v/manage/performance-monitoring-hardware).
 
 
 ```yaml

--- a/docset/winserver2022-ps/hyper-v/Set-VMReplicationServer.md
+++ b/docset/winserver2022-ps/hyper-v/Set-VMReplicationServer.md
@@ -146,7 +146,7 @@ To display a list of certificates in the computer's My store and the thumbprint 
 
 `PS C:\\\> dir | format-list`
 
-For more information about certificate stores, see [Certificate stores](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2003/cc757138(v=ws.10).
+For more information about certificate stores, see [Certificate stores](/previous-versions/windows/it-pro/windows-server-2003/cc757138(v=ws.10)).
 
 ```yaml
 Type: String
@@ -162,7 +162,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2022-ps/international/Set-WinDefaultInputMethodOverride.md
+++ b/docset/winserver2022-ps/international/Set-WinDefaultInputMethodOverride.md
@@ -56,7 +56,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### InputTIP
-You can pipe a locale ID and a keyboard language ID (KLID). See [Default Input Profiles (Input Locales) in Windows](https://docs.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs)
+You can pipe a locale ID and a keyboard language ID (KLID). See [Default Input Profiles (Input Locales) in Windows](/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs)
 
 ## OUTPUTS
 
@@ -65,4 +65,3 @@ You can pipe a locale ID and a keyboard language ID (KLID). See [Default Input P
 ## RELATED LINKS
 
 [Get-WinDefaultInputMethodOverride](./Get-WinDefaultInputMethodOverride.md)
-

--- a/docset/winserver2022-ps/msdtc/Test-Dtc.md
+++ b/docset/winserver2022-ps/msdtc/Test-Dtc.md
@@ -33,7 +33,7 @@ To run this cmdlet, you must first enable the firewall rule for Distributed Tran
 
 `netsh advfirewall firewall set rule group="Distributed Transaction Coordinator" new enable=yes`
 
-For more information, see [Netsh Command Syntax, Contexts, and Formatting](https://docs.microsoft.com/en-us/windows-server/networking/technologies/netsh/netsh-contexts).
+For more information, see [Netsh Command Syntax, Contexts, and Formatting](/windows-server/networking/technologies/netsh/netsh-contexts).
 
 To enable the rule using PowerShell run the following command:
 
@@ -318,4 +318,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Stop-Dtc](./Stop-Dtc.md)
 
 [Uninstall-Dtc](./Uninstall-Dtc.md)
-

--- a/docset/winserver2022-ps/netadapter/Enable-NetAdapterVmq.md
+++ b/docset/winserver2022-ps/netadapter/Enable-NetAdapterVmq.md
@@ -71,7 +71,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -255,4 +255,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-NetAdapterVmqQueue](./Get-NetAdapterVmqQueue.md)
 
 [Set-NetAdapterVmq](./Set-NetAdapterVmq.md)
-

--- a/docset/winserver2022-ps/netadapter/Get-NetAdapter.md
+++ b/docset/winserver2022-ps/netadapter/Get-NetAdapter.md
@@ -155,7 +155,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -278,7 +278,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays Windows Management Instrumentation (WMI) objects.
 The path after the pound sign (`#`) provides the namespace and class name for the underlying WMI object.
 
-[CIM_NetworkAdapter class](https://docs.microsoft.com/windows/win32/cimwin32prov/cim-networkadapter)
+[CIM_NetworkAdapter class](/windows/win32/cimwin32prov/cim-networkadapter)
 
 ## NOTES
 
@@ -293,4 +293,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Restart-NetAdapter](./Restart-NetAdapter.md)
 
 [Set-NetAdapter](./Set-NetAdapter.md)
-

--- a/docset/winserver2022-ps/netconnection/Set-NetConnectionProfile.md
+++ b/docset/winserver2022-ps/netconnection/Set-NetConnectionProfile.md
@@ -67,7 +67,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -288,4 +288,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Get-NetConnectionProfile](./Get-NetConnectionProfile.md)
-

--- a/docset/winserver2022-ps/netlldpagent/NetLldpAgent.md
+++ b/docset/winserver2022-ps/netlldpagent/NetLldpAgent.md
@@ -11,7 +11,7 @@ title: NetLldpAgent
 
 # NetLldpAgent Module
 ## Description
-This reference provides cmdlet descriptions and syntax for the Network Logical Link Discovery Protocol (LLDP) Agent. Use of the NetLldpAgent module requires the [DataCenterBridging](https://docs.microsoft.com/windows-server/networking/technologies/dcb/dcb-install) feature to be installed. The following cmdlets are covered by this reference:
+This reference provides cmdlet descriptions and syntax for the Network Logical Link Discovery Protocol (LLDP) Agent. Use of the NetLldpAgent module requires the [DataCenterBridging](/windows-server/networking/technologies/dcb/dcb-install) feature to be installed. The following cmdlets are covered by this reference:
 
 ## NetLldpAgent Cmdlets
 ### [Disable-NetLldpAgent](./Disable-NetLldpAgent.md)
@@ -22,5 +22,3 @@ Enables LLDP on a network interface on a computer.
 
 ### [Get-NetLldpAgent](./Get-NetLldpAgent.md)
 Gets the settings of the LLDP agent on a network interface on a host computer.
-
-

--- a/docset/winserver2022-ps/netsecurity/Set-NetFirewallAddressFilter.md
+++ b/docset/winserver2022-ps/netsecurity/Set-NetFirewallAddressFilter.md
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -350,4 +350,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Get-NetIPsecMainModeRule](./Get-NetIPsecMainModeRule.md)
 
 [Set-NetIPsecRule](./Set-NetIPsecRule.md)
-

--- a/docset/winserver2022-ps/nettcpip/New-NetRoute.md
+++ b/docset/winserver2022-ps/nettcpip/New-NetRoute.md
@@ -103,7 +103,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/New-CimSession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/Get-CimSession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/New-CimSession) or [Get-CimSession](/powershell/module/cimcmdlets/Get-CimSession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -408,4 +408,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Set-NetRoute](./Set-NetRoute.md)
 
 [Set-NetIPInterface](./Set-NetIPInterface.md)
-

--- a/docset/winserver2022-ps/pki/Get-Certificate.md
+++ b/docset/winserver2022-ps/pki/Get-Certificate.md
@@ -274,5 +274,4 @@ The EnrollmentResult object contains the results of enrollment.
 
 [Set-Location](https://go.microsoft.com/fwlink/p/?LinkId=293912)
 
-[System Store Locations](https://docs.microsoft.com/windows/desktop/seccrypto/system-store-locations)
-
+[System Store Locations](/windows/desktop/seccrypto/system-store-locations)

--- a/docset/winserver2022-ps/pki/Import-Certificate.md
+++ b/docset/winserver2022-ps/pki/Import-Certificate.md
@@ -137,4 +137,4 @@ The output is an array of **X509Certificate2\[\]** objects.
 
 [Export-Certificate](./Export-Certificate.md)
 
-[System Store Locations](https://docs.microsoft.com/windows/desktop/seccrypto/system-store-locations)
+[System Store Locations](/windows/desktop/seccrypto/system-store-locations)

--- a/docset/winserver2022-ps/pki/Import-PfxCertificate.md
+++ b/docset/winserver2022-ps/pki/Import-PfxCertificate.md
@@ -176,4 +176,4 @@ The imported **X509Certificate2** object contained in the PFX file that is assoc
 
 [Export-PfxCertificate](./Export-PfxCertificate.md)
 
-[System Store Locations](https://docs.microsoft.com/windows/desktop/seccrypto/system-store-locations)
+[System Store Locations](/windows/desktop/seccrypto/system-store-locations)

--- a/docset/winserver2022-ps/pki/New-SelfSignedCertificate.md
+++ b/docset/winserver2022-ps/pki/New-SelfSignedCertificate.md
@@ -623,7 +623,7 @@ Accept wildcard characters: False
 ```
 
 ### -Provider
-Specifies the name of the KSP or CSP that this cmdlet uses to create the certificate. See [Cryptographic Providers](https://docs.microsoft.com/en-us/windows/desktop/SecCertEnroll/understanding-cryptographic-providers) for more information.
+Specifies the name of the KSP or CSP that this cmdlet uses to create the certificate. See [Cryptographic Providers](/windows/desktop/SecCertEnroll/understanding-cryptographic-providers) for more information.
 Some acceptable values include:
 
 - Microsoft Software Key Storage Provider
@@ -1010,4 +1010,4 @@ An **X509Certificate2** object for the certificate that has been created.
 
 ## RELATED LINKS
 
-[System Store Locations](https://docs.microsoft.com/windows/desktop/seccrypto/system-store-locations)
+[System Store Locations](/windows/desktop/seccrypto/system-store-locations)

--- a/docset/winserver2022-ps/printmanagement/Get-PrintConfiguration.md
+++ b/docset/winserver2022-ps/printmanagement/Get-PrintConfiguration.md
@@ -85,7 +85,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -182,4 +182,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Set-PrintConfiguration](./Set-PrintConfiguration.md)
-

--- a/docset/winserver2022-ps/provisioning/Install-ProvisioningPackage.md
+++ b/docset/winserver2022-ps/provisioning/Install-ProvisioningPackage.md
@@ -1,4 +1,4 @@
-﻿---
+---
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: provcmdlets.dll-Help.xml
 Module Name: Provisioning
@@ -21,7 +21,7 @@ Install-ProvisioningPackage [-PackagePath] <String> [-ForceInstall] [-QuietInsta
 ```
 
 ## DESCRIPTION
-This cmdlet is used to install .ppkg files that are generated and exported by the [Windows Configuration Designer tool](https://docs.microsoft.com/windows/configuration/provisioning-packages/provisioning-install-icd).
+This cmdlet is used to install .ppkg files that are generated and exported by the [Windows Configuration Designer tool](/windows/configuration/provisioning-packages/provisioning-install-icd).
 
 The **Install-ProvisioningPackage** cmdlet is supported on Windows 11 client operating system only.
 

--- a/docset/winserver2022-ps/rdmgmt/Set-RDCertificate.md
+++ b/docset/winserver2022-ps/rdmgmt/Set-RDCertificate.md
@@ -178,7 +178,7 @@ Accept wildcard characters: False
 ### CommonParameters
 This cmdlet supports the following common parameters: *-Debug*, *-ErrorAction*, *-ErrorVariable*, *-InformationAction*, *-InformationVariable*, *-OutVariable*, *-OutBuffer*, *-PipelineVariable*, *-Verbose*, *-WarningAction*, and *-WarningVariable*.
 
-For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-6).
+For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 

--- a/docset/winserver2022-ps/rdmgmt/Set-RDCertificate.md
+++ b/docset/winserver2022-ps/rdmgmt/Set-RDCertificate.md
@@ -46,7 +46,7 @@ PS C:\>$Password = ConvertTo-SecureString -String "Cups34Horses&&" -AsPlainText 
 PS C:\>Set-RDCertificate -Role RDRedirector -ImportPath "C:\Certificates\Redirector07.pfx" -Password $Password -ConnectionBroker "RDCB.Contoso.com"
 ```
 
-The first part of the example uses the **ConvertTo-SecureString** cmdlet to create a secure string based on a string that the user supplies and stores it in the **$Password** variable. For more information, see [ConvertTo-SecureString](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/ConvertTo-SecureString?view=powershell-6). You can also enter the `Get-Help ConvertTo-SecureString` cmdlet into your PowerShell window.
+The first part of the example uses the **ConvertTo-SecureString** cmdlet to create a secure string based on a string that the user supplies and stores it in the **$Password** variable. For more information, see [ConvertTo-SecureString](/powershell/module/microsoft.powershell.security/ConvertTo-SecureString?view=powershell-6). You can also enter the `Get-Help ConvertTo-SecureString` cmdlet into your PowerShell window.
 
 The second part of the example specifies the file name of the certificate to use for the redirector role for the RD Connection Broker named RDCB.Contoso.com. The cmdlet uses the secure string stored in the **$Password** variable to help secure the certificate.
 
@@ -178,7 +178,7 @@ Accept wildcard characters: False
 ### CommonParameters
 This cmdlet supports the following common parameters: *-Debug*, *-ErrorAction*, *-ErrorVariable*, *-InformationAction*, *-InformationVariable*, *-OutVariable*, *-OutBuffer*, *-PipelineVariable*, *-Verbose*, *-WarningAction*, and *-WarningVariable*.
 
-For more information, see [about_CommonParameters](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-6).
+For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-6).
 
 ## Inputs
 
@@ -196,4 +196,4 @@ For more information, see [about_CommonParameters](https://docs.microsoft.com/po
 
 [New-RDCertificate](./New-RDCertificate.md)
 
-[about_CommonParameters](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-6)
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-6)

--- a/docset/winserver2022-ps/rdmgmt/Set-RDCertificate.md
+++ b/docset/winserver2022-ps/rdmgmt/Set-RDCertificate.md
@@ -196,4 +196,4 @@ For more information, see [about_CommonParameters](/powershell/module/microsoft.
 
 [New-RDCertificate](./New-RDCertificate.md)
 
-[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-6)
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216)

--- a/docset/winserver2022-ps/scheduledtasks/New-ScheduledTask.md
+++ b/docset/winserver2022-ps/scheduledtasks/New-ScheduledTask.md
@@ -104,7 +104,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2022-ps/scheduledtasks/New-ScheduledTaskSettingsSet.md
+++ b/docset/winserver2022-ps/scheduledtasks/New-ScheduledTaskSettingsSet.md
@@ -144,7 +144,7 @@ The second command creates scheduled task settings that specify if the task is n
 
 The third command registers the scheduled task Task01 to run the task action named Cmd, only then finish the task after one hour.
 
-Without the ExecutionTimeLimit setting defined, the time limit set to it's default of three days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-timespan).
+Without the ExecutionTimeLimit setting defined, the time limit set to it's default of three days for the Task Scheduler is allowed to complete the task. To configure the time limit, see [New-TimeSpan](/powershell/module/microsoft.powershell.utility/new-timespan).
 
 
 ## PARAMETERS
@@ -651,4 +651,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Start-ScheduledTask](./Start-ScheduledTask.md)
 
 [Unregister-ScheduledTask](./Unregister-ScheduledTask.md)
-

--- a/docset/winserver2022-ps/scheduledtasks/Register-ScheduledTask.md
+++ b/docset/winserver2022-ps/scheduledtasks/Register-ScheduledTask.md
@@ -342,7 +342,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docset/winserver2022-ps/scheduledtasks/Register-ScheduledTask.md
+++ b/docset/winserver2022-ps/scheduledtasks/Register-ScheduledTask.md
@@ -110,7 +110,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -342,7 +342,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 

--- a/docset/winserver2022-ps/smbshare/Grant-SmbShareAccess.md
+++ b/docset/winserver2022-ps/smbshare/Grant-SmbShareAccess.md
@@ -116,7 +116,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -281,4 +281,3 @@ This cmdlet returns a **MSFT_SmbShareAccessControlEntry** object.
 [Revoke-SmbShareAccess](./Revoke-SmbShareAccess.md)
 
 [Unblock-SmbShareAccess](./Unblock-SmbShareAccess.md)
-

--- a/docset/winserver2022-ps/smbshare/Remove-SmbComponent.md
+++ b/docset/winserver2022-ps/smbshare/Remove-SmbComponent.md
@@ -21,7 +21,7 @@ Remove-SmbComponent [-Name] <String[]> [-CimSession <CimSession[]>] [-ThrottleLi
 ```
 
 ## DESCRIPTION
-The Remove-SmbComponent cmdlet removes SMB1 components. SMB1 is a deprecated and unsafe protocol that’s no longer installed by default in most versions of Windows and Windows Server. For more information, review [SMBv1 is not installed by default in Windows 10 version 1709, Windows Server version 1709, and later versions](https://docs.microsoft.com/windows-server/storage/file-server/troubleshoot/smbv1-not-installed-by-default-in-windows).
+The Remove-SmbComponent cmdlet removes SMB1 components. SMB1 is a deprecated and unsafe protocol that’s no longer installed by default in most versions of Windows and Windows Server. For more information, review [SMBv1 is not installed by default in Windows 10 version 1709, Windows Server version 1709, and later versions](/windows-server/storage/file-server/troubleshoot/smbv1-not-installed-by-default-in-windows).
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/storage/Enable-PhysicalDiskIdentification.md
+++ b/docset/winserver2022-ps/storage/Enable-PhysicalDiskIdentification.md
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -177,4 +177,3 @@ This cmdlet outputs an object that represents the physical disk for which you en
 ## RELATED LINKS
 
 [Disable-PhysicalDiskIdentification](./Disable-PhysicalDiskIdentification.md)
-

--- a/docset/winserver2022-ps/storage/Format-Volume.md
+++ b/docset/winserver2022-ps/storage/Format-Volume.md
@@ -147,7 +147,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -499,4 +499,3 @@ This cmdlet returns an object that represents the newly formatted volume.
 [Repair-Volume](./Repair-Volume.md)
 
 [Set-Volume](./Set-Volume.md)
-

--- a/docset/winserver2022-ps/storage/Get-Disk.md
+++ b/docset/winserver2022-ps/storage/Get-Disk.md
@@ -14,7 +14,7 @@ title: Get-Disk
 Gets one or more disks visible to the operating system.
 
 > [!NOTE]
-> This cmdlet returns physical disk objects like basic disks and partitioned drive partitions.  Dynamic disks can span multiple pieces of physical media, so they will not be returned by Get-Disk. For more information, see [Basic and Dynamic Disks](https://docs.microsoft.com/windows/desktop/FileIO/basic-and-dynamic-disks).
+> This cmdlet returns physical disk objects like basic disks and partitioned drive partitions.  Dynamic disks can span multiple pieces of physical media, so they will not be returned by Get-Disk. For more information, see [Basic and Dynamic Disks](/windows/desktop/FileIO/basic-and-dynamic-disks).
 
 ## SYNTAX
 
@@ -401,4 +401,3 @@ This cmdlet outputs one or more objects representing disks.
 [Set-Disk](./Set-Disk.md)
 
 [Update-Disk](./Update-Disk.md)
-

--- a/docset/winserver2022-ps/storage/Get-PhysicalDisk.md
+++ b/docset/winserver2022-ps/storage/Get-PhysicalDisk.md
@@ -119,7 +119,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -523,4 +523,3 @@ The Get-PhysicalDisk cmdlet returns objects that represent physical disks.
 [New-VirtualDisk](./New-VirtualDisk.md)
 
 [Get-StorageNode](./Get-StorageNode.md)
-

--- a/docset/winserver2022-ps/storage/Get-VirtualDisk.md
+++ b/docset/winserver2022-ps/storage/Get-VirtualDisk.md
@@ -624,7 +624,7 @@ You can use the pipeline operator to pass an MSFT_TargetVirtualDisk object to th
 ## OUTPUTS
 
 ### Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/Storage/MSFT_VirtualDisk
-This cmdlet outputs an object that represents the specified virtual disk. For more information about output object type, please see [MSFT_VirtualDisk class](https://docs.microsoft.com/previous-versions/windows/desktop/stormgmt/msft-virtualdisk)
+This cmdlet outputs an object that represents the specified virtual disk. For more information about output object type, please see [MSFT_VirtualDisk class](/previous-versions/windows/desktop/stormgmt/msft-virtualdisk)
 
 ## NOTES
 
@@ -655,4 +655,3 @@ This cmdlet outputs an object that represents the specified virtual disk. For mo
 [Set-VirtualDisk](./Set-VirtualDisk.md)
 
 [Show-VirtualDisk](./Show-VirtualDisk.md)
-

--- a/docset/winserver2022-ps/storage/Get-VirtualDisk.md
+++ b/docset/winserver2022-ps/storage/Get-VirtualDisk.md
@@ -624,7 +624,7 @@ You can use the pipeline operator to pass an MSFT_TargetVirtualDisk object to th
 ## OUTPUTS
 
 ### Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/Storage/MSFT_VirtualDisk
-This cmdlet outputs an object that represents the specified virtual disk. For more information about output object type, please see [MSFT_VirtualDisk class](/previous-versions/windows/desktop/stormgmt/msft-virtualdisk)
+This cmdlet outputs an object that represents the specified virtual disk. For more information about output object type, see [MSFT_VirtualDisk class](/previous-versions/windows/desktop/stormgmt/msft-virtualdisk).
 
 ## NOTES
 

--- a/docset/winserver2022-ps/tls/Get-TlsCipherSuite.md
+++ b/docset/winserver2022-ps/tls/Get-TlsCipherSuite.md
@@ -24,7 +24,7 @@ The **Get-TlsCipherSuite** cmdlet gets an ordered collection of cipher suites fo
 
 For more information about the TLS cipher suites, see the documentation for the Enable-TlsCipherSuite cmdlet or type `Get-Help Enable-TlsCipherSuite`.
 
-For more information about protocol versions , see [BCRYPT_KDF_TLS_PRF (L"TLS_PRF")](/windows/desktop/api/bcrypt/nf-bcrypt-bcryptderivekey#bcrypt_kdf_tls_prf-ltls_prf) .
+For more information about protocol versions , see [BCRYPT_KDF_TLS_PRF (L"TLS_PRF")](/windows/desktop/api/bcrypt/nf-bcrypt-bcryptderivekey#bcrypt_kdf_tls_prf-ltls_prf).
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/tls/Get-TlsCipherSuite.md
+++ b/docset/winserver2022-ps/tls/Get-TlsCipherSuite.md
@@ -24,7 +24,7 @@ The **Get-TlsCipherSuite** cmdlet gets an ordered collection of cipher suites fo
 
 For more information about the TLS cipher suites, see the documentation for the Enable-TlsCipherSuite cmdlet or type `Get-Help Enable-TlsCipherSuite`.
 
-For more information about protocol versions , see [BCRYPT_KDF_TLS_PRF (L"TLS_PRF")](https://docs.microsoft.com/windows/desktop/api/bcrypt/nf-bcrypt-bcryptderivekey#bcrypt_kdf_tls_prf-ltls_prf) .
+For more information about protocol versions , see [BCRYPT_KDF_TLS_PRF (L"TLS_PRF")](/windows/desktop/api/bcrypt/nf-bcrypt-bcryptderivekey#bcrypt_kdf_tls_prf-ltls_prf) .
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/updateservices/Add-WsusDynamicCategory.md
+++ b/docset/winserver2022-ps/updateservices/Add-WsusDynamicCategory.md
@@ -38,7 +38,7 @@ In order to transfer dynamic categories from one update server to another, pass 
 
 This cmdlet is used to add Dynamic Categories to WSUS, based on the type of requirement (computer model, device or application). The definition of Dynamic Categories in a WSUS implementation helps to categorize the applying of updates to the different categories available.
 
-In some cases, you need advanced automation when using Dynamic Categories. If you want to download a specific device driver for a specific group of computers in the physical network, for example, advanced automation is required to use Dynamic Categories. In this case, the use of [Microsoft Endpoint Configuration Manager](https://docs.microsoft.com/configmgr/) is needed to [install and configure a software update point](https://docs.microsoft.com/configmgr/sum/get-started/install-a-software-update-point) feature.
+In some cases, you need advanced automation when using Dynamic Categories. If you want to download a specific device driver for a specific group of computers in the physical network, for example, advanced automation is required to use Dynamic Categories. In this case, the use of [Microsoft Endpoint Configuration Manager](/configmgr/) is needed to [install and configure a software update point](/configmgr/sum/get-started/install-a-software-update-point) feature.
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/vpnclient/Add-VpnConnection.md
+++ b/docset/winserver2022-ps/vpnclient/Add-VpnConnection.md
@@ -157,7 +157,7 @@ PS C:\> $EAPXml = [xml]Get-Content -Path C:\eap-config.xml
 PS C:\> Add-VpnConnection -Name "Test6" -ServerAddress "10.1.1.1" -TunnelType "L2tp" -EncryptionLevel "Required" -AuthenticationMethod Eap -SplitTunneling -AllUserConnection -RememberCredential -EapConfigXmlStream $EAPXml
 ```
 
-This set of commands adds a VPN connection using an already generated EAP XML configuration. For more information about how to generate EAP XML configuration, see [EAP Configuration](https://docs.microsoft.com/windows/client-management/mdm/eap-configuration).
+This set of commands adds a VPN connection using an already generated EAP XML configuration. For more information about how to generate EAP XML configuration, see [EAP Configuration](/windows/client-management/mdm/eap-configuration).
 
 ## PARAMETERS
 
@@ -574,4 +574,3 @@ This cmdlet returns a **VpnConnection** object that contains the VPN connection 
 [Remove-VpnConnection](./Remove-VpnConnection.md)
 
 [New-EapConfiguration](./New-EapConfiguration.md)
-

--- a/docset/winserver2022-ps/vpnclient/New-EapConfiguration.md
+++ b/docset/winserver2022-ps/vpnclient/New-EapConfiguration.md
@@ -64,8 +64,8 @@ PS C:\> $A = New-EapConfiguration -UseWinlogonCredential
 This command creates an EAP configuration object, customized by the *UseWinlogonCredential* parameter, and stores it in the variable named $A.
 By specifying the *UseWinlogonCredential* parameter, the EAP configuration object is configured to use MSCHAPv2 as the authentication method, and that Windows logon credentials are used automatically when connecting with the VPN connection profile.
 
-See [VPN authentication options](https://docs.microsoft.com/windows/security/identity-protection/vpn/vpn-authentication) 
-and [Add connectivity profiles](https://docs.microsoft.com/windows/configuration/wcd/wcd-connectivityprofiles#vpn-1) to learn more about VPN authentication methods.
+See [VPN authentication options](/windows/security/identity-protection/vpn/vpn-authentication) 
+and [Add connectivity profiles](/windows/configuration/wcd/wcd-connectivityprofiles#vpn-1) to learn more about VPN authentication methods.
 
 ### Example 3: Create a TLS customized EAP configuration object
 ```
@@ -416,4 +416,3 @@ This cmdlet returns a **VpnConnection** object that contains the VPN connection 
 [Add-VpnConnection](./Add-VpnConnection.md)
 
 [Set-VpnConnection](./Set-VpnConnection.md)
-

--- a/docset/winserver2022-ps/vpnclient/Set-VpnConnectionProxy.md
+++ b/docset/winserver2022-ps/vpnclient/Set-VpnConnectionProxy.md
@@ -108,7 +108,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/docset/winserver2022-ps/webadministration/Get-WebApplication.md
+++ b/docset/winserver2022-ps/webadministration/Get-WebApplication.md
@@ -84,4 +84,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-WebApplication](./Remove-WebApplication.md)
 
-[Microsoft.Web.Administration.ConfigurationElement#Application](https://docs.microsoft.com/dotnet/api/microsoft.web.administration.application?view=iis-dotnet)
+[Microsoft.Web.Administration.ConfigurationElement#Application](/dotnet/api/microsoft.web.administration.application?view=iis-dotnet)

--- a/docset/winserver2022-ps/webadministration/New-WebAppPool.md
+++ b/docset/winserver2022-ps/webadministration/New-WebAppPool.md
@@ -20,7 +20,7 @@ New-WebAppPool [-Name] <String> [-Force] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **New-WebAppPool** cmdlet creates an Internet Information Services (IIS) application pool. For changing different properties of the application pool after creation, see [PowerShell Snap-in: Making Configuration Changes to Websites and App Pools](https://docs.microsoft.com/iis/manage/powershell/powershell-snap-in-making-simple-configuration-changes-to-web-sites-and-application-pools).
+The **New-WebAppPool** cmdlet creates an Internet Information Services (IIS) application pool. For changing different properties of the application pool after creation, see [PowerShell Snap-in: Making Configuration Changes to Websites and App Pools](/iis/manage/powershell/powershell-snap-in-making-simple-configuration-changes-to-web-sites-and-application-pools).
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/webapplicationproxy/Set-WebApplicationProxyConfiguration.md
+++ b/docset/winserver2022-ps/webapplicationproxy/Set-WebApplicationProxyConfiguration.md
@@ -135,7 +135,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -298,4 +298,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Get-WebApplicationProxyConfiguration](./Get-WebApplicationProxyConfiguration.md)
-

--- a/docset/winserver2022-ps/windowserrorreporting/Disable-WindowsErrorReporting.md
+++ b/docset/winserver2022-ps/windowserrorreporting/Disable-WindowsErrorReporting.md
@@ -27,7 +27,7 @@ Windows Error Reporting generates reports in response to system events, such as 
 
 To get the current WER status, use the [Get-WindowsErrorReporting](./Get-WindowsErrorReporting.md) cmdlet.
 If you disable WER, you can use the [Enable-WindowsErrorReporting](./Enable-WindowsErrorReporting.md) cmdlet to re-enable it.
-After you run this cmdlet, WER again sends information about application failures to Microsoft. To customize the settings of Windows Error Reporting, use registry keys described in [WER Settings](/windows/desktop/wer/wer-settings) article.
+After you run this cmdlet, WER again sends information about application failures to Microsoft. To customize the settings of Windows Error Reporting, use registry keys described in the [WER Settings](/windows/desktop/wer/wer-settings) article.
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/windowserrorreporting/Disable-WindowsErrorReporting.md
+++ b/docset/winserver2022-ps/windowserrorreporting/Disable-WindowsErrorReporting.md
@@ -27,7 +27,7 @@ Windows Error Reporting generates reports in response to system events, such as 
 
 To get the current WER status, use the [Get-WindowsErrorReporting](./Get-WindowsErrorReporting.md) cmdlet.
 If you disable WER, you can use the [Enable-WindowsErrorReporting](./Enable-WindowsErrorReporting.md) cmdlet to re-enable it.
-After you run this cmdlet, WER again sends information about application failures to Microsoft. To customize the settings of Windows Error Reporting, use registry keys described in [WER Settings](https://docs.microsoft.com/windows/desktop/wer/wer-settings) article.
+After you run this cmdlet, WER again sends information about application failures to Microsoft. To customize the settings of Windows Error Reporting, use registry keys described in [WER Settings](/windows/desktop/wer/wer-settings) article.
 
 ## EXAMPLES
 
@@ -58,4 +58,3 @@ Otherwise, it returns $False.
 [Enable-WindowsErrorReporting](./Enable-WindowsErrorReporting.md)
 
 [Get-WindowsErrorReporting](./Get-WindowsErrorReporting.md)
-


### PR DESCRIPTION
**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
