### PR TITLE
Fix formatting issues for 6 docs in Defender module - CR/LF, spacing, linting

### DIFF
--- a/docset/winserver2022-ps/defender/Add-MpPreference.md
+++ b/docset/winserver2022-ps/defender/Add-MpPreference.md
@@ -16,31 +16,37 @@ Modifies settings for Windows Defender.
 ## SYNTAX
 
 ```
-Add-MpPreference [-ExclusionPath <String[]>] [-ExclusionExtension <String[]>] [-ExclusionProcess <String[]>]
- [-ExclusionIpAddress <String[]>] [-ThreatIDDefaultAction_Ids <Int64[]>]
- [-ThreatIDDefaultAction_Actions <ThreatAction[]>] [-AttackSurfaceReductionOnlyExclusions <String[]>]
- [-ControlledFolderAccessAllowedApplications <String[]>] [-ControlledFolderAccessProtectedFolders <String[]>]
- [-AttackSurfaceReductionRules_Ids <String[]>] [-AttackSurfaceReductionRules_Actions <ASRRuleActionType[]>]
- [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
+Add-MpPreference [-ExclusionPath <String[]>] [-ExclusionExtension <String[]>]
+[-ExclusionProcess <String[]>] [-ExclusionIpAddress <String[]>]
+[-ThreatIDDefaultAction_Ids <Int64[]>] [-ThreatIDDefaultAction_Actions <ThreatAction[]>]
+[-AttackSurfaceReductionOnlyExclusions <String[]>]
+[-ControlledFolderAccessAllowedApplications <String[]>]
+[-ControlledFolderAccessProtectedFolders <String[]>] [-AttackSurfaceReductionRules_Ids <String[]>]
+[-AttackSurfaceReductionRules_Actions <ASRRuleActionType[]>] [-Force] [-CimSession <CimSession[]>]
+[-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Add-MpPreference** cmdlet modifies settings for Windows Defender.
-Use this cmdlet to add exclusions for file name extensions, paths, and processes, and to add default actions for high, moderate, and low threats.
+
+The `Add-MpPreference` cmdlet modifies settings for Windows Defender. Use this cmdlet to add
+exclusions for file name extensions, paths, and processes, and to add default actions for high,
+moderate, and low threats.
 
 ## EXAMPLES
 
 ### Example 1: Add a folder to the exclusion list
+
 ```powershell
-Add-MpPreference -ExclusionPath "C:\Temp"
+Add-MpPreference -ExclusionPath 'C:\Temp'
 ```
 
 This command adds the folder C:\Temp to the exclusion list.
 The command disables Windows Defender scheduled and real-time scanning for files in this folder.
 
 ### Example 2: Allow an application to access folders
+
 ```powershell
-Add-MpPreference -ControlledFolderAccessAllowedApplications "c:\apps\test.exe"
+Add-MpPreference -ControlledFolderAccessAllowedApplications 'c:\apps\test.exe'
 ```
 
 This command allows the specified application to make changes in controlled folders.
@@ -48,14 +54,17 @@ This command allows the specified application to make changes in controlled fold
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete. 
 
-The cmdlet immediately returns an object that represents the job and then displays the command prompt. 
-You can continue to work in the session while the job completes. 
-To manage the job, use the `*-Job` cmdlets. 
-To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
 
-For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
+The cmdlet immediately returns an object that represents the job and then displays the command
+prompt. You can continue to work in the session while the job completes. To manage the job, use the
+`*-Job` cmdlets. To get the job results, use the
+[Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet.
+
+For more information about Windows PowerShell background jobs, see
+[about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
 ```yaml
 Type: SwitchParameter
@@ -70,9 +79,15 @@ Accept wildcard characters: False
 ```
 
 ### -AttackSurfaceReductionOnlyExclusions
-Specifies the files and paths to exclude from attack surface reduction (ASR) rules. Specifies the folders or files and resources that should be excluded from ASR rules. Enter a folder path or a fully qualified resource name. For example, `C:\Windows` excludes all files in that directory. `C:\Windows\App.exe` excludes only that specific file in that specific folder.
 
-See the [ASR rules](/windows/security/threat-protection/microsoft-defender-atp/enable-attack-surface-reduction#exclude-files-and-folders-from-asr-rules) topic for more information about excluding files and folders from ASR rules.
+Specifies the files and paths to exclude from attack surface reduction (ASR) rules. Specifies the
+folders or files and resources that should be excluded from ASR rules. Enter a folder path or a
+fully qualified resource name. For example, `C:\Windows` excludes all files in that directory.
+`C:\Windows\App.exe` excludes only that specific file in that specific folder.
+
+See the
+[ASR rules](/windows/security/threat-protection/microsoft-defender-atp/enable-attack-surface-reduction#exclude-files-and-folders-from-asr-rules)
+topic for more information about excluding files and folders from ASR rules.
 
 ```yaml
 Type: String[]
