### PR TITLE
Update Remove-SmbShare.md for scopename and related example

### DIFF
--- a/docset/winserver2022-ps/smbshare/Remove-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/Remove-SmbShare.md
@@ -50,12 +50,12 @@ Performing operation 'Remove-Share' on Target 'Contoso-FS,Data'.
 
 This command deletes the SMB share named Data.
 
-### Example 2: Delete an SMB share without confirmation
+### Example 2: Delete a Windows Server failover cluster file server resource SMB share without confirmation
 ```
 PS C:\>Remove-SmbShare -Name "VMFiles" -ScopeName "Contoso-SO" -Force
 ```
 
-This command deletes the SMB share named VMFiles without user confirmation.
+This command deletes the SMB share named VMFiles on the Contoso-SO file server resource without user confirmation.
 
 ## PARAMETERS
 
@@ -153,7 +153,7 @@ Accept wildcard characters: False
 ```
 
 ### -ScopeName
-Specifies an array of the scopes of the SMB share to delete.
+Specifies an array of the scopes of the SMB share to delete. For use with Windows Server failover cluster file server resources.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2022-ps/smbshare/Remove-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/Remove-SmbShare.md
@@ -51,11 +51,12 @@ Performing operation 'Remove-Share' on Target 'Contoso-FS,Data'.
 This command deletes the SMB share named Data.
 
 ### Example 2: Delete a Windows Server failover cluster file server resource SMB share without confirmation
-```
-PS C:\>Remove-SmbShare -Name "VMFiles" -ScopeName "Contoso-SO" -Force
+
+```powershell
+Remove-SmbShare -Name "VMFiles" -ScopeName "Contoso-SO" -Force
 ```
 
-This command deletes the SMB share named VMFiles on the Contoso-SO file server resource without user confirmation.
+This command deletes the SMB share named VMFiles on the `Contoso-SO` file server resource without user confirmation.
 
 ## PARAMETERS
 
@@ -153,6 +154,7 @@ Accept wildcard characters: False
 ```
 
 ### -ScopeName
+
 Specifies an array of the scopes of the SMB share to delete. For use with Windows Server failover cluster file server resources.
 
 ```yaml


### PR DESCRIPTION
# PR Summary

Redesigned help to not be misleading about scopename: previous examples and help were often referring to failover clustering without being explicit, showing output that 99.9% of customers will never see because they are not running clusters. I am going to do this against get-smbshare, new-smbshare, set-smbshare, remove-smbshare as needed.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
