### PR TITLE
Removed unnedded this from description

### DIFF
--- a/docset/winserver2022-ps/secureboot/Format-SecureBootUEFI.md
+++ b/docset/winserver2022-ps/secureboot/Format-SecureBootUEFI.md
@@ -38,7 +38,7 @@ The **Format-SecureBootUEFI** cmdlet receives certificates or hashes as input an
 The Set-SecureBootUEFI cmdlet uses this object to update the variable.
 If you specify a signable file, this cmdlet creates a file that has the specified name that has to be signed.
 
-This cmdlet this runs on both UEFI and BIOS (non-UEFI) computers.
+This cmdlet runs on both UEFI and BIOS (non-UEFI) computers.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Issue https://github.com/MicrosoftDocs/windows-powershell-docs/issues/3189 was raised about an additional "this" being used in the description so I have removed it.

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
