### PR TITLE
SmbShare module new compression parameters

### DIFF
--- a/docset/winserver2022-ps/smbshare/New-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbShare.md
@@ -66,14 +66,15 @@ This command creates an encrypted SMB share.
 $Parameters = @{
     Name = 'VMSFiles'
     Path = 'C:\ClusterStorage\Volume1\VMFiles'
-    ChangeAccess = 'Users'
+    ChangeAccess = 'CONTOSO\Finance Users','CONTOSO\HR Users'
     FullAccess = 'Administrators'
 }
 New-SmbShare @Parameters
 ```
 
-This command creates an SMB share named `VMSFiles` and grants Change permissions to the local
-`Users` group, and Full Access permissions to the local `Administrators` group.
+This command creates an SMB share named `VMSFiles` and grants Change permissions to the domain
+groups `CONTOSO\Finance Users` and `CONTOSO\HR Users`. Full Access permissions to the builtin
+`Administrators` group.
 
 This example uses splatting to pass parameter values from the `$Parameters` variable to the command.
 Learn more about [Splatting](/powershell/module/microsoft.powershell.core/about/about_splatting).
@@ -160,7 +161,8 @@ Accept wildcard characters: False
 ### -ChangeAccess
 
 Specifies which users are granted modify permission to access the share. Multiple users can be
-specified by using a comma-separated list.
+specified by using a comma-separated list. Each entry in the comma-separated list must be contained
+within single or double quotes, for example `'CONTOSO\Finance Users','CONTOSO\HR Users'`.
 
 ```yaml
 Type: String[]
@@ -306,10 +308,12 @@ Accept wildcard characters: False
 ### -FullAccess
 
 Specifies which accounts are granted full permission to access the share. Use a comma-separated list
-to specify multiple accounts. An account may not be specified more than once in the **FullAccess**,
-**ChangeAccess**, or **ReadAccess** parameter lists, but may be specified once in the
-**FullAccess**, **ChangeAccess**, or **ReadAccess** parameter list and once in the **NoAccess**
-parameter list.
+to specify multiple accounts. Each entry in the comma-separated list must be contained within single
+or double quotes, for example `'CONTOSO\Finance Users','CONTOSO\HR Users'`.
+
+An account may not be specified more than once in the **FullAccess**, **ChangeAccess**, or
+**ReadAccess** parameter lists, but may be specified once in the **FullAccess**, **ChangeAccess**,
+or **ReadAccess** parameter list and once in the **NoAccess** parameter list.
 
 ```yaml
 Type: String[]
@@ -365,8 +369,9 @@ Accept wildcard characters: False
 
 ### -NoAccess
 
-Specifies which accounts are denied access to the SMB share.
-Multiple accounts can be specified by supplying a comma-separated list.
+Specifies which accounts are denied access to the SMB share. Multiple accounts can be specified by
+supplying a comma-separated list. Each entry in the comma-separated list must be contained within
+single or double quotes, for example `'CONTOSO\Finance Users','CONTOSO\HR Users'`.
 
 ```yaml
 Type: String[]
@@ -399,8 +404,9 @@ Accept wildcard characters: False
 
 ### -ReadAccess
 