@@ -87,8 +102,10 @@ Accept wildcard characters: False
 ```
 
 ### -AttackSurfaceReductionRules_Actions
-Specifies the states of attack surface reduction rules specified by using the **AttackSurfaceReductionRules_Ids** parameter.
-If you add multiple rules as a comma-separated list, specify their states separately as a comma-separated list.
+
+Specifies the states of attack surface reduction rules specified by using the
+**AttackSurfaceReductionRules_Ids** parameter. If you add multiple rules as a comma-separated list,
+specify their states separately as a comma-separated list.
 
 ```yaml
 Type: ASRRuleActionType[]
@@ -103,10 +120,10 @@ Accept wildcard characters: False
 ```
 
 ### -AttackSurfaceReductionRules_Ids
-Specifies the IDs of attack surface reduction rules.
-Use the **AttackSurfaceReductionRules_Actions** parameter to specify the state for each rule. 
-If you add multiple rules as a comma-separated list, specify their states separately as a comma-separated list.
 
+Specifies the IDs of attack surface reduction rules. Use the **AttackSurfaceReductionRules_Actions**
+parameter to specify the state for each rule. If you add multiple rules as a comma-separated list,
+specify their states separately as a comma-separated list.
 
 ```yaml
 Type: String[]
@@ -121,9 +138,11 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. 
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. 
-The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967)
+or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -138,6 +157,7 @@ Accept wildcard characters: False
 ```
 
 ### -ControlledFolderAccessAllowedApplications
+
 Specifies applications that can make changes in controlled folders.
 
 ```yaml
@@ -153,6 +173,7 @@ Accept wildcard characters: False
 ```
 
 ### -ControlledFolderAccessProtectedFolders
+
 Specifies more folders to protect.
 
 ```yaml
@@ -168,8 +189,9 @@ Accept wildcard characters: False
 ```
 
 ### -ExclusionExtension
-Specifies an array of file name extensions, such as obj or lib, to exclude from scheduled, custom, and real-time scanning.
-This cmdlet adds these file name extensions to the exclusions.
+
+Specifies an array of file name extensions, such as obj or lib, to exclude from scheduled, custom,
+and real-time scanning. This cmdlet adds these file name extensions to the exclusions.
 
 ```yaml
 Type: String[]
@@ -184,6 +206,7 @@ Accept wildcard characters: False
 ```
 
 ### -ExclusionIpAddress
+
 Specifies an array of IP addresses to exclude from scheduled and real-time scanning.
 
 ```yaml
@@ -199,6 +222,7 @@ Accept wildcard characters: False
 ```
 
 ### -ExclusionPath
+
 Specifies an array of file paths to exclude from scheduled and real-time scanning.
 You can specify a folder to exclude all the files under the folder.
 
@@ -215,11 +239,11 @@ Accept wildcard characters: False
 ```
 
 ### -ExclusionProcess
-Specifies an array of processes, as paths to process images.
-This cmdlet excludes any files opened by the processes that you specify from scheduled and real-time scanning.
-Specifying this parameter excludes files opened by executable programs only.
-The cmdlet does not exclude the processes themselves.
-To exclude a process, specify it by using the **ExclusionPath** parameter.
+
+Specifies an array of processes, as paths to process images. This cmdlet excludes any files opened
+by the processes that you specify from scheduled and real-time scanning. Specifying this parameter
+excludes files opened by executable programs only. The cmdlet does not exclude the processes
+themselves. To exclude a process, specify it by using the **ExclusionPath** parameter.
 
 ```yaml
 Type: String[]
@@ -234,6 +258,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Forces the command to run without asking for user confirmation.
 
 ```yaml
