### PR TITLE
Cabgen failure LAPS build 

### DIFF
--- a/docset/winserver2019-ps/laps/LAPS.md
+++ b/docset/winserver2019-ps/laps/LAPS.md
@@ -1,6 +1,5 @@
 ---
-description: This reference provides cmdlet descriptions and syntax for the Windows Local Administrator Password
-Solution (LAPS) module.
+description: This reference provides cmdlet descriptions and syntax for the Windows Local Administrator Password Solution (LAPS) module.
 Module Name: LAPS
 Module Guid: 8eb7ddf9-7890-49ae-9af1-3b41d7e63c41
 Download Help Link: https://aka.ms/winsvr-2019-pshelp

--- a/docset/winserver2022-ps/laps/LAPS.md
+++ b/docset/winserver2022-ps/laps/LAPS.md
@@ -1,6 +1,5 @@
 ---
-description: This reference provides cmdlet descriptions and syntax for the Windows Local Administrator Password
-Solution (LAPS) module.
+description: This reference provides cmdlet descriptions and syntax for the Windows Local Administrator Password Solution (LAPS) module.
 Module Name: LAPS
 Module Guid: 8eb7ddf9-7890-49ae-9af1-3b41d7e63c41
 Download Help Link: https://aka.ms/winsvr-2022-pshelp


### PR DESCRIPTION
# PR Summary
Cabgen failure on build of LAPS documentation. Error still states `Invalid yaml: expected simple key-value` for LAPS documentation. These two files had multiline entries which could not be parsed. Attempting to resolve failure in process. 