### PR TITLE
Updated description when access is granted

### DIFF
--- a/docset/winserver2022-ps/failoverclusters/Grant-ClusterAccess.md
+++ b/docset/winserver2022-ps/failoverclusters/Grant-ClusterAccess.md
@@ -1,8 +1,8 @@
 ---
-description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
+description: Use this article to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: Microsoft.FailoverClusters.PowerShell.dll-Help.xml
 Module Name: FailoverClusters
-ms.date: 12/20/2016
+ms.date: 05/17/2023
 online version: https://docs.microsoft.com/powershell/module/failoverclusters/grant-clusteraccess?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Grant-ClusterAccess
@@ -21,8 +21,10 @@ Grant-ClusterAccess [-User] <StringCollection> [-Full] [-ReadOnly] [-InputObject
 ```
 
 ## DESCRIPTION
-The **Grant-ClusterAccess** cmdlet grants access to a failover cluster, either full access or read-only access.
-To provide someone with read-only access to the cluster, use the **ReadOnly** parameter.
+The **Grant-ClusterAccess** cmdlet grants access to a failover cluster, either full access or
+read-only access. To provide someone with read-only access to the cluster, use the **ReadOnly**
+parameter. Granting full access to the cluster is equivalent to granting full access to each of the
+cluster nodes.
 
 ## EXAMPLES
 


### PR DESCRIPTION
# PR Summary

This change makes users aware that _granting full access to the cluster is equivalent to granting full access to each of the cluster nodes_ in the documentation for Grant-ClusterAccess cmdlet.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].