@@ -249,15 +274,16 @@ Accept wildcard characters: False
 ```
 
 ### -ThreatIDDefaultAction_Actions
-Specifies an array of the actions to take for the IDs specified by using the **ThreatIDDefaultAction_Ids** parameter.
-The acceptable values for this parameter are:
 
-- 1: Clean 
-- 2: Quarantine 
-- 3: Remove 
-- 6: Allow 
-- 8: UserDefined 
-- 9: NoAction 
+Specifies an array of the actions to take for the IDs specified by using the
+**ThreatIDDefaultAction_Ids** parameter. The acceptable values for this parameter are:
+
+- 1: Clean
+- 2: Quarantine
+- 3: Remove
+- 6: Allow
+- 8: UserDefined
+- 9: NoAction
 - 10: Block
 
 ```yaml
@@ -274,6 +300,7 @@ Accept wildcard characters: False
 ```
 
 ### -ThreatIDDefaultAction_Ids
+
 Specifies an array of threat IDs.
 This cmdlet adds the default action for the threat IDs that you specify.
 
@@ -290,9 +317,12 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-If this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
-The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
 
 ```yaml
 Type: Int32
@@ -307,7 +337,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -322,4 +356,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-MpPreference](./Remove-MpPreference.md)
 
 [Set-MpPreference](./Set-MpPreference.md)
-

--- a/docset/winserver2022-ps/defender/Add-MpPreference.md
+++ b/docset/winserver2022-ps/defender/Add-MpPreference.md
@@ -190,7 +190,7 @@ Accept wildcard characters: False
 
 ### -ExclusionExtension
 
-Specifies an array of file name extensions, such as obj or lib, to exclude from scheduled, custom,
+Specifies an array of file name extensions, such as `obj` or `lib`, to exclude from scheduled, custom,
 and real-time scanning. This cmdlet adds these file name extensions to the exclusions.
 
 ```yaml
@@ -278,13 +278,13 @@ Accept wildcard characters: False
 Specifies an array of the actions to take for the IDs specified by using the
 **ThreatIDDefaultAction_Ids** parameter. The acceptable values for this parameter are:
 
-- 1: Clean
-- 2: Quarantine
-- 3: Remove
-- 6: Allow
-- 8: UserDefined
-- 9: NoAction
-- 10: Block
+- `1`: Clean
+- `2`: Quarantine
+- `3`: Remove
+- `6`: Allow
+- `8`: UserDefined
+- `9`: NoAction
+- `10`: Block
 
 ```yaml
 Type: ThreatAction[]

--- a/docset/winserver2022-ps/defender/Defender.md
+++ b/docset/winserver2022-ps/defender/Defender.md
@@ -10,7 +10,9 @@ title: Defender
 ---
 
 # Defender Module
+
 ## Description
+
 This reference provides functions descriptions and syntax for all Defender-specific functions. 
 It lists the functions in alphabetical order based on the verb at the beginning of the functions.
 
@@ -18,40 +20,51 @@ It lists the functions in alphabetical order based on the verb at the beginning 
 > You might also hear these functions being referred to as cmdlets. They were designed to appear like cmdlets, even though they were developed as PowerShell functions.
 
 ## Defender Cmdlets
+
 ### [Add-MpPreference](./Add-MpPreference.md)
+
 Modifies settings for Windows Defender.
 
 ### [Get-MpComputerStatus](./Get-MpComputerStatus.md)
+
 Gets the status of antimalware software on the computer.
 
 ### [Get-MpPreference](./Get-MpPreference.md)
+
 Gets preferences for the Windows Defender scans and updates.
 
 ### [Get-MpThreat](./Get-MpThreat.md)
+
 Gets the history of threats detected on the computer.
 
 ### [Get-MpThreatCatalog](./Get-MpThreatCatalog.md)
+
 Gets known threats from the definitions catalog.
 
 ### [Get-MpThreatDetection](./Get-MpThreatDetection.md)
+
 Gets active and past malware threats that Windows Defender detected.
 
 ### [Remove-MpPreference](./Remove-MpPreference.md)
+
 Removes exclusions or default actions.
 
 ### [Remove-MpThreat](./Remove-MpThreat.md)
+
 Removes active threats from a computer.
 
 ### [Set-MpPreference](./Set-MpPreference.md)
+
 Configures preferences for Windows Defender scans and updates.
 
 ### [Start-MpScan](./Start-MpScan.md)
