### PR TITLE
Update Install-ADDSDomainController.md

### DIFF
--- a/docset/winserver2016-ps/addsdeployment/Install-ADDSDomainController.md
+++ b/docset/winserver2016-ps/addsdeployment/Install-ADDSDomainController.md
@@ -345,7 +345,7 @@ Accept wildcard characters: False
 ```
 
 ### -LogPath
-Specifies the fully qualified, non-UNC path to a directory on a fixed disk of the local computer that will contain the domain log files, for example, `C:\Windows\Logs`.
+Specifies the fully qualified, non-UNC path to a directory on a fixed disk of the local computer that will contain the domain log files, for example, `C:\Windows\NTDS`.
 The default is `%SYSTEMROOT%\NTDS`.
 
 ```yaml


### PR DESCRIPTION
Modifying example in "-LogPath" as it could cause DCPromo to fail as directory is non-empty, DCPromo needs to empty it out and permissions may prevent this operation. Sysvol and Database paths both use their full path defaults as examples in this document, so proposing the same for the Log directory.