-Specifies which users are granted read permission to access the share.
-Multiple users can be specified by supplying a comma-separated list.
+Specifies which users are granted read permission to access the share. Multiple users can be
+specified by supplying a comma-separated list. Each entry in the comma-separated list must be
+contained within single or double quotes, for example `'CONTOSO\Finance Users','CONTOSO\HR Users'`.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2022-ps/smbshare/New-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbShare.md
@@ -17,16 +17,17 @@ Creates an SMB share.
 
 ```
 New-SmbShare [-Temporary] [-ContinuouslyAvailable <Boolean>] [-Description <String>]
-[-ConcurrentUserLimit <UInt32>] [-CATimeout <UInt32>]
-[-FolderEnumerationMode <FolderEnumerationMode>] [-CachingMode <CachingMode>]
-[-FullAccess <String[]>] [-ChangeAccess <String[]>] [-ReadAccess <String[]>] [-NoAccess <String[]>]
-[-SecurityDescriptor <String>] [-Path] <String> [-Name] <String> [[-ScopeName] <String>]
-[-EncryptData <Boolean>] [-CompressData <Boolean>] [-LeasingMode <LeasingMode>]
-[-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
-[<CommonParameters>]
+ [-ConcurrentUserLimit <UInt32>] [-CATimeout <UInt32>]
+ [-FolderEnumerationMode <FolderEnumerationMode>] [-CachingMode <CachingMode>]
+ [-FullAccess <String[]>] [-ChangeAccess <String[]>] [-ReadAccess <String[]>] [-NoAccess <String[]>]
+ [-SecurityDescriptor <String>] [-Path] <String> [-Name] <String> [[-ScopeName] <String>]
+ [-EncryptData <Boolean>] [-CompressData <Boolean>] [-LeasingMode <LeasingMode>]
+ [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 The `New-SmbShare` cmdlet exposes a file system folder to remote clients as a Server Message Block
 (SMB) share.
 
@@ -35,6 +36,7 @@ To delete a share that was created by this cmdlet, use the `Remove-SmbShare` cmd
 ## EXAMPLES
 
 ### Example 1: Create an SMB share
+
 ```powershell
 $Parameters = @{
     Name = 'VMSFiles'
@@ -51,6 +53,7 @@ This example uses splatting to pass parameter values from the `$Parameters` vari
 Learn more about [Splatting](/powershell/module/microsoft.powershell.core/about/about_splatting).
 
 ### Example 2: Create an encrypted SMB share
+
 ```powershell
 New-SmbShare -Name "Data" -Path "J:\Data" -EncryptData $True
 ```
@@ -58,6 +61,7 @@ New-SmbShare -Name "Data" -Path "J:\Data" -EncryptData $True
 This command creates an encrypted SMB share.
 
 ### Example 3: Create an SMB share with Multiple Permissions
+
 ```powershell
 $Parameters = @{
     Name = 'VMSFiles'
@@ -77,6 +81,7 @@ Learn more about [Splatting](/powershell/module/microsoft.powershell.core/about/
 ## PARAMETERS
 
 ### -AsJob
+
 Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
 complete.
 
@@ -93,6 +98,7 @@ Accept wildcard characters: False
 ```
 
 ### -CATimeout
+
 Specifies the continuous availability time-out for the share.
 
 ```yaml
@@ -108,6 +114,7 @@ Accept wildcard characters: False
 ```
 
 ### -CachingMode
+
 Specifies the caching mode of the offline files for the SMB share. There are five caching modes:
 
 - None.
@@ -135,6 +142,7 @@ Accept wildcard characters: False
 ```
 
 ### -CATimeout
+
 Specifies the continuous availability time-out for the share.
 
 ```yaml
@@ -150,6 +158,7 @@ Accept wildcard characters: False
 ```
 
 ### -ChangeAccess
+
 Specifies which users are granted modify permission to access the share. Multiple users can be
 specified by using a comma-separated list.
 
@@ -166,6 +175,7 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
+
 Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
 object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967)
 or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the
@@ -184,6 +194,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompressData
+
 Indicates that SMB compression is requested for all client connections that support it.
 
 ```yaml
@@ -199,6 +210,7 @@ Accept wildcard characters: False
 ```
 
 ### -ConcurrentUserLimit
+
 Specifies the maximum number of concurrently connected users that the new SMB share may accommodate.
 If this parameter is set to zero (0), then the number of users is unlimited. The default value is
 zero (0).
@@ -216,6 +228,7 @@ Accept wildcard characters: False
 ```
 
 ### -ContinuouslyAvailable
+
 Indicates that the share is continuously available.
 
 ```yaml
@@ -231,6 +244,7 @@ Accept wildcard characters: False
 ```
 
 ### -Description
+
 Specifies an optional description of the SMB share. A description of the share is displayed by
 running the Get-SmbShare cmdlet. The description may not contain more than 256 characters. The
 default value no description, or an empty description.
@@ -248,6 +262,7 @@ Accept wildcard characters: False
 ```
 
 ### -EncryptData
+
 Indicates that the share is encrypted.
 
 ```yaml
@@ -263,13 +278,14 @@ Accept wildcard characters: False
 ```
 
 ### -FolderEnumerationMode
+
 Specifies which files and folders in the SMB share are visible to users. The acceptable values for
 this parameter are:
 
-- AccessBased. SMB does not display the files and folders for a share to a user unless that user has
+- AccessBased. SMB doesn't display the files and folders for a share to a user unless that user has
   rights to access the files and folders. By default, access-based enumeration is disabled for new
   SMB shares.
-- Unrestricted. SMB displays files and folders to a user even when the user does not have permission
+- Unrestricted. SMB displays files and folders to a user even when the user doesn't have permission
   to access the items.
 
 The default value is Unrestricted.
@@ -288,6 +304,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullAccess
+
 Specifies which accounts are granted full permission to access the share. Use a comma-separated list
 to specify multiple accounts. An account may not be specified more than once in the **FullAccess**,
 **ChangeAccess**, or **ReadAccess** parameter lists, but may be specified once in the
@@ -328,9 +345,11 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies a name for the SMB share. The name may be composed of any valid file name characters, but
-must be less than 80 characters long. The names `pipe` and `mailslot` are reserved for use by the
-computer.
+
+Specifies a name for the SMB share. The names `pipe` and `mailslot` are reserved for use by the
+computer. Share names can be up to a maximum of 80 characters long. The SMB share name can use any
+character allowed by Windows for files and directories, to learn more about naming conventions for
+files read the [Naming Files, Paths, and Namespaces](/windows/win32/fileio/naming-a-file) articles.
 
 ```yaml
 Type: String
@@ -345,6 +364,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoAccess
+
 Specifies which accounts are denied access to the SMB share.
 Multiple accounts can be specified by supplying a comma-separated list.
 
@@ -361,9 +381,10 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies the path of the location of the folder to share.
 The path must be fully qualified.
-Relative paths or paths that contain wildcard characters are not permitted.
+Relative paths or paths that contain wildcard characters aren't permitted.
 
 ```yaml
 Type: String
@@ -378,6 +399,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReadAccess
+
 Specifies which users are granted read permission to access the share.
 Multiple users can be specified by supplying a comma-separated list.
 
@@ -394,6 +416,7 @@ Accept wildcard characters: False
 ```
 
 ### -ScopeName
+
 Specifies the scope name of the share.
 
 ```yaml
@@ -409,6 +432,7 @@ Accept wildcard characters: False
 ```
 
 ### -SecurityDescriptor
+
 Specifies the security descriptor for the SMB share in string format.
 
 ```yaml
@@ -424,8 +448,9 @@ Accept wildcard characters: False
 ```
 
 ### -Temporary
+
 Specifies the lifetime of the new SMB share.
-A temporary share does not persist beyond the next restart of the computer.
+A temporary share doesn't persist beyond the next restart of the computer.
 By default, new SMB shares are persistent, and non-temporary.
 
 ```yaml
@@ -441,6 +466,7 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
+
 Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
 this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an
 optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
@@ -460,6 +486,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -475,10 +502,11 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
 
-NOTE: The WhatIf switch does not work with this cmdlet.
+Shows what would happen if the cmdlet runs.
+The cmdlet isn't run.
+
+NOTE: The WhatIf switch doesn't work with this cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -493,6 +521,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see
@@ -505,6 +534,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/SMB/MSFT_SmbShare
+
 The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays
 Windows Management Instrumentation (WMI) objects. The path after the pound sign (`#`) provides the
 namespace and class name for the underlying WMI object. This cmdlet returns a **MSFT_SmbShare**

--- a/docset/winserver2022-ps/smbshare/New-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbShare.md
@@ -20,8 +20,8 @@ New-SmbShare [-Temporary] [-ContinuouslyAvailable <Boolean>] [-Description <Stri
  [-ConcurrentUserLimit <UInt32>] [-CATimeout <UInt32>] [-FolderEnumerationMode <FolderEnumerationMode>]
  [-CachingMode <CachingMode>] [-FullAccess <String[]>] [-ChangeAccess <String[]>] [-ReadAccess <String[]>]
  [-NoAccess <String[]>] [-SecurityDescriptor <String>] [-Path] <String> [-Name] <String>
- [[-ScopeName] <String>] [-EncryptData <Boolean>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
- [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-ScopeName] <String>] [-EncryptData <Boolean>] [-CompressData <Boolean>] [-LeasingMode <LeasingMode>]
+ [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/docset/winserver2022-ps/smbshare/New-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbShare.md
@@ -247,7 +247,7 @@ Accept wildcard characters: False
 
 Specifies an optional description of the SMB share. A description of the share is displayed by
 running the `Get-SmbShare` cmdlet. The description may not contain more than 256 characters. The
-default value no description, or an empty description.
+default value is no description or an empty description.
 
 ```yaml
 Type: String
@@ -282,13 +282,13 @@ Accept wildcard characters: False
 Specifies which files and folders in the SMB share are visible to users. The acceptable values for
 this parameter are:
 
-- AccessBased. SMB doesn't display the files and folders for a share to a user unless that user has
-  rights to access the files and folders. By default, access-based enumeration is disabled for new
-  SMB shares.
-- Unrestricted. SMB displays files and folders to a user even when the user doesn't have permission
-  to access the items.
+- `AccessBased`. SMB doesn't display the files and folders for a share to a user unless that user
+  has rights to access the files and folders. By default, access-based enumeration is disabled for
+  new SMB shares.
+- `Unrestricted`. SMB displays files and folders to a user even when the user doesn't have
+  permission to access the items.
 
-The default value is Unrestricted.
+The default value is `Unrestricted`.
 
 ```yaml
 Type: FolderEnumerationMode
@@ -348,7 +348,7 @@ Accept wildcard characters: False
 
 Specifies a name for the SMB share. The names `pipe` and `mailslot` are reserved for use by the
 computer. Share names can be up to a maximum of 80 characters long. The SMB share name can use any
-character allowed by Windows for files and directories, to learn more about naming conventions for
+character allowed by Windows for files and directories. To learn more about naming conventions for
 files read the [Naming Files, Paths, and Namespaces](/windows/win32/fileio/naming-a-file) articles.
 
 ```yaml
@@ -382,8 +382,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path of the location of the folder to share.
-The path must be fully qualified.
+Specifies the path of the location of the folder to share. The path must be fully qualified.
 Relative paths or paths that contain wildcard characters aren't permitted.
 
 ```yaml
@@ -468,7 +467,7 @@ Accept wildcard characters: False
 ### -ThrottleLimit
 
 Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
-this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
 optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
 computer. The throttle limit applies only to the current cmdlet, not to the session or to the
 computer.
@@ -535,7 +534,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/SMB/MSFT_SmbShare
 
-The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays
+The **Microsoft.Management.Infrastructure.CimInstance** object is a wrapper class that displays
 Windows Management Instrumentation (WMI) objects. The path after the pound sign (`#`) provides the
 namespace and class name for the underlying WMI object. This cmdlet returns a **MSFT_SmbShare**
 object that represents the SMB share.

--- a/docset/winserver2022-ps/smbshare/New-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbShare.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbShare.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 12/20/2016
+ms.date: 10/20/2022
 online version: https://learn.microsoft.com/powershell/module/smbshare/new-smbshare?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-SmbShare
@@ -246,7 +246,7 @@ Accept wildcard characters: False
 ### -Description
 
 Specifies an optional description of the SMB share. A description of the share is displayed by
-running the Get-SmbShare cmdlet. The description may not contain more than 256 characters. The
+running the `Get-SmbShare` cmdlet. The description may not contain more than 256 characters. The
 default value no description, or an empty description.
 
 ```yaml

--- a/docset/winserver2022-ps/smbshare/New-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbShare.md
@@ -510,7 +510,8 @@ Accept wildcard characters: False
 Shows what would happen if the cmdlet runs.
 The cmdlet isn't run.
 
-NOTE: The **WhatIf** switch doesn't work with this cmdlet.
+> [!NOTE]
+> The **WhatIf** switch doesn't work with this cmdlet.
 
 ```yaml
 Type: SwitchParameter

--- a/docset/winserver2022-ps/smbshare/New-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbShare.md
@@ -17,56 +17,68 @@ Creates an SMB share.
 
 ```
 New-SmbShare [-Temporary] [-ContinuouslyAvailable <Boolean>] [-Description <String>]
- [-ConcurrentUserLimit <UInt32>] [-CATimeout <UInt32>] [-FolderEnumerationMode <FolderEnumerationMode>]
- [-CachingMode <CachingMode>] [-FullAccess <String[]>] [-ChangeAccess <String[]>] [-ReadAccess <String[]>]
- [-NoAccess <String[]>] [-SecurityDescriptor <String>] [-Path] <String> [-Name] <String>
- [[-ScopeName] <String>] [-EncryptData <Boolean>] [-CompressData <Boolean>] [-LeasingMode <LeasingMode>]
- [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-ConcurrentUserLimit <UInt32>] [-CATimeout <UInt32>]
+[-FolderEnumerationMode <FolderEnumerationMode>] [-CachingMode <CachingMode>]
+[-FullAccess <String[]>] [-ChangeAccess <String[]>] [-ReadAccess <String[]>] [-NoAccess <String[]>]
+[-SecurityDescriptor <String>] [-Path] <String> [-Name] <String> [[-ScopeName] <String>]
+[-EncryptData <Boolean>] [-CompressData <Boolean>] [-LeasingMode <LeasingMode>]
+[-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
+[<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **New-SmbShare** cmdlet exposes a file system folder to remote clients as a Server Message Block (SMB) share.
+The `New-SmbShare` cmdlet exposes a file system folder to remote clients as a Server Message Block
+(SMB) share.
 
-To delete a share that was created by this cmdlet, use the Remove-SmbShare cmdlet.
+To delete a share that was created by this cmdlet, use the `Remove-SmbShare` cmdlet.
 
 ## EXAMPLES
 
 ### Example 1: Create an SMB share
-```
-PS C:\>New-SmbShare -Name "VMSFiles" -Path "C:\ClusterStorage\Volume1\VMFiles" -FullAccess "Contoso\Administrator", "Contoso\Contoso-HV1$"
-Name                          ScopeName                     Path                          Description
-----                          ---------                     ----                          -----------
-VMSFiles                      Contoso-SO                    C:\ClusterStorage\Volume1\...
+```powershell
+$Parameters = @{
+    Name = 'VMSFiles'
+    Path = 'C:\ClusterStorage\Volume1\VMFiles'
+    FullAccess = 'Contoso\Administrator', 'Contoso\Contoso-HV1$'
+}
+New-SmbShare @Parameters
 ```
 
-This command creates an SMB share named "VMSFiles" and grants Full Access permissions to "Contoso\Administrator", and "Contoso\Contoso-HV1$".
+This command creates an SMB share named `VMSFiles` and grants Full Access permissions to
+`Contoso\Administrator`, and `Contoso\Contoso-HV1$`.
+
+This example uses splatting to pass parameter values from the `$Parameters` variable to the command.
+Learn more about [Splatting](/powershell/module/microsoft.powershell.core/about/about_splatting).
 
 ### Example 2: Create an encrypted SMB share
-```
-PS C:\>New-SmbShare -Name "Data" -Path "J:\Data" -EncryptData $True
-Name                          ScopeName                     Path                          Description
-----                          ---------                     ----                          -----------
-Data                          Contoso-FS                    J:\Data
+```powershell
+New-SmbShare -Name "Data" -Path "J:\Data" -EncryptData $True
 ```
 
 This command creates an encrypted SMB share.
 
 ### Example 3: Create an SMB share with Multiple Permissions
+```powershell
+$Parameters = @{
+    Name = 'VMSFiles'
+    Path = 'C:\ClusterStorage\Volume1\VMFiles'
+    ChangeAccess = 'Users'
+    FullAccess = 'Administrators'
+}
+New-SmbShare @Parameters
 ```
-PS C:\>New-SmbShare -Name "VMSFiles" -Path "C:\ClusterStorage\Volume1\VMFiles" -ChangeAccess "Users" -FullAccess "Administrators"
 
-Name                          ScopeName                     Path                          Description
-----                          ---------                     ----                          -----------
-VMSFiles                      Contoso-SO                    C:\ClusterStorage\Volume1\...
-```
+This command creates an SMB share named `VMSFiles` and grants Change permissions to the local
+`Users` group, and Full Access permissions to the local `Administrators` group.
 
-This command creates an SMB share named "VMSFiles" and grants Change permissions to the local "Users" group, and Full Access permissions to the local "Administrators" group.
-
+This example uses splatting to pass parameter values from the `$Parameters` variable to the command.
+Learn more about [Splatting](/powershell/module/microsoft.powershell.core/about/about_splatting).
 
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
 
 ```yaml
 Type: SwitchParameter
@@ -96,8 +108,7 @@ Accept wildcard characters: False
 ```
 
 ### -CachingMode
-Specifies the caching mode of the offline files for the SMB share.
-There are five caching modes:
+Specifies the caching mode of the offline files for the SMB share. There are five caching modes:
 
 - None.
 Prevents users from storing documents and programs offline.
@@ -139,8 +150,8 @@ Accept wildcard characters: False
 ```
 
 ### -ChangeAccess
-Specifies which users are granted modify permission to access the share.
-Multiple users can be specified by using a comma-separated list.
+Specifies which users are granted modify permission to access the share. Multiple users can be
+specified by using a comma-separated list.
 
 ```yaml
 Type: String[]
@@ -155,9 +166,10 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
-The default is the current session on the local computer.
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967)
+or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -188,8 +200,8 @@ Accept wildcard characters: False
 
 ### -ConcurrentUserLimit
 Specifies the maximum number of concurrently connected users that the new SMB share may accommodate.
-If this parameter is set to zero (0), then the number of users is unlimited.
-The default value is zero (0).
+If this parameter is set to zero (0), then the number of users is unlimited. The default value is
+zero (0).
 
 ```yaml
 Type: UInt32
@@ -219,10 +231,9 @@ Accept wildcard characters: False
 ```
 
 ### -Description
-Specifies an optional description of the SMB share.
-A description of the share is displayed by running the Get-SmbShare cmdlet.
-The description may not contain more than 256 characters.
-The default value no description, or an empty description.
+Specifies an optional description of the SMB share. A description of the share is displayed by
+running the Get-SmbShare cmdlet. The description may not contain more than 256 characters. The
+default value no description, or an empty description.
 
 ```yaml
 Type: String
@@ -252,14 +263,14 @@ Accept wildcard characters: False
 ```
 
 ### -FolderEnumerationMode
-Specifies which files and folders in the SMB share are visible to users.
-The acceptable values for this parameter are:
+Specifies which files and folders in the SMB share are visible to users. The acceptable values for
+this parameter are:
 
-- AccessBased.
-SMB does not display the files and folders for a share to a user unless that user has rights to access the files and folders.
-By default, access-based enumeration is disabled for new SMB shares.
-- Unrestricted.
-SMB displays files and folders to a user even when the user does not have permission to access the items.
+- AccessBased. SMB does not display the files and folders for a share to a user unless that user has
+  rights to access the files and folders. By default, access-based enumeration is disabled for new
+  SMB shares.
+- Unrestricted. SMB displays files and folders to a user even when the user does not have permission
+  to access the items.
 
 The default value is Unrestricted.
 
@@ -277,9 +288,11 @@ Accept wildcard characters: False
 ```
 
 ### -FullAccess
-Specifies which accounts are granted full permission to access the share.
-Use a comma-separated list to specify multiple accounts.
-An account may not be specified more than once in the *FullAccess*, *ChangeAccess*, or *ReadAccess* parameter lists, but may be specified once in the *FullAccess*, *ChangeAccess*, or *ReadAccess* parameter list and once in the *NoAccess* parameter list.
+Specifies which accounts are granted full permission to access the share. Use a comma-separated list
+to specify multiple accounts. An account may not be specified more than once in the **FullAccess**,
+**ChangeAccess**, or **ReadAccess** parameter lists, but may be specified once in the
+**FullAccess**, **ChangeAccess**, or **ReadAccess** parameter list and once in the **NoAccess**
+parameter list.
 
 ```yaml
 Type: String[]
@@ -295,11 +308,12 @@ Accept wildcard characters: False
 
 ### -LeasingMode
 
-Specifies SMB leasing and oplock behaviors for application compatibility. The acceptable values for this parameter are: 
+Specifies SMB leasing and oplock behaviors for application compatibility. The acceptable values for
+this parameter are:
 
 - `Full:` Use default lease and oplock behaviors from SMB3.
 - `Shared:` Grant read-caching lease but not write or handle-caching.
-- `None:` = No oplocks or leases, behave like SMB1 (not recommended).
+- `None:` No oplocks or leases, behave like SMB1 (not recommended).
 
 ```yaml
 Type: LeasingMode
@@ -314,9 +328,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies a name for the SMB share.
-The name may be composed of any valid file name characters, but must be less than 80 characters long.
-The names `pipe` and `mailslot` are reserved for use by the computer.
+Specifies a name for the SMB share. The name may be composed of any valid file name characters, but
+must be less than 80 characters long. The names `pipe` and `mailslot` are reserved for use by the
+computer.
 
 ```yaml
 Type: String
@@ -427,9 +441,11 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-If this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
-The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
 
 ```yaml
 Type: Int32
@@ -477,7 +493,10 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -486,9 +505,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/SMB/MSFT_SmbShare
-The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays Windows Management Instrumentation (WMI) objects.
-The path after the pound sign (`#`) provides the namespace and class name for the underlying WMI object.
-This cmdlet returns a **MSFT_SmbShare** object that represents the SMB share.
+The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays
+Windows Management Instrumentation (WMI) objects. The path after the pound sign (`#`) provides the
+namespace and class name for the underlying WMI object. This cmdlet returns a **MSFT_SmbShare**
+object that represents the SMB share.
 
 ## NOTES
 

--- a/docset/winserver2022-ps/smbshare/New-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbShare.md
@@ -454,9 +454,8 @@ Accept wildcard characters: False
 
 ### -Temporary
 
-Specifies the lifetime of the new SMB share.
-A temporary share doesn't persist beyond the next restart of the computer.
-By default, new SMB shares are persistent, and non-temporary.
+Specifies the new SMB share is temporary and will not persist beyond the next restart of the
+computer. By default, new SMB shares aren't temporary.
 
 ```yaml
 Type: SwitchParameter
@@ -511,7 +510,7 @@ Accept wildcard characters: False
 Shows what would happen if the cmdlet runs.
 The cmdlet isn't run.
 
-NOTE: The WhatIf switch doesn't work with this cmdlet.
+NOTE: The **WhatIf** switch doesn't work with this cmdlet.
 
 ```yaml
 Type: SwitchParameter

--- a/docset/winserver2022-ps/smbshare/Reset-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Reset-SmbClientConfiguration.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbClientConfiguration.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 06/24/2022
+ms.date: 09/15/2022
 online version: http://go.microsoft.com/fwlink/?LinkID=241959
 schema: 2.0.0
 title: Reset-SmbClientConfiguration
@@ -34,10 +34,14 @@ The `Reset-SmbClientConfiguration` cmdlet resets SMB client configuration parame
 default values.
 
 > [!NOTE]
-> This cmdlet is available beginning with 2022-06 Cumulative Update for Microsoft server operating
+> - This cmdlet is available beginning with 2022-06 Cumulative Update for Microsoft server operating
 > system version 21H2 for x64-based Systems
 > ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
 > version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
+> - The **CompressibilitySampling** and **RequestCompression** parameters are available beginning
+> with 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based
+> Systems ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for
+> Windows 11, version 22H2 ([KB5016691](https://support.microsoft.com/help/5016691)).
 
 ## EXAMPLES
 
@@ -104,7 +108,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompressibilitySampling
-{{ Fill CompressibilitySampling Description }}
+Resets the compression sampling behavior.
 
 ```yaml
 Type: SwitchParameter
@@ -488,7 +492,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequestCompression
-{{ Fill RequestCompression Description }}
+Resets the SMB client request compression value to its default value.
 
 ```yaml
 Type: SwitchParameter

--- a/docset/winserver2022-ps/smbshare/Reset-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Reset-SmbClientConfiguration.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbClientConfiguration.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 09/15/2022
+ms.date: 10/20/2022
 online version: http://go.microsoft.com/fwlink/?LinkID=241959
 schema: 2.0.0
 title: Reset-SmbClientConfiguration

--- a/docset/winserver2022-ps/smbshare/Reset-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Reset-SmbClientConfiguration.md
@@ -40,9 +40,9 @@ default values.
 > version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
 >
 > - The **CompressibilitySampling** and **RequestCompression** parameters are available beginning
-> with 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based
-> Systems ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for
-> Windows 11, version 22H2 ([KB5016691](https://support.microsoft.com/help/5016691)).
+>   with 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based
+>   Systems ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for
+>   Windows 11, version 22H2 ([KB5016691](https://support.microsoft.com/help/5016691)).
 
 ## EXAMPLES
 
@@ -110,7 +110,7 @@ Accept wildcard characters: False
 
 ### -CompressibilitySampling
 
-Resets the compression sampling behavior.
+Resets the compression sampling behavior to its default value.
 
 ```yaml
 Type: SwitchParameter

--- a/docset/winserver2022-ps/smbshare/Reset-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Reset-SmbClientConfiguration.md
@@ -16,16 +16,16 @@ Resets the Server Message Block (SMB) client configuration parameters to their d
 ## SYNTAX
 
 ```
-Reset-SmbClientConfiguration [-All] [-ConnectionCountPerRssNetworkInterface]
- [-DirectoryCacheEntriesMax] [-DirectoryCacheEntrySizeMax] [-DirectoryCacheLifetime]
- [-DisableCompression] [-DormantFileLimit] [-EnableBandwidthThrottling]
- [-EnableByteRangeLockingOnReadOnlyFiles] [-EnableLargeMtu] [-EnableLoadBalanceScaleOut]
- [-EnableMultiChannel] [-EncryptionCiphers] [-ExtendedSessionTimeout] [-FileInfoCacheEntriesMax]
- [-FileInfoCacheLifetime] [-FileNotFoundCacheEntriesMax] [-FileNotFoundCacheLifetime]
- [-ForceSMBEncryptionOverQuic] [-KeepConn] [-MaxCmds] [-MaximumConnectionCountPerServer]
- [-OplocksDisabled] [-SessionTimeout] [-SkipCertificateCheck] [-UseOpportunisticLocking]
- [-WindowSizeThreshold] [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Reset-SmbClientConfiguration [-All] [-CompressibilitySampling]
+[-ConnectionCountPerRssNetworkInterface] [-DirectoryCacheEntriesMax] [-DirectoryCacheEntrySizeMax]
+[-DirectoryCacheLifetime] [-DisableCompression] [-DormantFileLimit] [-EnableBandwidthThrottling]
+[-EnableByteRangeLockingOnReadOnlyFiles] [-EnableLargeMtu] [-EnableLoadBalanceScaleOut]
+[-EnableMultiChannel] [-EncryptionCiphers] [-ExtendedSessionTimeout] [-FileInfoCacheEntriesMax]
+[-FileInfoCacheLifetime] [-FileNotFoundCacheEntriesMax] [-FileNotFoundCacheLifetime]
+[-ForceSMBEncryptionOverQuic] [-KeepConn] [-MaxCmds] [-MaximumConnectionCountPerServer]
+[-OplocksDisabled] [-RequestCompression] [-SessionTimeout] [-SkipCertificateCheck]
+[-UseOpportunisticLocking] [-WindowSizeThreshold] [-Force] [-CimSession <CimSession[]>]
+[-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -95,6 +95,21 @@ current session on the local computer.
 Type: CimSession[]
 Parameter Sets: (All)
 Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CompressibilitySampling
+{{ Fill CompressibilitySampling Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named
@@ -458,8 +473,22 @@ Accept wildcard characters: False
 ```
 
 ### -OplocksDisabled
-
 Resets the opportunistic locks disabled value to its default value.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequestCompression
+{{ Fill RequestCompression Description }}
 
 ```yaml
 Type: SwitchParameter

--- a/docset/winserver2022-ps/smbshare/Reset-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Reset-SmbClientConfiguration.md
@@ -17,15 +17,15 @@ Resets the Server Message Block (SMB) client configuration parameters to their d
 
 ```
 Reset-SmbClientConfiguration [-All] [-CompressibilitySampling]
-[-ConnectionCountPerRssNetworkInterface] [-DirectoryCacheEntriesMax] [-DirectoryCacheEntrySizeMax]
-[-DirectoryCacheLifetime] [-DisableCompression] [-DormantFileLimit] [-EnableBandwidthThrottling]
-[-EnableByteRangeLockingOnReadOnlyFiles] [-EnableLargeMtu] [-EnableLoadBalanceScaleOut]
-[-EnableMultiChannel] [-EncryptionCiphers] [-ExtendedSessionTimeout] [-FileInfoCacheEntriesMax]
-[-FileInfoCacheLifetime] [-FileNotFoundCacheEntriesMax] [-FileNotFoundCacheLifetime]
-[-ForceSMBEncryptionOverQuic] [-KeepConn] [-MaxCmds] [-MaximumConnectionCountPerServer]
-[-OplocksDisabled] [-RequestCompression] [-SessionTimeout] [-SkipCertificateCheck]
-[-UseOpportunisticLocking] [-WindowSizeThreshold] [-Force] [-CimSession <CimSession[]>]
-[-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ConnectionCountPerRssNetworkInterface] [-DirectoryCacheEntriesMax] [-DirectoryCacheEntrySizeMax]
+ [-DirectoryCacheLifetime] [-DisableCompression] [-DormantFileLimit] [-EnableBandwidthThrottling]
+ [-EnableByteRangeLockingOnReadOnlyFiles] [-EnableLargeMtu] [-EnableLoadBalanceScaleOut]
+ [-EnableMultiChannel] [-EncryptionCiphers] [-ExtendedSessionTimeout] [-FileInfoCacheEntriesMax]
+ [-FileInfoCacheLifetime] [-FileNotFoundCacheEntriesMax] [-FileNotFoundCacheLifetime]
+ [-ForceSMBEncryptionOverQuic] [-KeepConn] [-MaxCmds] [-MaximumConnectionCountPerServer]
+ [-OplocksDisabled] [-RequestCompression] [-SessionTimeout] [-SkipCertificateCheck]
+ [-UseOpportunisticLocking] [-WindowSizeThreshold] [-Force] [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,6 +38,7 @@ default values.
 > system version 21H2 for x64-based Systems
 > ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
 > version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
+>
 > - The **CompressibilitySampling** and **RequestCompression** parameters are available beginning
 > with 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based
 > Systems ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for
@@ -108,6 +109,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompressibilitySampling
+
 Resets the compression sampling behavior.
 
 ```yaml
@@ -477,6 +479,7 @@ Accept wildcard characters: False
 ```
 
 ### -OplocksDisabled
+
 Resets the opportunistic locks disabled value to its default value.
 
 ```yaml
@@ -492,6 +495,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequestCompression
+
 Resets the SMB client request compression value to its default value.
 
 ```yaml
@@ -609,7 +613,7 @@ Accept wildcard characters: False
 ### -WhatIf
 
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter

--- a/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbServerConfiguration.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 06/24/2022
+ms.date: 09/15/2022
 online version: http://go.microsoft.com/fwlink/?LinkID=241959
 schema: 2.0.0
 title: Reset-SmbServerConfiguration
@@ -39,10 +39,14 @@ default values. For more information on SMB server and protocol specifications, 
 and [[MS-SMB2]:Server Message Block (SMB) Protocol Versions 2 and3](/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962).
 
 > [!NOTE]
-> This cmdlet is available beginning with 2022-06 Cumulative Update for Microsoft server operating
+> - This cmdlet is available beginning with 2022-06 Cumulative Update for Microsoft server operating
 > system version 21H2 for x64-based Systems
 > ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
 > version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
+> - The **DisableCompression** and **RequestCompression** parameters are available beginning with
+> 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based Systems
+> ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for Windows 11,
+> version 22H2 ([KB5016691](https://support.microsoft.com/help/5016691)).
 
 ## EXAMPLES
 
@@ -222,7 +226,7 @@ Accept wildcard characters: False
 ```
 
 ### -DisableCompression
-{{ Fill DisableCompression Description }}
+Resets the SMB compression behavior to its default value.
 
 ```yaml
 Type: SwitchParameter
@@ -604,7 +608,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequestCompression
-{{ Fill RequestCompression Description }}
+Resets the SMB server request compression value to its default value.
 
 ```yaml
 Type: SwitchParameter

--- a/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
@@ -45,9 +45,9 @@ and [[MS-SMB2]:Server Message Block (SMB) Protocol Versions 2 and3](/openspecs/w
 > version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
 >
 > - The **DisableCompression** and **RequestCompression** parameters are available beginning with
-> 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based Systems
-> ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for Windows 11,
-> version 22H2 ([KB5016691](https://support.microsoft.com/help/5016691)).
+>   2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based
+>   Systems ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for
+>   Windows 11, version 22H2 ([KB5016691](https://support.microsoft.com/help/5016691)).
 
 ## EXAMPLES
 

--- a/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbServerConfiguration.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 09/15/2022
+ms.date: 10/20/2022
 online version: http://go.microsoft.com/fwlink/?LinkID=241959
 schema: 2.0.0
 title: Reset-SmbServerConfiguration

--- a/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
@@ -17,18 +17,18 @@ Resets the Server Message Block (SMB) server configuration parameters to their d
 
 ```
 Reset-SmbServerConfiguration [-All] [-AnnounceComment] [-AnnounceServer] [-AsynchronousCredits]
-[-AuditSmb1Access] [-AutoShareServer] [-AutoShareWorkstation] [-CachedOpenLimit]
-[-DisableCompression] [-DisableSmbEncryptionOnSecureConnection] [-DurableHandleV2TimeoutInSeconds]
-[-EnableDownlevelTimewarp] [-EnableLeasing] [-EnableMultiChannel] [-EnableOplocks]
-[-EnableSMB2Protocol] [-EnableSMBQUIC] [-EnableStrictNameChecking] [-EncryptData]
-[-EncryptionCiphers] [-IrpStackSize] [-KeepAliveTime] [-MaxChannelPerSession] [-MaxMpxCount]
-[-MaxSessionPerConnection] [-MaxThreadsPerQueue] [-MaxWorkItems] [-NullSessionShares]
-[-OplockBreakWait] [-PendingClientTimeoutInSeconds] [-RejectUnencryptedAccess]
-[-RequestCompression] [-RestrictNamedpipeAccessViaQuic] [-ServerHidden] [-Smb2CreditsMax]
-[-Smb2CreditsMin] [-SmbServerNameHardeningLevel] [-TreatHostAsStableStorage]
-[-ValidateAliasNotCircular] [-ValidateShareScope] [-ValidateShareScopeNotAliased]
-[-ValidateTargetName] [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
-[-WhatIf] [-Confirm] [<CommonParameters>]
+ [-AuditSmb1Access] [-AutoShareServer] [-AutoShareWorkstation] [-CachedOpenLimit]
+ [-DisableCompression] [-DisableSmbEncryptionOnSecureConnection] [-DurableHandleV2TimeoutInSeconds]
+ [-EnableDownlevelTimewarp] [-EnableLeasing] [-EnableMultiChannel] [-EnableOplocks]
+ [-EnableSMB2Protocol] [-EnableSMBQUIC] [-EnableStrictNameChecking] [-EncryptData]
+ [-EncryptionCiphers] [-IrpStackSize] [-KeepAliveTime] [-MaxChannelPerSession] [-MaxMpxCount]
+ [-MaxSessionPerConnection] [-MaxThreadsPerQueue] [-MaxWorkItems] [-NullSessionShares]
+ [-OplockBreakWait] [-PendingClientTimeoutInSeconds] [-RejectUnencryptedAccess]
+ [-RequestCompression] [-RestrictNamedpipeAccessViaQuic] [-ServerHidden] [-Smb2CreditsMax]
+ [-Smb2CreditsMin] [-SmbServerNameHardeningLevel] [-TreatHostAsStableStorage]
+ [-ValidateAliasNotCircular] [-ValidateShareScope] [-ValidateShareScopeNotAliased]
+ [-ValidateTargetName] [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -43,6 +43,7 @@ and [[MS-SMB2]:Server Message Block (SMB) Protocol Versions 2 and3](/openspecs/w
 > system version 21H2 for x64-based Systems
 > ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
 > version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
+>
 > - The **DisableCompression** and **RequestCompression** parameters are available beginning with
 > 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based Systems
 > ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for Windows 11,
@@ -226,6 +227,7 @@ Accept wildcard characters: False
 ```
 
 ### -DisableCompression
+
 Resets the SMB compression behavior to its default value.
 
 ```yaml
@@ -593,6 +595,7 @@ Accept wildcard characters: False
 ```
 
 ### -RejectUnencryptedAccess
+
 Resets the unencrypted access behavior to its default value.
 
 ```yaml
@@ -608,6 +611,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequestCompression
+
 Resets the SMB server request compression value to its default value.
 
 ```yaml
@@ -741,7 +745,7 @@ Accept wildcard characters: False
 
 ### -ValidateAliasNotCircular
 
-Resets whether the aliases that are not circular are validated to its default value.
+Resets whether the aliases that aren't circular are validated to its default value.
 
 ```yaml
 Type: SwitchParameter
@@ -821,7 +825,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter

--- a/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
@@ -17,18 +17,18 @@ Resets the Server Message Block (SMB) server configuration parameters to their d
 
 ```
 Reset-SmbServerConfiguration [-All] [-AnnounceComment] [-AnnounceServer] [-AsynchronousCredits]
- [-AuditSmb1Access] [-AutoShareServer] [-AutoShareWorkstation] [-CachedOpenLimit]
- [-DisableSmbEncryptionOnSecureConnection] [-DurableHandleV2TimeoutInSeconds]
- [-EnableDownlevelTimewarp] [-EnableLeasing] [-EnableMultiChannel] [-EnableOplocks]
- [-EnableSMB2Protocol] [-EnableSMBQUIC] [-EnableStrictNameChecking] [-EncryptData]
- [-EncryptionCiphers] [-IrpStackSize] [-KeepAliveTime] [-MaxChannelPerSession] [-MaxMpxCount]
- [-MaxSessionPerConnection] [-MaxThreadsPerQueue] [-MaxWorkItems] [-NullSessionShares]
- [-OplockBreakWait] [-PendingClientTimeoutInSeconds] [-RejectUnencryptedAccess]
- [-RestrictNamedpipeAccessViaQuic] [-ServerHidden] [-Smb2CreditsMax] [-Smb2CreditsMin]
- [-SmbServerNameHardeningLevel] [-TreatHostAsStableStorage] [-ValidateAliasNotCircular]
- [-ValidateShareScope] [-ValidateShareScopeNotAliased] [-ValidateTargetName] [-Force]
- [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+[-AuditSmb1Access] [-AutoShareServer] [-AutoShareWorkstation] [-CachedOpenLimit]
+[-DisableCompression] [-DisableSmbEncryptionOnSecureConnection] [-DurableHandleV2TimeoutInSeconds]
+[-EnableDownlevelTimewarp] [-EnableLeasing] [-EnableMultiChannel] [-EnableOplocks]
+[-EnableSMB2Protocol] [-EnableSMBQUIC] [-EnableStrictNameChecking] [-EncryptData]
+[-EncryptionCiphers] [-IrpStackSize] [-KeepAliveTime] [-MaxChannelPerSession] [-MaxMpxCount]
+[-MaxSessionPerConnection] [-MaxThreadsPerQueue] [-MaxWorkItems] [-NullSessionShares]
+[-OplockBreakWait] [-PendingClientTimeoutInSeconds] [-RejectUnencryptedAccess]
+[-RequestCompression] [-RestrictNamedpipeAccessViaQuic] [-ServerHidden] [-Smb2CreditsMax]
+[-Smb2CreditsMin] [-SmbServerNameHardeningLevel] [-TreatHostAsStableStorage]
+[-ValidateAliasNotCircular] [-ValidateShareScope] [-ValidateShareScopeNotAliased]
+[-ValidateTargetName] [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+[-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -213,6 +213,21 @@ current session on the local computer.
 Type: CimSession[]
 Parameter Sets: (All)
 Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableCompression
+{{ Fill DisableCompression Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named
@@ -574,8 +589,22 @@ Accept wildcard characters: False
 ```
 
 ### -RejectUnencryptedAccess
-
 Resets the unencrypted access behavior to its default value.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequestCompression
+{{ Fill RequestCompression Description }}
 
 ```yaml
 Type: SwitchParameter

--- a/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
@@ -39,10 +39,15 @@ Set-SmbClientConfiguration [-CompressibilitySamplingSize <UInt64>]
 The `Set-SmbClientConfiguration` cmdlet sets the Server Message Block (SMB) client configuration.
 
 > [!NOTE]
-> The **EncryptionCiphers** parameter is available beginning with 2022-06 Cumulative Update for
+> - The **EncryptionCiphers** parameter is available beginning with 2022-06 Cumulative Update for
 > Microsoft server operating system version 21H2 for x64-based Systems
 > ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
 > version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
+> - The **CompressibilitySamplingSize**, **CompressibleThreshold**,
+> **EnableCompressibilitySampling**, and **RequestCompression** parameters are available beginning
+> with 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based
+> Systems ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for
+> Windows 11, version 22H2 ([KB5016691](https://support.microsoft.com/help/5016691)).
 
 ## EXAMPLES
 
@@ -103,7 +108,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompressibilitySamplingSize
-{{ Fill CompressibilitySamplingSize Description }}
+Specifies the size in bytes to sample in a file to look for compressible data.
 
 ```yaml
 Type: UInt64
@@ -118,7 +123,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompressibleThreshold
-{{ Fill CompressibleThreshold Description }}
+Specifies the threshold in bytes in which to attempt to find compressible data.
 
 ```yaml
 Type: UInt64
@@ -260,7 +265,13 @@ Accept wildcard characters: False
 ```
 
 ### -EnableCompressibilitySampling
-{{ Fill EnableCompressibilitySampling Description }}
+Controls the sampling behavior. SMB by default always attempts to compress the entire file when a
+client or server requests it, without using compression sampling. With EnableCompressibilitySampling
+set to '$true' SMB uses of an algorithm where it attempted to compress the first 524,288,000 bytes
+(500 MiB) of a file during transfer and track that at least 104,857,600 bytes (100 MiB) compressed
+within that 500 MiB range. If fewer than 100 MiB was compressible, SMB compression stopped trying to
+compress the rest of the file. If at least 100 MiB compressed, SMB compression attempted to compress
+the rest of the file.
 
 ```yaml
 Type: Boolean
@@ -547,7 +558,8 @@ Accept wildcard characters: False
 ```
 
 ### -RequestCompression
-{{ Fill RequestCompression Description }}
+Indicates if SMB client should always request compression even if server or application didn't
+specify it.
 
 ```yaml
 Type: Boolean

--- a/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
@@ -40,9 +40,9 @@ The `Set-SmbClientConfiguration` cmdlet sets the Server Message Block (SMB) clie
 
 > [!NOTE]
 > - The **EncryptionCiphers** parameter is available beginning with 2022-06 Cumulative Update for
-> Microsoft server operating system version 21H2 for x64-based Systems
-> ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
-> version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
+>   Microsoft server operating system version 21H2 for x64-based Systems
+>   ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
+>   version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
 >
 > - The **CompressibilitySamplingSize**, **CompressibleThreshold**,
 >   **EnableCompressibilitySampling**, and **RequestCompression** parameters are available beginning

--- a/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
@@ -110,7 +110,9 @@ Accept wildcard characters: False
 
 ### -CompressibilitySamplingSize
 
-Specifies the size in bytes to sample in a file to look for compressible data.
+Specifies the size in bytes to sample in a file to look for compressible data. Although the
+parameter type is **UInt64**, the sampling size can be specified up to a maximum of is 9,007,199,254,740,992
+(9 PiB).
 
 ```yaml
 Type: UInt64
@@ -126,7 +128,9 @@ Accept wildcard characters: False
 
 ### -CompressibleThreshold
 
-Specifies the threshold in bytes in which to attempt to find compressible data.
+Specifies the threshold in bytes in which to attempt to find compressible data. Although the
+parameter type is **UInt64**, the threshold can be specified up to a maximum of is 9,007,199,254,740,992
+(9 PiB).
 
 ```yaml
 Type: UInt64

--- a/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
@@ -17,21 +17,21 @@ Sets the SMB client configuration.
 
 ```
 Set-SmbClientConfiguration [-CompressibilitySamplingSize <UInt64>]
-[-CompressibleThreshold <UInt64>] [-ConnectionCountPerRssNetworkInterface <UInt32>]
-[-DirectoryCacheEntriesMax <UInt32>] [-DirectoryCacheEntrySizeMax <UInt32>]
-[-DirectoryCacheLifetime <UInt32>] [-DisableCompression <Boolean>] [-DormantFileLimit <UInt32>]
-[-EnableBandwidthThrottling <Boolean>] [-EnableByteRangeLockingOnReadOnlyFiles <Boolean>]
-[-EnableCompressibilitySampling <Boolean>] [-EnableInsecureGuestLogons <Boolean>]
-[-EnableLargeMtu <Boolean>] [-EnableLoadBalanceScaleOut <Boolean>] [-EnableMultiChannel <Boolean>]
-[-EnableSecuritySignature <Boolean>] [-EncryptionCiphers <String>]
-[-ExtendedSessionTimeout <UInt32>] [-FileInfoCacheEntriesMax <UInt32>]
-[-FileInfoCacheLifetime <UInt32>] [-FileNotFoundCacheEntriesMax <UInt32>]
-[-FileNotFoundCacheLifetime <UInt32>] [-ForceSMBEncryptionOverQuic <Boolean>] [-KeepConn <UInt32>]
-[-MaxCmds <UInt32>] [-MaximumConnectionCountPerServer <UInt32>] [-OplocksDisabled <Boolean>]
-[-RequestCompression <Boolean>] [-RequireSecuritySignature <Boolean>] [-SessionTimeout <UInt32>]
-[-SkipCertificateCheck <Boolean>] [-UseOpportunisticLocking <Boolean>]
-[-WindowSizeThreshold <UInt32>] [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
-[-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-CompressibleThreshold <UInt64>] [-ConnectionCountPerRssNetworkInterface <UInt32>]
+ [-DirectoryCacheEntriesMax <UInt32>] [-DirectoryCacheEntrySizeMax <UInt32>]
+ [-DirectoryCacheLifetime <UInt32>] [-DisableCompression <Boolean>] [-DormantFileLimit <UInt32>]
+ [-EnableBandwidthThrottling <Boolean>] [-EnableByteRangeLockingOnReadOnlyFiles <Boolean>]
+ [-EnableCompressibilitySampling <Boolean>] [-EnableInsecureGuestLogons <Boolean>]
+ [-EnableLargeMtu <Boolean>] [-EnableLoadBalanceScaleOut <Boolean>] [-EnableMultiChannel <Boolean>]
+ [-EnableSecuritySignature <Boolean>] [-EncryptionCiphers <String>]
+ [-ExtendedSessionTimeout <UInt32>] [-FileInfoCacheEntriesMax <UInt32>]
+ [-FileInfoCacheLifetime <UInt32>] [-FileNotFoundCacheEntriesMax <UInt32>]
+ [-FileNotFoundCacheLifetime <UInt32>] [-ForceSMBEncryptionOverQuic <Boolean>] [-KeepConn <UInt32>]
+ [-MaxCmds <UInt32>] [-MaximumConnectionCountPerServer <UInt32>] [-OplocksDisabled <Boolean>]
+ [-RequestCompression <Boolean>] [-RequireSecuritySignature <Boolean>] [-SessionTimeout <UInt32>]
+ [-SkipCertificateCheck <Boolean>] [-UseOpportunisticLocking <Boolean>]
+ [-WindowSizeThreshold <UInt32>] [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
+ [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -43,6 +43,7 @@ The `Set-SmbClientConfiguration` cmdlet sets the Server Message Block (SMB) clie
 > Microsoft server operating system version 21H2 for x64-based Systems
 > ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
 > version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
+>
 > - The **CompressibilitySamplingSize**, **CompressibleThreshold**,
 > **EnableCompressibilitySampling**, and **RequestCompression** parameters are available beginning
 > with 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based
@@ -108,6 +109,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompressibilitySamplingSize
+
 Specifies the size in bytes to sample in a file to look for compressible data.
 
 ```yaml
@@ -123,6 +125,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompressibleThreshold
+
 Specifies the threshold in bytes in which to attempt to find compressible data.
 
 ```yaml
@@ -250,6 +253,7 @@ Accept wildcard characters: False
 ```
 
 ### -EnableByteRangeLockingOnReadOnlyFiles
+
 Indicates that byte range locking on read-only files is enabled.
 
 ```yaml
@@ -265,13 +269,19 @@ Accept wildcard characters: False
 ```
 
 ### -EnableCompressibilitySampling
+
 Controls the sampling behavior. SMB by default always attempts to compress the entire file when a
-client or server requests it, without using compression sampling. With EnableCompressibilitySampling
-set to '$true' SMB uses of an algorithm where it attempted to compress the first 524,288,000 bytes
-(500 MiB) of a file during transfer and track that at least 104,857,600 bytes (100 MiB) compressed
-within that 500 MiB range. If fewer than 100 MiB was compressible, SMB compression stopped trying to
-compress the rest of the file. If at least 100 MiB compressed, SMB compression attempted to compress
-the rest of the file.
+client or server requests it. With **EnableCompressibilitySampling** set to `$true`, SMB uses the
+compression sampling algorithm where it attempts to compress the file based on the values
+configured in the **CompressibiltySamplingSize** and **CompressibleThreshold** parameters.
+
+With **EnableCompressibilitySampling** set to `$true` and if you don't use the
+**CompressibiltySamplingSize** and **CompressibleThreshold** parameters, the algorithm will by
+default attempt to compress the first 524,288,000 bytes (500 MiB) of a file during transfer. The
+algorithm will try to track that at least 104,857,600 bytes (100 MiB) compresses within that 500 MiB
+range. If fewer than 100 MiB was compressible, SMB compression stopped trying to compress the rest
+of the file. If at least 100 MiB compressed, SMB compression attempted to compress the rest of the
+file.
 
 ```yaml
 Type: Boolean
@@ -480,7 +490,7 @@ Accept wildcard characters: False
 ### -ForceSMBEncryptionOverQuic
 
 Specifies that the SMB client uses SMB encryption inside of the SMB over QUIC TLS 1.3 encrypted
-tunnel even if the SMB server does not require it.
+tunnel even if the SMB server doesn't require it.
 
 ```yaml
 Type: Boolean
@@ -543,6 +553,7 @@ Accept wildcard characters: False
 ```
 
 ### -OplocksDisabled
+
 Indicates that opportunistic locks are disabled.
 
 ```yaml
@@ -558,6 +569,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequestCompression
+
 Indicates if SMB client should always request compression even if server or application didn't
 specify it.
 
@@ -677,7 +689,7 @@ Accept wildcard characters: False
 ### -WhatIf
 
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter

--- a/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbClientConfiguration.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 06/24/2022
+ms.date: 10/20/2022
 online version: https://learn.microsoft.com/powershell/module/smbshare/set-smbclientconfiguration?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-SmbClientConfiguration

--- a/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
@@ -45,10 +45,10 @@ The `Set-SmbClientConfiguration` cmdlet sets the Server Message Block (SMB) clie
 > version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
 >
 > - The **CompressibilitySamplingSize**, **CompressibleThreshold**,
-> **EnableCompressibilitySampling**, and **RequestCompression** parameters are available beginning
-> with 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based
-> Systems ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for
-> Windows 11, version 22H2 ([KB5016691](https://support.microsoft.com/help/5016691)).
+>   **EnableCompressibilitySampling**, and **RequestCompression** parameters are available beginning
+>   with 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based
+>   Systems ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for
+>   Windows 11, version 22H2 ([KB5016691](https://support.microsoft.com/help/5016691)).
 
 ## EXAMPLES
 
@@ -111,8 +111,8 @@ Accept wildcard characters: False
 ### -CompressibilitySamplingSize
 
 Specifies the size in bytes to sample in a file to look for compressible data. Although the
-parameter type is **UInt64**, the sampling size can be specified up to a maximum of is 9,007,199,254,740,992
-(9 PiB).
+parameter type is **UInt64**, the sampling size can be specified up to a maximum of
+`9,007,199,254,740,992` (9 PiB).
 
 ```yaml
 Type: UInt64
@@ -129,8 +129,8 @@ Accept wildcard characters: False
 ### -CompressibleThreshold
 
 Specifies the threshold in bytes in which to attempt to find compressible data. Although the
-parameter type is **UInt64**, the threshold can be specified up to a maximum of is 9,007,199,254,740,992
-(9 PiB).
+parameter type is **UInt64**, the threshold can be specified up to a maximum of
+`9,007,199,254,740,992` (9 PiB).
 
 ```yaml
 Type: UInt64
@@ -279,13 +279,12 @@ client or server requests it. With **EnableCompressibilitySampling** set to `$tr
 compression sampling algorithm where it attempts to compress the file based on the values
 configured in the **CompressibiltySamplingSize** and **CompressibleThreshold** parameters.
 
-With **EnableCompressibilitySampling** set to `$true` and if you don't use the
-**CompressibiltySamplingSize** and **CompressibleThreshold** parameters, the algorithm will by
-default attempt to compress the first 524,288,000 bytes (500 MiB) of a file during transfer. The
-algorithm will try to track that at least 104,857,600 bytes (100 MiB) compresses within that 500 MiB
-range. If fewer than 100 MiB was compressible, SMB compression stopped trying to compress the rest
-of the file. If at least 100 MiB compressed, SMB compression attempted to compress the rest of the
-file.
+When you specify **EnableCompressibilitySampling** as `$true` and don't specify either the
+**CompressibiltySamplingSize** or **CompressibleThreshold** parameters, the algorithm attempts to
+compress the first `524,288,000` bytes (500 MiB) of a file during transfer. The algorithm tries to
+track that at least `104,857,600` bytes (100 MiB) compresses within that 500 MiB range. If fewer
+than 100 MiB was compressible, SMB compression stops trying to compress the rest of the file. If at
+least 100 MiB compressed, SMB compression attempts to compress the rest of the file.
 
 ```yaml
 Type: Boolean
@@ -574,7 +573,7 @@ Accept wildcard characters: False
 
 ### -RequestCompression
 
-Indicates if SMB client should always request compression even if server or application didn't
+Indicates if an SMB client should always request compression even if the server or application didn't
 specify it.
 
 ```yaml

--- a/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
@@ -573,8 +573,8 @@ Accept wildcard characters: False
 
 ### -RequestCompression
 
-Indicates if an SMB client should always request compression even if the server or application didn't
-specify it.
+Indicates if an SMB client should always request compression even if the server or application
+didn't specify it.
 
 ```yaml
 Type: Boolean

--- a/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbClientConfiguration.md
@@ -16,21 +16,22 @@ Sets the SMB client configuration.
 ## SYNTAX
 
 ```
-Set-SmbClientConfiguration [-ConnectionCountPerRssNetworkInterface <UInt32>]
- [-DirectoryCacheEntriesMax <UInt32>] [-DirectoryCacheEntrySizeMax <UInt32>]
- [-DirectoryCacheLifetime <UInt32>] [-DisableCompression <Boolean>] [-DormantFileLimit <UInt32>]
- [-EnableBandwidthThrottling <Boolean>] [-EnableByteRangeLockingOnReadOnlyFiles <Boolean>]
- [-EnableInsecureGuestLogons <Boolean>] [-EnableLargeMtu <Boolean>]
- [-EnableLoadBalanceScaleOut <Boolean>] [-EnableMultiChannel <Boolean>]
- [-EnableSecuritySignature <Boolean>] [-EncryptionCiphers <String>]
- [-ExtendedSessionTimeout <UInt32>] [-FileInfoCacheEntriesMax <UInt32>]
- [-FileInfoCacheLifetime <UInt32>] [-FileNotFoundCacheEntriesMax <UInt32>]
- [-FileNotFoundCacheLifetime <UInt32>] [-ForceSMBEncryptionOverQuic <Boolean>] [-KeepConn <UInt32>]
- [-MaxCmds <UInt32>] [-MaximumConnectionCountPerServer <UInt32>] [-OplocksDisabled <Boolean>]
- [-RequireSecuritySignature <Boolean>] [-SessionTimeout <UInt32>] [-SkipCertificateCheck <Boolean>]
- [-UseOpportunisticLocking <Boolean>] [-WindowSizeThreshold <UInt32>] [-Force]
- [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Set-SmbClientConfiguration [-CompressibilitySamplingSize <UInt64>]
+[-CompressibleThreshold <UInt64>] [-ConnectionCountPerRssNetworkInterface <UInt32>]
+[-DirectoryCacheEntriesMax <UInt32>] [-DirectoryCacheEntrySizeMax <UInt32>]
+[-DirectoryCacheLifetime <UInt32>] [-DisableCompression <Boolean>] [-DormantFileLimit <UInt32>]
+[-EnableBandwidthThrottling <Boolean>] [-EnableByteRangeLockingOnReadOnlyFiles <Boolean>]
+[-EnableCompressibilitySampling <Boolean>] [-EnableInsecureGuestLogons <Boolean>]
+[-EnableLargeMtu <Boolean>] [-EnableLoadBalanceScaleOut <Boolean>] [-EnableMultiChannel <Boolean>]
+[-EnableSecuritySignature <Boolean>] [-EncryptionCiphers <String>]
+[-ExtendedSessionTimeout <UInt32>] [-FileInfoCacheEntriesMax <UInt32>]
+[-FileInfoCacheLifetime <UInt32>] [-FileNotFoundCacheEntriesMax <UInt32>]
+[-FileNotFoundCacheLifetime <UInt32>] [-ForceSMBEncryptionOverQuic <Boolean>] [-KeepConn <UInt32>]
+[-MaxCmds <UInt32>] [-MaximumConnectionCountPerServer <UInt32>] [-OplocksDisabled <Boolean>]
+[-RequestCompression <Boolean>] [-RequireSecuritySignature <Boolean>] [-SessionTimeout <UInt32>]
+[-SkipCertificateCheck <Boolean>] [-UseOpportunisticLocking <Boolean>]
+[-WindowSizeThreshold <UInt32>] [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
+[-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -93,6 +94,36 @@ current session on the local computer.
 Type: CimSession[]
 Parameter Sets: (All)
 Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CompressibilitySamplingSize
+{{ Fill CompressibilitySamplingSize Description }}
+
+```yaml
+Type: UInt64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CompressibleThreshold
+{{ Fill CompressibleThreshold Description }}
+
+```yaml
+Type: UInt64
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named
@@ -214,8 +245,22 @@ Accept wildcard characters: False
 ```
 
 ### -EnableByteRangeLockingOnReadOnlyFiles
-
 Indicates that byte range locking on read-only files is enabled.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableCompressibilitySampling
+{{ Fill EnableCompressibilitySampling Description }}
 
 ```yaml
 Type: Boolean
@@ -487,8 +532,22 @@ Accept wildcard characters: False
 ```
 
 ### -OplocksDisabled
-
 Indicates that opportunistic locks are disabled.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequestCompression
+{{ Fill RequestCompression Description }}
 
 ```yaml
 Type: Boolean

--- a/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
@@ -48,9 +48,9 @@ and [[MS-SMB2]:Server Message Block (SMB) Protocol Versions 2 and 3](/openspecs/
 
 > [!NOTE]
 > - The **EncryptionCiphers** parameter is available beginning with 2022-06 Cumulative Update for
-> Microsoft server operating system version 21H2 for x64-based Systems
-> ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
-> version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
+>   Microsoft server operating system version 21H2 for x64-based Systems
+>   ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
+>   version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
 >
 > - The **DisableCompression** and **RequestCompression** parameters are available beginning with
 >   2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based

--- a/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbServerConfiguration.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 09/15/2022
+ms.date: 10/20/2022
 online version: /powershell/module/smbshare/set-smbserverconfiguration?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-SmbServerConfiguration
@@ -71,9 +71,9 @@ This command sets the SMB Service configuration without user confirmation.
 
 ```powershell
 $Parameters = @{
-    RequireSecuritySignature = $True
-    EnableSecuritySignature = $True
-    EncryptData = $True
+    RequireSecuritySignature = $true
+    EnableSecuritySignature = $true
+    EncryptData = $true
     Confirm = $false
 }
 Set-SmbServerConfiguration @Parameters
@@ -86,7 +86,7 @@ splatting to pass parameter values from the `$Parameters` variable to the comman
 ### Example 3: Turn off the default server and workstations shares
 
 ```powershell
-Set-SmbServerConfiguration -AutoShareServer $False -AutoShareWorkstation $False -Confirm:$false
+Set-SmbServerConfiguration -AutoShareServer $false -AutoShareWorkstation $false -Confirm:$false
 ```
 
 This command turns off the default server and workstations shares without user confirmation.
@@ -94,7 +94,7 @@ This command turns off the default server and workstations shares without user c
 ### Example 4: Turn off server announcements
 
 ```powershell
-Set-SmbServerConfiguration -ServerHidden $False -AnnounceServer $False -Confirm:$false
+Set-SmbServerConfiguration -ServerHidden $false -AnnounceServer $false -Confirm:$false
 ```
 
 This command turns off server announcements without user confirmation.
@@ -788,7 +788,7 @@ Accept wildcard characters: False
 
 ### -RestrictNamedpipeAccessViaQuic
 
-Specifies that named pipes are allowed when using SMB over QUIC. A value of $TRUE prevents use of
+Specifies that named pipes are allowed when using SMB over QUIC. A value of `$true` prevents use of
 named pipes and is the default.
 
 ```yaml

--- a/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
@@ -53,9 +53,9 @@ and [[MS-SMB2]:Server Message Block (SMB) Protocol Versions 2 and 3](/openspecs/
 > version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
 >
 > - The **DisableCompression** and **RequestCompression** parameters are available beginning with
-> 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based Systems
-> ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for Windows 11,
-> version 22H2 ([KB5016691](https://support.microsoft.com/help/5016691)).
+>   2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based
+>   Systems ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for
+>   Windows 11, version 22H2 ([KB5016691](https://support.microsoft.com/help/5016691)).
 
 ## EXAMPLES
 
@@ -285,7 +285,7 @@ Accept wildcard characters: False
 
 ### -DisableCompression
 
-Indicated that the SMB server should never compress files even if client or application requested
+Indicates that the SMB server should never compress files even if client or application requested
 it.
 
 ```yaml
@@ -738,7 +738,7 @@ Accept wildcard characters: False
 
 ### -RejectUnencryptedAccess
 
-Indicates whether the client that doesn't support encryption is denied access if it attempts to
+Indicates whether a client that doesn't support encryption is denied access if it attempts to
 connect to an encrypted share.
 
 ```yaml
@@ -755,8 +755,9 @@ Accept wildcard characters: False
 
 ### -RequestCompression
 
-Indicates if SMB server should always request compression even if client or application didn't
-specify it.
+```suggestion
+Indicates whether the SMB server should always request compression even if client or application
+didn't specify it.
 
 ```yaml
 Type: Boolean

--- a/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
@@ -738,7 +738,7 @@ Accept wildcard characters: False
 
 ### -RejectUnencryptedAccess
 
-Indicates whether a client that doesn't support encryption is denied access if it attempts to
+Indicates whether the client that doesn't support encryption is denied access if it attempts to
 connect to an encrypted share.
 
 ```yaml
@@ -755,9 +755,8 @@ Accept wildcard characters: False
 
 ### -RequestCompression
 
-```suggestion
-Indicates whether the SMB server should always request compression even if client or application
-didn't specify it.
+Indicates if SMB server should always request compression even if client or application didn't
+specify it.
 
 ```yaml
 Type: Boolean

--- a/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
@@ -17,25 +17,26 @@ Sets the Server Message Block (SMB) server configuration.
 
 ```
 Set-SmbServerConfiguration [-AnnounceComment <String>] [-AnnounceServer <Boolean>]
- [-AsynchronousCredits <UInt32>] [-AuditSmb1Access <Boolean>] [-AutoDisconnectTimeout <UInt32>]
- [-AutoShareServer <Boolean>] [-AutoShareWorkstation <Boolean>] [-CachedOpenLimit <UInt32>]
- [-DisableSmbEncryptionOnSecureConnection <Boolean>] [-DurableHandleV2TimeoutInSeconds <UInt32>]
- [-EnableAuthenticateUserSharing <Boolean>] [-EnableDownlevelTimewarp <Boolean>]
- [-EnableForcedLogoff <Boolean>] [-EnableLeasing <Boolean>] [-EnableMultiChannel <Boolean>]
- [-EnableOplocks <Boolean>] [-EnableSecuritySignature <Boolean>] [-EnableSMB1Protocol <Boolean>]
- [-EnableSMB2Protocol <Boolean>] [-EnableSMBQUIC <Boolean>] [-EnableStrictNameChecking <Boolean>]
- [-EncryptData <Boolean>] [-EncryptionCiphers <String>] [-IrpStackSize <UInt32>]
- [-KeepAliveTime <UInt32>] [-MaxChannelPerSession <UInt32>] [-MaxMpxCount <UInt32>]
- [-MaxSessionPerConnection <UInt32>] [-MaxThreadsPerQueue <UInt32>] [-MaxWorkItems <UInt32>]
- [-NullSessionPipes <String>] [-NullSessionShares <String>] [-OplockBreakWait <UInt32>]
- [-PendingClientTimeoutInSeconds <UInt32>] [-RejectUnencryptedAccess <Boolean>]
- [-RequireSecuritySignature <Boolean>] [-RestrictNamedpipeAccessViaQuic <Boolean>]
- [-ServerHidden <Boolean>] [-Smb2CreditsMax <UInt32>] [-Smb2CreditsMin <UInt32>]
- [-SmbServerNameHardeningLevel <UInt32>] [-TreatHostAsStableStorage <Boolean>]
- [-ValidateAliasNotCircular <Boolean>] [-ValidateShareScope <Boolean>]
- [-ValidateShareScopeNotAliased <Boolean>] [-ValidateTargetName <Boolean>] [-Force]
- [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+[-AsynchronousCredits <UInt32>] [-AuditSmb1Access <Boolean>] [-AutoDisconnectTimeout <UInt32>]
+[-AutoShareServer <Boolean>] [-AutoShareWorkstation <Boolean>] [-CachedOpenLimit <UInt32>]
+[-DisableCompression <Boolean>] [-DisableSmbEncryptionOnSecureConnection <Boolean>]
+[-DurableHandleV2TimeoutInSeconds <UInt32>] [-EnableAuthenticateUserSharing <Boolean>]
+[-EnableDownlevelTimewarp <Boolean>] [-EnableForcedLogoff <Boolean>] [-EnableLeasing <Boolean>]
+[-EnableMultiChannel <Boolean>] [-EnableOplocks <Boolean>] [-EnableSecuritySignature <Boolean>]
+[-EnableSMB1Protocol <Boolean>] [-EnableSMB2Protocol <Boolean>] [-EnableSMBQUIC <Boolean>]
+[-EnableStrictNameChecking <Boolean>] [-EncryptData <Boolean>] [-EncryptionCiphers <String>]
+[-IrpStackSize <UInt32>] [-KeepAliveTime <UInt32>] [-MaxChannelPerSession <UInt32>]
+[-MaxMpxCount <UInt32>] [-MaxSessionPerConnection <UInt32>] [-MaxThreadsPerQueue <UInt32>]
+[-MaxWorkItems <UInt32>] [-NullSessionPipes <String>] [-NullSessionShares <String>]
+[-OplockBreakWait <UInt32>] [-PendingClientTimeoutInSeconds <UInt32>]
+[-RejectUnencryptedAccess <Boolean>] [-RequestCompression <Boolean>]
+[-RequireSecuritySignature <Boolean>] [-RestrictNamedpipeAccessViaQuic <Boolean>]
+[-ServerHidden <Boolean>] [-Smb2CreditsMax <UInt32>] [-Smb2CreditsMin <UInt32>]
+[-SmbServerNameHardeningLevel <UInt32>] [-TreatHostAsStableStorage <Boolean>]
+[-ValidateAliasNotCircular <Boolean>] [-ValidateShareScope <Boolean>]
+[-ValidateShareScopeNotAliased <Boolean>] [-ValidateTargetName <Boolean>] [-Force]
+[-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
+[<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -269,6 +270,21 @@ current session on the local computer.
 Type: CimSession[]
 Parameter Sets: (All)
 Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableCompression
+{{ Fill DisableCompression Description }}
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named
@@ -714,9 +730,23 @@ Accept wildcard characters: False
 ```
 
 ### -RejectUnencryptedAccess
-
 Indicates whether the client that does not support encryption is denied access if it attempts to
 connect to an encrypted share.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequestCompression
+{{ Fill RequestCompression Description }}
 
 ```yaml
 Type: Boolean

--- a/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbServerConfiguration.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 06/24/2022
+ms.date: 09/15/2022
 online version: /powershell/module/smbshare/set-smbserverconfiguration?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-SmbServerConfiguration
@@ -47,10 +47,14 @@ For more information on SMB server and protocol specifications, see
 and [[MS-SMB2]:Server Message Block (SMB) Protocol Versions 2 and 3](/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962).
 
 > [!NOTE]
-> The **EncryptionCiphers** parameter is available beginning with 2022-06 Cumulative Update for
+> - The **EncryptionCiphers** parameter is available beginning with 2022-06 Cumulative Update for
 > Microsoft server operating system version 21H2 for x64-based Systems
 > ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
 > version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
+> - The **DisableCompression** and **RequestCompression** parameters are available beginning with
+> 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based Systems
+> ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for Windows 11,
+> version 22H2 ([KB5016691](https://support.microsoft.com/help/5016691)).
 
 ## EXAMPLES
 
@@ -279,7 +283,8 @@ Accept wildcard characters: False
 ```
 
 ### -DisableCompression
-{{ Fill DisableCompression Description }}
+Indicated that the SMB server should never compress files even if client or application requested
+it.
 
 ```yaml
 Type: Boolean
@@ -746,7 +751,8 @@ Accept wildcard characters: False
 ```
 
 ### -RequestCompression
-{{ Fill RequestCompression Description }}
+Indicates if SMB server should always request compression even if client or application didn't
+specify it.
 
 ```yaml
 Type: Boolean

--- a/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
@@ -17,26 +17,26 @@ Sets the Server Message Block (SMB) server configuration.
 
 ```
 Set-SmbServerConfiguration [-AnnounceComment <String>] [-AnnounceServer <Boolean>]
-[-AsynchronousCredits <UInt32>] [-AuditSmb1Access <Boolean>] [-AutoDisconnectTimeout <UInt32>]
-[-AutoShareServer <Boolean>] [-AutoShareWorkstation <Boolean>] [-CachedOpenLimit <UInt32>]
-[-DisableCompression <Boolean>] [-DisableSmbEncryptionOnSecureConnection <Boolean>]
-[-DurableHandleV2TimeoutInSeconds <UInt32>] [-EnableAuthenticateUserSharing <Boolean>]
-[-EnableDownlevelTimewarp <Boolean>] [-EnableForcedLogoff <Boolean>] [-EnableLeasing <Boolean>]
-[-EnableMultiChannel <Boolean>] [-EnableOplocks <Boolean>] [-EnableSecuritySignature <Boolean>]
-[-EnableSMB1Protocol <Boolean>] [-EnableSMB2Protocol <Boolean>] [-EnableSMBQUIC <Boolean>]
-[-EnableStrictNameChecking <Boolean>] [-EncryptData <Boolean>] [-EncryptionCiphers <String>]
-[-IrpStackSize <UInt32>] [-KeepAliveTime <UInt32>] [-MaxChannelPerSession <UInt32>]
-[-MaxMpxCount <UInt32>] [-MaxSessionPerConnection <UInt32>] [-MaxThreadsPerQueue <UInt32>]
-[-MaxWorkItems <UInt32>] [-NullSessionPipes <String>] [-NullSessionShares <String>]
-[-OplockBreakWait <UInt32>] [-PendingClientTimeoutInSeconds <UInt32>]
-[-RejectUnencryptedAccess <Boolean>] [-RequestCompression <Boolean>]
-[-RequireSecuritySignature <Boolean>] [-RestrictNamedpipeAccessViaQuic <Boolean>]
-[-ServerHidden <Boolean>] [-Smb2CreditsMax <UInt32>] [-Smb2CreditsMin <UInt32>]
-[-SmbServerNameHardeningLevel <UInt32>] [-TreatHostAsStableStorage <Boolean>]
-[-ValidateAliasNotCircular <Boolean>] [-ValidateShareScope <Boolean>]
-[-ValidateShareScopeNotAliased <Boolean>] [-ValidateTargetName <Boolean>] [-Force]
-[-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
-[<CommonParameters>]
+ [-AsynchronousCredits <UInt32>] [-AuditSmb1Access <Boolean>] [-AutoDisconnectTimeout <UInt32>]
+ [-AutoShareServer <Boolean>] [-AutoShareWorkstation <Boolean>] [-CachedOpenLimit <UInt32>]
+ [-DisableCompression <Boolean>] [-DisableSmbEncryptionOnSecureConnection <Boolean>]
+ [-DurableHandleV2TimeoutInSeconds <UInt32>] [-EnableAuthenticateUserSharing <Boolean>]
+ [-EnableDownlevelTimewarp <Boolean>] [-EnableForcedLogoff <Boolean>] [-EnableLeasing <Boolean>]
+ [-EnableMultiChannel <Boolean>] [-EnableOplocks <Boolean>] [-EnableSecuritySignature <Boolean>]
+ [-EnableSMB1Protocol <Boolean>] [-EnableSMB2Protocol <Boolean>] [-EnableSMBQUIC <Boolean>]
+ [-EnableStrictNameChecking <Boolean>] [-EncryptData <Boolean>] [-EncryptionCiphers <String>]
+ [-IrpStackSize <UInt32>] [-KeepAliveTime <UInt32>] [-MaxChannelPerSession <UInt32>]
+ [-MaxMpxCount <UInt32>] [-MaxSessionPerConnection <UInt32>] [-MaxThreadsPerQueue <UInt32>]
+ [-MaxWorkItems <UInt32>] [-NullSessionPipes <String>] [-NullSessionShares <String>]
+ [-OplockBreakWait <UInt32>] [-PendingClientTimeoutInSeconds <UInt32>]
+ [-RejectUnencryptedAccess <Boolean>] [-RequestCompression <Boolean>]
+ [-RequireSecuritySignature <Boolean>] [-RestrictNamedpipeAccessViaQuic <Boolean>]
+ [-ServerHidden <Boolean>] [-Smb2CreditsMax <UInt32>] [-Smb2CreditsMin <UInt32>]
+ [-SmbServerNameHardeningLevel <UInt32>] [-TreatHostAsStableStorage <Boolean>]
+ [-ValidateAliasNotCircular <Boolean>] [-ValidateShareScope <Boolean>]
+ [-ValidateShareScopeNotAliased <Boolean>] [-ValidateTargetName <Boolean>] [-Force]
+ [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -51,6 +51,7 @@ and [[MS-SMB2]:Server Message Block (SMB) Protocol Versions 2 and 3](/openspecs/
 > Microsoft server operating system version 21H2 for x64-based Systems
 > ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
 > version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
+>
 > - The **DisableCompression** and **RequestCompression** parameters are available beginning with
 > 2022-08 Cumulative Update for Microsoft server operating system version 21H2 for x64-based Systems
 > ([KB5016693](https://support.microsoft.com/help/5016693)), and Cumulative Update for Windows 11,
@@ -283,6 +284,7 @@ Accept wildcard characters: False
 ```
 
 ### -DisableCompression
+
 Indicated that the SMB server should never compress files even if client or application requested
 it.
 
@@ -735,7 +737,8 @@ Accept wildcard characters: False
 ```
 
 ### -RejectUnencryptedAccess
-Indicates whether the client that does not support encryption is denied access if it attempts to
+
+Indicates whether the client that doesn't support encryption is denied access if it attempts to
 connect to an encrypted share.
 
 ```yaml
@@ -751,6 +754,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequestCompression
+
 Indicates if SMB server should always request compression even if client or application didn't
 specify it.
 
@@ -902,7 +906,7 @@ Accept wildcard characters: False
 
 ### -ValidateAliasNotCircular
 
-Indicates whether the aliases that are not circular are validated.
+Indicates whether the aliases that aren't circular are validated.
 
 ```yaml
 Type: Boolean
@@ -982,7 +986,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
The [SmbShare Module | Microsoft Docs](https://docs.microsoft.com/en-us/powershell/module/smbshare/?view=windowsserver2022-ps) for Windows Server needs to be updated with new parameters for the Reset-SmbClientConfiguration, Reset-SmbServerConfiguration, Set-SmbClientConfiguration, and Set-SmbServerConfiguration commands.

More information can be found in the blog article: [SMB compression behavior & settings changes - Microsoft Tech Community](https://techcommunity.microsoft.com/t5/storage-at-microsoft/smb-compression-behavior-amp-settings-changes/ba-p/3610763)