+
 Starts a scan on a computer.
 
 ### [Start-MpWDOScan](./Start-MpWDOScan.md)
+
 Starts a Windows Defender offline scan.
 
 ### [Update-MpSignature](./Update-MpSignature.md)
+
 Updates the antimalware definitions on a computer.
-
-

--- a/docset/winserver2022-ps/defender/Get-MpComputerStatus.md
+++ b/docset/winserver2022-ps/defender/Get-MpComputerStatus.md
@@ -16,15 +16,19 @@ Gets the status of antimalware software on the computer.
 ## SYNTAX
 
 ```
-Get-MpComputerStatus [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
+Get-MpComputerStatus [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+[<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-MpComputerStatus** cmdlet gets the status of antimalware software installed on the computer.
+
+The `Get-MpComputerStatus` cmdlet gets the status of antimalware software installed on the
+computer.
 
 ## EXAMPLES
 
 ### Example 1: Get the computer status
+
 ```
 PS C:\> Get-MpComputerStatus
 AMEngineVersion                 : 1.1.9700.0
@@ -66,14 +70,17 @@ This command gets the status of antimalware protection software installed on the
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete. 
 
-The cmdlet immediately returns an object that represents the job and then displays the command prompt. 
-You can continue to work in the session while the job completes. 
-To manage the job, use the `*-Job` cmdlets. 
-To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
 
