### PR TITLE
Adding Maximum Virtual Machine Live Migration clarity for Failover Clusters

### DIFF
--- a/docset/winserver2022-ps/failoverclusters/Get-Cluster.md
+++ b/docset/winserver2022-ps/failoverclusters/Get-Cluster.md
@@ -95,6 +95,11 @@ local cluster.
 (Get-Cluster).MaximumParallelMigrations = 2
 ```
 
+Beginning with the 2022-09 Cumulative Update, you can now configure the number of parallel live
+migrations within a cluster. For more information, see
+[KB5017381](https://support.microsoft.com/help/5017381) for Windows Server 2022 and
+[KB5017382](https://support.microsoft.com/help/5017382) for Azure Stack HCI, version 21H2.
+
 This example sets the cluster property MaximumParallelMigrations to a value of `2`, limiting the
 number of live migrations that a cluster node can participate in. Both existing and new cluster
 nodes inherit this value of `2` because it's a cluster property. Setting the cluster

--- a/docset/winserver2022-ps/failoverclusters/Get-Cluster.md
+++ b/docset/winserver2022-ps/failoverclusters/Get-Cluster.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: Microsoft.FailoverClusters.PowerShell.dll-Help.xml
 Module Name: FailoverClusters
-ms.date: 11/22/2022
+ms.date: 02/08/2023
 online version: https://learn.microsoft.com/powershell/module/failoverclusters/get-cluster?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Cluster
@@ -88,6 +88,18 @@ local cluster.
  before the cluster will be quarantined. This is set to 3 by default.
 - **QuarantineDuration**: This setting, set to 7200 seconds or 2 hours by default, controls how long
   a host will remain quarantined.
+
+### Example 7
+
+```powershell
+(Get-Cluster).MaximumParallelMigrations = 2
+```
+
+This example sets the cluster property MaximumParallelMigrations to a value of `2`, limiting the
+number of live migrations that a cluster node can participate in. Both existing and new cluster
+nodes inherit this value of `2` because it's a cluster property. Setting the cluster
+property overrides any values configured using the [Set-VMHost](../hyper-v/Set-VMHost.md)
+command.
 
 ## PARAMETERS
 

--- a/docset/winserver2022-ps/hyper-v/Set-VMHost.md
+++ b/docset/winserver2022-ps/hyper-v/Set-VMHost.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: Microsoft.HyperV.PowerShell.Cmdlets.dll-Help.xml
 Module Name: Hyper-V
-ms.date: 12/20/2016
+ms.date: 02/08/2023
 online version: https://learn.microsoft.com/powershell/module/hyper-v/set-vmhost?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-VMHost
@@ -281,7 +281,10 @@ Accept wildcard characters: False
 ```
 
 ### -MaximumVirtualMachineMigrations
-Specifies the maximum number of live migrations that can be performed at the same time on the Hyper-V host.
+Specifies the maximum number of live migrations that can be performed at the same time on the
+Hyper-V host. If your host is part a Failover Cluster, the cluster property takes precedence any
+values set by the **MaximumVirtualMachineMigrations** parameter. To check the cluster property,
+you can run the PowerShell command `(Get-Cluster).MaximumParallelMigrations`.
 
 ```yaml
 Type: UInt32


### PR DESCRIPTION
This PR added a new example to Get-Cluster based on the updated guide in our new enhancement currently documented in the Tech Community article, [New Cluster-Wide Control For Virtual Machine Live Migrations In Windows Server and Azure Stack HCI](https://techcommunity.microsoft.com/t5/failover-clustering/new-cluster-wide-control-for-virtual-machine-live-migrations-in/ba-p/3709680). Additionally, clarity has been added to the Set-VMHost command.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
