### PR TITLE
Update Get-SmbShare.md for scopename and related example

### DIFF
--- a/docset/winserver2022-ps/smbshare/New-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbShare.md
@@ -39,8 +39,8 @@ To delete a share that was created by this cmdlet, use the `Remove-SmbShare` cmd
 
 ```powershell
 $Parameters = @{
-    Name = 'VMSFiles'
-    Path = 'C:\ClusterStorage\Volume1\VMFiles'
+    Name = 'Public'
+    Path = 'D:\Public'
     FullAccess = 'Contoso\Administrator', 'Contoso\Contoso-HV1$'
 }
 New-SmbShare @Parameters
@@ -422,7 +422,7 @@ Accept wildcard characters: False
 
 ### -ScopeName
 
-Specifies the scope name of the share.
+Specifies the scope name of the share. For use with Windows Server failover cluster file server resources.
 
 ```yaml
 Type: String


### PR DESCRIPTION
# PR Summary

Redesigned help to not be misleading about scopename: previous examples and help were often referring to failover clustering without being explicit, showing output that 99.9% of customers will never see because they are not running clusters. I am going to do this against get-smbshare, new-smbshare, set-smbshare, remove-smbshare as needed.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