-For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
+The cmdlet immediately returns an object that represents the job and then displays the command
+prompt. You can continue to work in the session while the job completes. To manage the job, use the
+`*-Job` cmdlets. To get the job results, use the
+[Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet.
+
+For more information about Windows PowerShell background jobs, see
+[about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
 ```yaml
 Type: SwitchParameter
@@ -88,9 +95,11 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. 
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. 
-The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967)
+or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -105,9 +114,12 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-If this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
-The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
 
 ```yaml
 Type: Int32
@@ -122,12 +134,16 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
-## INPUTS
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216). ## INPUTS
 
 ## OUTPUTS
 
 ## NOTES
 
 ## RELATED LINKS
+
 [Get-MpComputerStatus Properties](/previous-versions/windows/desktop/defender/msft-mpcomputerstatus#properties)

--- a/docset/winserver2022-ps/defender/Get-MpPreference.md
+++ b/docset/winserver2022-ps/defender/Get-MpPreference.md
@@ -16,15 +16,20 @@ Gets preferences for the Windows Defender scans and updates.
 ## SYNTAX
 
 ```
-Get-MpPreference [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
+Get-MpPreference [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+[<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-MpPreference** cmdlet gets preferences for the Windows Defender scans and updates. For more information about the preferences that this cmdlet retrieves, see [Windows Defender Preferences Class](/previous-versions/windows/desktop/legacy/dn455323(v=vs.85)).
+
+The `Get-MpPreference` cmdlet gets preferences for the Windows Defender scans and updates. For more
+information about the preferences that this cmdlet retrieves, see
+[Windows Defender Preferences Class](/previous-versions/windows/desktop/legacy/dn455323(v=vs.85)).
 
 ## EXAMPLES
 
 ### Example 1: View the scheduled scan day
+
 ```
 PS C:\> $Preferences = Get-MpPreference
 PS C:\> $Preferences.ScanScheduleDay
@@ -32,19 +37,23 @@ PS C:\> $Preferences.ScanScheduleDay
 
 The first command gets the preferences, and then stores them in the **$Preferences** variable.
 
-The second command uses standard dot syntax to display the **ScanScheduleDay** property of the object stored in the **$Preferences** variable.
+The second command uses standard dot syntax to display the **ScanScheduleDay** property of the
+object stored in the **$Preferences** variable.
 
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete. 
 
-The cmdlet immediately returns an object that represents the job and then displays the command prompt. 
-You can continue to work in the session while the job completes. 
-To manage the job, use the `*-Job` cmdlets. 
-To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
 
-For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
+The cmdlet immediately returns an object that represents the job and then displays the command
+prompt. You can continue to work in the session while the job completes. To manage the job, use the
+`*-Job` cmdlets. To get the job results, use the
+[Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet.
+
+For more information about Windows PowerShell background jobs, see
+[about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
 ```yaml
 Type: SwitchParameter
@@ -59,9 +68,11 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. 
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. 
-The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967)
+or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -76,9 +87,12 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-If this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
-The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
 
 ```yaml
 Type: Int32
@@ -93,7 +107,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docset/winserver2022-ps/defender/Get-MpThreat.md
+++ b/docset/winserver2022-ps/defender/Get-MpThreat.md
@@ -16,22 +16,27 @@ Gets the history of threats detected on the computer.
 ## SYNTAX
 
 ### DefaultSet (Default)
+
 ```
 Get-MpThreat [<CommonParameters>]
 ```
 
 ### ById
+
 ```
 Get-MpThreat [-ThreatID <Int64[]>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
- [<CommonParameters>]
+[<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-MpThreat** cmdlet gets the history of threats that Windows Defender detected on the computer.
+
+The `Get-MpThreat` cmdlet gets the history of threats that Windows Defender detected on the
+computer.
 
 ## EXAMPLES
 
 ### Example 1: Get the history of a detected threat
+
 ```
 PS C:\> Get-MpThreat -ThreatID 1994
 ```
@@ -41,14 +46,17 @@ This command gets the history of the threat on the local computer that has the I
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete. 
 
-The cmdlet immediately returns an object that represents the job and then displays the command prompt. 
-You can continue to work in the session while the job completes. 
-To manage the job, use the `*-Job` cmdlets. 
-To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
 
-For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
+The cmdlet immediately returns an object that represents the job and then displays the command
+prompt. You can continue to work in the session while the job completes. To manage the job, use the
+`*-Job` cmdlets. To get the job results, use the
+[Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet.
+
+For more information about Windows PowerShell background jobs, see
+[about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
 ```yaml
 Type: SwitchParameter
@@ -63,9 +71,11 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. 
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. 
-The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967)
+or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -80,6 +90,7 @@ Accept wildcard characters: False
 ```
 
 ### -ThreatID
+
 Specifies an array of threat IDs.
 This cmdlet gets the history of the threats that you specify.
 
@@ -96,9 +107,12 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-If this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
-The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
 
 ```yaml
 Type: Int32
@@ -113,7 +127,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docset/winserver2022-ps/defender/Get-MpThreatCatalog.md
+++ b/docset/winserver2022-ps/defender/Get-MpThreatCatalog.md
@@ -16,23 +16,27 @@ Gets known threats from the definitions catalog.
 ## SYNTAX
 
 ### DefaultSet (Default)
+
 ```
 Get-MpThreatCatalog [<CommonParameters>]
 ```
 
 ### ById
+
 ```
 Get-MpThreatCatalog [-ThreatID <Int64[]>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 The **Get-MpThreatCatalog** cmdlet gets known threats from the Windows Defender definitions catalog.
 The definitions catalog contains references to all known threats that Windows Defender can identify.
 
 ## EXAMPLES
 
 ### Example 1: Get a known threat from the definitions catalog
+
 ```
 PS C:\> Get-MpThreatCatalog -ThreatID 1994
 ```
@@ -42,14 +46,17 @@ This command gets the known threat that has the ID 1994.
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete. 
 
-The cmdlet immediately returns an object that represents the job and then displays the command prompt. 
-You can continue to work in the session while the job completes. 
-To manage the job, use the `*-Job` cmdlets. 
-To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
 
-For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
+The cmdlet immediately returns an object that represents the job and then displays the command
+prompt. You can continue to work in the session while the job completes. To manage the job, use the
+`*-Job` cmdlets. To get the job results, use the
+[Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet.
+
+For more information about Windows PowerShell background jobs, see
+[about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
 ```yaml
 Type: SwitchParameter
@@ -64,9 +71,11 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. 
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. 
-The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967)
+or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -81,6 +90,7 @@ Accept wildcard characters: False
 ```
 
 ### -ThreatID
+
 Specifies an array of threat IDs.
 This cmdlet gets the threats that you specify from the definitions catalog.
 
@@ -97,9 +107,12 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-If this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
-The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
 
 ```yaml
 Type: Int32
@@ -114,7 +127,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -129,4 +146,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-MpThreat](./Remove-MpThreat.md)
 
 [Get-MpThreatDetection](./Get-MpThreatDetection.md)
-


### PR DESCRIPTION
# PR Summary
This change adds CR/LF, removes trailing spaces, changes ** to ` for PowerShell cmdlet names.

- Fixes #3348

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
