### PR TITLE
Address formatting in articles for some ActiveDirectory cmdlets

### DIFF
--- a/docset/winserver2022-ps/activedirectory/Add-ADCentralAccessPolicyMember.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADCentralAccessPolicyMember.md
@@ -38,8 +38,8 @@ $params = @{
 Add-ADCentralAccessPolicyMember @params
 ```
 
-This command adds the central access rules Finance Documents Rule and Corporate Documents Rule to
-the central access policy Finance Policy.
+This command adds the central access rules `Finance Documents Rule` and `Corporate Documents Rule`
+to the central access policy Finance Policy.
 
 ### EXAMPLE 2
 
@@ -238,8 +238,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/docset/winserver2022-ps/activedirectory/Add-ADCentralAccessPolicyMember.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADCentralAccessPolicyMember.md
@@ -16,46 +16,59 @@ Adds central access rules to a central access policy in Active Directory.
 ## SYNTAX
 
 ```
-Add-ADCentralAccessPolicyMember [-WhatIf] [-Confirm] [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADCentralAccessPolicy> [-Members] <ADCentralAccessRule[]> [-PassThru] [-Server <String>]
- [<CommonParameters>]
+Add-ADCentralAccessPolicyMember [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
+ [-Credential <PSCredential>] [-Identity] <ADCentralAccessPolicy>
+ [-Members] <ADCentralAccessRule[]> [-PassThru] [-Server <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Add-ADCentralAccessPolicyMember** cmdlet adds central access rules to a central access policy in Active Directory.
+
+The `Add-ADCentralAccessPolicyMember` cmdlet adds central access rules to a central access policy
+in Active Directory.
 
 ## EXAMPLES
 
-### Example 1: Add central access rules to an existing central access policy
-```
-PS C:\> Add-ADCentralAccessPolicyMember -Identity "Finance Policy" -Member "Finance Documents Rule","Corporate Documents Rule"
+### EXAMPLE 1
+
+```powershell
+$params = @{
+    Identity = 'Finance Policy'
+    Member = 'Finance Documents Rule', 'Corporate Documents Rule'
+}
+Add-ADCentralAccessPolicyMember @params
 ```
 
-This command adds the central access rules Finance Documents Rule and Corporate Documents Rule to the central access policy Finance Policy.
+This command adds the central access rules Finance Documents Rule and Corporate Documents Rule to
+the central access policy Finance Policy.
 
-### Example 2: Add a central access rule to an existing central access policy
-```
-PS C:\> Get-ADCentralAccessPolicy -Filter "Name -like 'Corporate*'" | Add-ADCentralAccessPolicyMember -Members "Corporate Documents Rule"
+### EXAMPLE 2
+
+```powershell
+Get-ADCentralAccessPolicy -Filter "Name -like 'Corporate*'" |
+    Add-ADCentralAccessPolicyMember -Members 'Corporate Documents Rule'
 ```
 
-This command gets all central access policies that have a name that starts with Corporate and then passes this information to Add-ADCentralAccessPolicyMember by using the pipeline operator.
-The **Add-ADCentralAccessPolicyMember** cmdlet then adds the central access rule with the name Corporate Documents Rule to it.
+This command gets all central access policies that have a name that starts with `Corporate` and then
+passes this information to `Add-ADCentralAccessPolicyMember` by using the pipeline operator. The
+`Add-ADCentralAccessPolicyMember` cmdlet then adds the central access rule with the name
+`Corporate Documents Rule` to it.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -68,10 +81,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -83,20 +97,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User0`1 or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -108,19 +126,21 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory object by providing one of the following property values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory object by providing one of the following property values. The
+identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the
+attribute. The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID (objectGUID) 
-- A security identifier (objectSid) 
-- A SAM account name (sAMAccountName)
+- A GUID (**objectGUID**)
+- A security identifier (**objectSid**)
+- A SAM account name (**sAMAccountName**)
 
-This parameter can also get this object through the pipeline or you can set this parameter to an object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+object instance.
 
 ```yaml
-Type: ADCentralAccessPolicy
+Type: Microsoft.ActiveDirectory.Management.ADCentralAccessPolicy
 Parameter Sets: (All)
 Aliases: 
 
@@ -132,21 +152,23 @@ Accept wildcard characters: False
 ```
 
 ### -Members
-Specifies a set of central access rule (CAR) objects in a comma-separated list to add to a central access policy.
-To identify each object, use one of the following property values: 
+
+Specifies a set of central access rule (CAR) objects in a comma-separated list to add to a central
+access policy. To identify each object, use one of the following property values:
 
 - Name
 - A distinguished name
-- GUID (objectGUID) 
+- GUID (**objectGUID**)
 
- Note: The identifier in parentheses is the LDAP display name.
+> [!NOTE]
+> The identifier in parentheses is the LDAP display name.
 
 You can also provide objects to this parameter directly.
 
 You cannot pass objects through the pipeline to this parameter.
 
 ```yaml
-Type: ADCentralAccessRule[]
+Type: Microsoft.ActiveDirectory.Management.ADCentralAccessRule[]
 Parameter Sets: (All)
 Aliases: 
 
@@ -158,11 +180,12 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns an object representing the item with which you are working.
 By default, this cmdlet does not generate any output.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: 
 
@@ -174,30 +197,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following:  Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways:  
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -209,11 +237,12 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -225,26 +254,32 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None or Microsoft.ActiveDirectory.Management.ADCentralAccessPolicy
-An **ADCentralAccessPolicy** object is received by the *Identity* parameter.
+
+An **ADCentralAccessPolicy** object is received by the **Identity** parameter.
 
 ## OUTPUTS
 
 ### None or Microsoft.ActiveDirectory.ADCentralAccessPolicy
-Returns the modified **ADCentralAccessPolicy** object when the *PassThru* parameter is specified.
+
+Returns the modified **ADCentralAccessPolicy** object when the **PassThru** parameter is specified.
 By default, this cmdlet does not generate any output.
 
 ## NOTES
-* This cmdlet does not work with a read-only domain controller.
-* This cmdlet does not work with an Active Directory snapshot.
+
+- This cmdlet does not work with a read-only domain controller.
+- This cmdlet does not work with an Active Directory snapshot.
 
 ## RELATED LINKS
 
 [Remove-ADCentralAccessPolicyMember](./Remove-ADCentralAccessPolicyMember.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
-

--- a/docset/winserver2022-ps/activedirectory/Add-ADComputerServiceAccount.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADComputerServiceAccount.md
@@ -55,7 +55,7 @@ This command adds the service account `SvcAcct1` to a Computer Account `Computer
 
 ### EXAMPLE 2
 
-```
+```powershell
 Add-ADComputerServiceAccount -Computer ComputerAcct1 -ServiceAccount SvcAcct1, SvcAcct2
 ```
 

--- a/docset/winserver2022-ps/activedirectory/Add-ADComputerServiceAccount.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADComputerServiceAccount.md
@@ -40,7 +40,7 @@ account by its distinguished name, GUID, Security Identifier (SID) or Security A
 `$<localServiceAccountObject>`. If you are specifying more than one account, use a comma-separated
 list.
 
-> {!NOTE]
+> [!NOTE]
 > Adding a service account is a different operation than installing the service account locally.
 
 ## EXAMPLES
@@ -290,8 +290,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/docset/winserver2022-ps/activedirectory/Add-ADComputerServiceAccount.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADComputerServiceAccount.md
@@ -179,23 +179,23 @@ following cases:
 
 - If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
   is automatically generated from this distinguished name.
-- If running cmdlets from an Active Directory provider drive, the default value of **Partition**is
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
   automatically generated from the current path in the drive.
-- If none of the previous cases apply, the default value of **Partition**is set to the default
+- If none of the previous cases apply, the default value of **Partition** is set to the default
   partition or naming context of the target domain.
 
 In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for
-**Partition**is set in the following cases:
+**Partition** is set in the following cases:
 
-- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**is
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition** is
   automatically generated from this distinguished name.
-- If running cmdlets from an Active Directory provider drive, the default value of **Partition**is
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
   automatically generated from the current path in the drive.
-- If the target AD LDS instance has a default naming context, the default value of **Partition**is
+- If the target AD LDS instance has a default naming context, the default value of **Partition** is
   set to the default naming context. To specify a default naming context for an AD LDS environment,
   set the **msDS-defaultNamingContext** property of the Active Directory directory service agent
   (DSA) object (**nTDSDSA**) for the AD LDS instance.
-- If none of the previous cases apply, the **Partition**parameter will not take any default value.
+- If none of the previous cases apply, the **Partition** parameter will not take any default value.
 
 ```yaml
 Type: System.String

--- a/docset/winserver2022-ps/activedirectory/Add-ADComputerServiceAccount.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADComputerServiceAccount.md
@@ -187,8 +187,8 @@ following cases:
 In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for
 **Partition** is set in the following cases:
 
-- If the **Identity** parameter is set to a distinguished name, the default value of **Partition** is
-  automatically generated from this distinguished name.
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
 - If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
   automatically generated from the current path in the drive.
 - If the target AD LDS instance has a default naming context, the default value of **Partition** is

--- a/docset/winserver2022-ps/activedirectory/Add-ADComputerServiceAccount.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADComputerServiceAccount.md
@@ -16,57 +16,68 @@ Adds one or more service accounts to an Active Directory computer.
 ## SYNTAX
 
 ```
-Add-ADComputerServiceAccount [-WhatIf] [-Confirm] [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADComputer> [-Partition <String>] [-PassThru] [-Server <String>]
- [-ServiceAccount] <ADServiceAccount[]> [<CommonParameters>]
+Add-ADComputerServiceAccount [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
+ [-Credential <PSCredential>] [-Identity] <ADComputer> [-Partition <String>] [-PassThru]
+ [-Server <String>] [-ServiceAccount] <ADServiceAccount[]> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Add-ADComputerServiceAccount** cmdlet adds one or more computer service accounts to an Active Directory computer.
 
-The *Computer* parameter specifies the Active Directory computer that will host the new service accounts.
-You can identify a computer by its distinguished name, GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.
-You can also set the *Computer* parameter to a computer object variable, such as `$<localComputerobject>`, or pass a computer object through the pipeline to the *Computer* parameter.
-For example, you can use the **Get-ADComputer** cmdlet to retrieve a computer object and then pass the object through the pipeline to the **Add-ADComputerServiceAccount** cmdlet.
+The `Add-ADComputerServiceAccount` cmdlet adds one or more computer service accounts to an Active
+Directory computer.
 
-The *ServiceAccount* parameter specifies the service accounts to add.
-You can identify a service account by its distinguished name, GUID, Security Identifier (SID) or Security Accounts Manager (SAM) account name.
-You can also specify service account object variables, such as `$<localServiceAccountObject>`.
-If you are specifying more than one account, use a comma-separated list.
+The **Computer** parameter specifies the Active Directory computer that will host the new service
+accounts. You can identify a computer by its distinguished name, GUID, security identifier (SID) or
+Security Accounts Manager (SAM) account name. You can also set the **Computer** parameter to a
+computer object variable, such as `$<localComputerobject>`, or pass a computer object through the
+pipeline to the **Computer** parameter. For example, you can use the `Get-ADComputer` cmdlet to
+retrieve a computer object and then pass the object through the pipeline to the
+`Add-ADComputerServiceAccount` cmdlet.
 
-Note: Adding a service account is a different operation than installing the service account locally.
+The **ServiceAccount** parameter specifies the service accounts to add. You can identify a service
+account by its distinguished name, GUID, Security Identifier (SID) or Security Accounts Manager
+(SAM) account name. You can also specify service account object variables, such as
+`$<localServiceAccountObject>`. If you are specifying more than one account, use a comma-separated
+list.
+
+> {!NOTE]
+> Adding a service account is a different operation than installing the service account locally.
 
 ## EXAMPLES
 
-### Example 1: Add a service account to a specified computer account
-```
-PS C:\> Add-ADComputerServiceAccount -Computer ComputerAcct1 -ServiceAccount SvcAcct1
+### EXAMPLE 1
+
+```powershell
+Add-ADComputerServiceAccount -Computer ComputerAcct1 -ServiceAccount SvcAcct1
 ```
 
-This command adds the service account SvcAcct1 to a Computer Account ComputerAcct1.
+This command adds the service account `SvcAcct1` to a Computer Account `ComputerAcct1`.
 
-### Example 2: Add multiple service accounts to a specified computer account
+### EXAMPLE 2
+
 ```
-PS C:\> Add-ADComputerServiceAccount -Computer ComputerAcct1 -ServiceAccount SvcAcct1,SvcAcct2
+Add-ADComputerServiceAccount -Computer ComputerAcct1 -ServiceAccount SvcAcct1, SvcAcct2
 ```
 
-This command adds two service accounts, SvcAcct1 and SvcAcct2, to a Computer Account ComputerAcct1.
+This command adds two service accounts, `SvcAcct1` and `SvcAcct2`, to a Computer Account
+`ComputerAcct1`.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -79,10 +90,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -94,20 +106,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -119,23 +135,25 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory computer object by providing one of the following property values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory computer object by providing one of the following property values. The
+identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the
+attribute. The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID (objectGUID) 
-- A security identifier (objectSid) 
-- Security Accounts Manager account name (sAMAccountName)
+- A GUID (**objectGUID**)
+- A security identifier (**objectSid**)
+- Security Accounts Manager account name (**sAMAccountName**)
 
-The cmdlet searches the default naming context or partition to find the object.
-If the identifier given is a distinguished name, the partition to search is computed from that distinguished name.
-If two or more objects are found, the cmdlet returns a non-terminating error.
+The cmdlet searches the default naming context or partition to find the object. If the identifier
+given is a distinguished name, the partition to search is computed from that distinguished name. If
+two or more objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to a computer object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to a
+computer object instance.
 
 ```yaml
-Type: ADComputer
+Type: Microsoft.ActiveDirectory.Management.ADComputer
 Parameter Sets: (All)
 Aliases: Computer
 
@@ -147,30 +165,40 @@ Accept wildcard characters: False
 ```
 
 ### -Partition
-Specifies the distinguished name of an Active Directory partition.
-The distinguished name must be one of the naming contexts on the current directory server.
-The cmdlet searches this partition to find the object defined by the *Identity* parameter.
 
-In many cases, a default value is used for the *Partition* parameter if no value is specified.
-The rules for determining the default value are given below.
-Note that rules listed first are evaluated first and once a default value can be determined, no further rules are evaluated.
+Specifies the distinguished name of an Active Directory partition. The distinguished name must be
+one of the naming contexts on the current directory server. The cmdlet searches this partition to
+find the object defined by the **Identity** parameter.
 
-In Active Directory Domain Services environments, a default value for *Partition* is set in the following cases: 
+In many cases, a default value is used for the **Partition** parameter if no value is specified. The
+rules for determining the default value are given below. Note that rules listed first are evaluated
+first and once a default value can be determined, no further rules are evaluated.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name. 
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If none of the previous cases apply, the default value of *Partition* is set to the default partition or naming context of the target domain.
+In Active Directory Domain Services environments, a default value for **Partition** is set in the
+following cases:
 
-In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for *Partition* is set in the following cases:
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition**is
+  automatically generated from the current path in the drive.
+- If none of the previous cases apply, the default value of **Partition**is set to the default
+  partition or naming context of the target domain.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name.
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If the target AD LDS instance has a default naming context, the default value of *Partition* is set to the default naming context.
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent (DSA) object (**nTDSDSA**) for the AD LDS instance. 
-- If none of the previous cases apply, the *Partition* parameter will not take any default value.
+In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for
+**Partition**is set in the following cases:
+
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**is
+  automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition**is
+  automatically generated from the current path in the drive.
+- If the target AD LDS instance has a default naming context, the default value of **Partition**is
+  set to the default naming context. To specify a default naming context for an AD LDS environment,
+  set the **msDS-defaultNamingContext** property of the Active Directory directory service agent
+  (DSA) object (**nTDSDSA**) for the AD LDS instance.
+- If none of the previous cases apply, the **Partition**parameter will not take any default value.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -182,11 +210,12 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns an object representing the item with which you are working.
 By default, this cmdlet does not generate any output.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: 
 
@@ -198,30 +227,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways: 
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -233,16 +267,17 @@ Accept wildcard characters: False
 ```
 
 ### -ServiceAccount
+
 Specifies one or more Active Directory service accounts.
 The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID (objectGUID) 
-- A Security Identifier (objectSid) 
-- SAM account name (sAMAccountName)
+- A GUID (**objectGUID**)
+- A Security Identifier (**objectSid**)
+- SAM account name (**sAMAccountName**)
 
 ```yaml
-Type: ADServiceAccount[]
+Type: Microsoft.ActiveDirectory.Management.ADServiceAccount[]
 Parameter Sets: (All)
 Aliases: 
 
@@ -254,11 +289,12 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -270,23 +306,30 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADComputer
-A computer object is received by the *Computer* parameter.
+
+A computer object is received by the **Computer** parameter.
 
 ## OUTPUTS
 
 ### None or Microsoft.ActiveDirectory.Management.ADComputer
-This cmdlet returns the modified computer object when the *PassThru* parameter is specified.
-By default, this cmdlet does not generate any output.
+
+This cmdlet returns the modified computer object when the **PassThru** parameter is specified. By
+default, this cmdlet does not generate any output.
 
 ## NOTES
-* This cmdlet does not work with AD LDS.
-* This cmdlet does not work with a read-only domain controller.
-* This cmdlet does not work when targeting a snapshot using the *Server* parameter.
+
+- This cmdlet does not work with AD LDS.
+- This cmdlet does not work with a read-only domain controller.
+- This cmdlet does not work when targeting a snapshot using the **Server** parameter.
 
 ## RELATED LINKS
 
@@ -297,4 +340,3 @@ By default, this cmdlet does not generate any output.
 [Remove-ADComputerServiceAccount](./Remove-ADComputerServiceAccount.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
-

--- a/docset/winserver2022-ps/activedirectory/Add-ADDomainControllerPasswordReplicationPolicy.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADDomainControllerPasswordReplicationPolicy.md
@@ -116,8 +116,7 @@ Accept wildcard characters: False
 
 ### -AuthType
 
-Specifies the authentication method to use.
-The acceptable values for this parameter are:
+Specifies the authentication method to use. The acceptable values for this parameter are:
 
 - `Negotiate` or `0`
 - `Basic` or `1`

--- a/docset/winserver2022-ps/activedirectory/Add-ADDomainControllerPasswordReplicationPolicy.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADDomainControllerPasswordReplicationPolicy.md
@@ -16,68 +16,93 @@ Adds users, computers, and groups to the allowed or denied list of a read-only d
 ## SYNTAX
 
 ### AllowedPRP
+
 ```
-Add-ADDomainControllerPasswordReplicationPolicy [-WhatIf] [-Confirm] -AllowedList <ADPrincipal[]>
- [-AuthType <ADAuthType>] [-Credential <PSCredential>] [[-Identity] <ADDomainController>] [-Server <String>]
- [<CommonParameters>]
+Add-ADDomainControllerPasswordReplicationPolicy [-WhatIf] [-Confirm]
+ -AllowedList <ADPrincipal[]> [-AuthType <ADAuthType>] [-Credential <PSCredential>]
+ [[-Identity] <ADDomainController>] [-Server <String>] [<CommonParameters>]
 ```
 
 ### DeniedPRP
+
 ```
-Add-ADDomainControllerPasswordReplicationPolicy [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
- [-Credential <PSCredential>] -DeniedList <ADPrincipal[]> [[-Identity] <ADDomainController>] [-Server <String>]
- [<CommonParameters>]
+Add-ADDomainControllerPasswordReplicationPolicy [-WhatIf] [-Confirm]
+ [-AuthType <ADAuthType>] [-Credential <PSCredential>] -DeniedList <ADPrincipal[]>
+ [[-Identity] <ADDomainController>] [-Server <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Add-ADDomainControllerPasswordReplicationPolicy** cmdlet adds one or more users, computers, and groups to the allowed or denied list of a read-only domain controller (RODC) password replication policy.
 
-The *Identity* parameter specifies the read-only domain controller (RODC) that uses the allowed and denied lists to apply the password replication policy.
-You can identify a domain controller by its GUID, IPV4Address, global IPV6Address, or DNS host name.
-You can also identify a domain controller by the name of the server object that represents the domain controller, the distinguished name of the NTDS settings object of the server object, the GUID of the NTDS settings object of the server object under the configuration partition, or the distinguished name of the computer object that represents the domain controller.
-You can also set the *Identity* parameter to a domain controller object variable, such as `$<localDomainControllerObject>`, or pass a domain controller object through the pipeline to the *Identity* parameter.
-For example, you can use the **Get-ADDomainController** cmdlet to get a domain controller object and then pass the object through the pipeline to the **Add-ADDomainControllerPasswordReplicationPolicy** cmdlet.
-You must specify a read-only domain controller.
-If you specify a writeable domain controller for this parameter, the cmdlet returns a non-terminating error.
+The `Add-ADDomainControllerPasswordReplicationPolicy` cmdlet adds one or more users, computers,
+and groups to the allowed or denied list of a read-only domain controller (RODC) password
+replication policy.
 
-The *AllowedList* parameter specifies the users, computers, and groups to add to the allowed list.
-Similarly, the *DeniedList* parameter specifies the users, computers, and groups to add to the denied list.
-You must specify either one or both of the *AllowedList* and *DeniedList* parameters.
-You can identify a user, computer, or group by distinguished name, GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.
-You can also specify user, computer, or group variables, such as `$<localUserObject>`.
-If you are specifying more than one item, use a comma-separated list.
-If a specified user, computer, or group is not on the allowed or denied list, the cmdlet does not return an error.
+The **Identity** parameter specifies the read-only domain controller (RODC) that uses the allowed
+and denied lists to apply the password replication policy. You can identify a domain controller by
+its GUID, IPV4Address, global IPV6Address, or DNS host name. You can also identify a domain
+controller by the name of the server object that represents the domain controller, the distinguished
+name of the NTDS settings object of the server object, the GUID of the NTDS settings object of the
+server object under the configuration partition, or the distinguished name of the computer object
+that represents the domain controller. You can also set the **Identity** parameter to a domain
+controller object variable, such as `$<localDomainControllerObject>`, or pass a domain controller
+object through the pipeline to the **Identity** parameter. For example, you can use the
+`Get-ADDomainController` cmdlet to get a domain controller object and then pass the object through
+the pipeline to the `Add-ADDomainControllerPasswordReplicationPolicy` cmdlet. You must specify a
+read-only domain controller. If you specify a writeable domain controller for this parameter, the
+cmdlet returns a non-terminating error.
+
+The **AllowedList** parameter specifies the users, computers, and groups to add to the allowed list.
+Similarly, the **DeniedList** parameter specifies the users, computers, and groups to add to the
+denied list. You must specify either one or both of the **AllowedList** and **DeniedList**
+parameters. You can identify a user, computer, or group by distinguished name, GUID, security
+identifier (SID) or Security Accounts Manager (SAM) account name. You can also specify user,
+computer, or group variables, such as `$<localUserObject>`. If you are specifying more than one
+item, use a comma-separated list. If a specified user, computer, or group is not on the allowed or
+denied list, the cmdlet does not return an error.
 
 ## EXAMPLES
 
-### Example 1: Add user accounts with specified SamAccountNames to the allowed list
-```
-PS C:\> Add-ADDomainControllerPasswordReplicationPolicy -Identity "USER01-RODC1" -AllowedList "PattiFuller", "DavidChew"
+### Example 1
+
+```powershell
+$params = @{
+    Identity = 'USER01-RODC1'
+    AllowedList = 'PattiFuller', 'DavidChew'
+}
+Add-ADDomainControllerPasswordReplicationPolicy @params
 ```
 
-This command adds user accounts with the specified SamAccountNames to the Allowed list on the RODC specified by the *Identity* parameter.
+This command adds user accounts with the specified SamAccountNames to the Allowed list on the RODC
+specified by the **Identity** parameter.
 
-### Example 2: Add user accounts with specified SamAccountNames to the denied list
-```
-PS C:\> Add-ADDomainControllerPasswordReplicationPolicy -Identity "USER02-RODC1" -DeniedList "ElisaDaugherty ", "EvanNarvaez"
+### Example 2
+
+```powershell
+$params = @{
+    Identity = 'USER02-RODC1'
+    DeniedList = 'ElisaDaugherty', 'EvanNarvaez'
+}
+Add-ADDomainControllerPasswordReplicationPolicy @params
 ```
 
-This command adds user accounts with the specified SamAccountNames to the Denied list on the RODC specified by the *Identity* parameter.
+This command adds user accounts with the specified SamAccountNames to the Denied list on the RODC
+specified by the **Identity** parameter.
 
 ## PARAMETERS
 
 ### -AllowedList
-Specifies the users, computers, groups or other accounts to add to the list of accounts allowed to replicate their passwords to this RODC.
-You can specify more than one value by using a comma-separated list.
-The acceptable values for this parameter are:
+
+Specifies the users, computers, groups or other accounts to add to the list of accounts allowed to
+replicate their passwords to this RODC. You can specify more than one value by using a
+comma-separated list. The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID  (objectGUID) 
-- A security identifier (objectSid) 
-- A Security Accounts Manager (SAM) account name  (sAMAccountName)
+- A GUID  (**objectGUID**)
+- A security identifier (**objectSid**)
+- A Security Accounts Manager (SAM) account name  (**sAMAccountName**)
 
 ```yaml
-Type: ADPrincipal[]
+Type: Microsoft.ActiveDirectory.Management.ADPrincipal[]
 Parameter Sets: AllowedPRP
 Aliases: 
 
@@ -89,18 +114,19 @@ Accept wildcard characters: False
 ```
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -113,10 +139,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -128,24 +155,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
 
-Specifies the credentials for the security context under which the task is performed.
-If this security context doesn't have directory level permissions to perform the task, then an error is returned by the directory.
-If running under the context of an Active Directory module for Window PowerShell provider drive, the credentials information associated with the drive is used as the default value; otherwise, the currently logged on user security context is used.
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -157,17 +184,18 @@ Accept wildcard characters: False
 ```
 
 ### -DeniedList
-Specifies the users, computers, groups or other accounts to add to the list of accounts that are denied the right to replicate their passwords to this RODC.
-You can specify more than one value by using a comma-separated list.
-The acceptable values for this parameter are:
+
+Specifies the users, computers, groups or other accounts to add to the list of accounts that are
+denied the right to replicate their passwords to this RODC. You can specify more than one value by
+using a comma-separated list. The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID  (objectGUID) 
-- A security identifier (objectSid) 
-- A SAM account name (sAMAccountName)
+- A GUID  (**objectGUID**)
+- A security identifier (**objectSid**)
+- A Security Accounts Manager (SAM) account name  (**sAMAccountName**)
 
 ```yaml
-Type: ADPrincipal[]
+Type: Microsoft.ActiveDirectory.Management.ADPrincipal[]
 Parameter Sets: DeniedPRP
 Aliases: 
 
@@ -179,14 +207,15 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory domain controller object by providing one of the following values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
-The acceptable values for this parameter are:
 
-- A GUID (objectGUID) 
+Specifies an Active Directory domain controller object by providing one of the following values. The
+identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the
+attribute. The acceptable values for this parameter are:
+
+- A GUID (**objectGUID**)
 - An IPV4Address
-- A Global IPV6Address 
-- A   DNS Host Name (dNSHostName) 
+- A Global IPV6Address
+- A   DNS Host Name (**dNSHostName**)
 - A name of the server object
 - A distinguished name of the NTDS Settings object
 - A distinguished name of the server object that represents the domain controller
@@ -197,10 +226,11 @@ The acceptable values for this parameter are:
 The cmdlet searches the default naming context or partition to find the object.
 If two or more objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to an object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+object instance.
 
 ```yaml
-Type: ADDomainController
+Type: Microsoft.ActiveDirectory.Management.ADDomainController
 Parameter Sets: (All)
 Aliases: 
 
@@ -212,30 +242,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following:  Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways: 
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
-- By using the domain of the computer that runs Windows PowerShell
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
+- By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -247,11 +282,12 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -263,25 +299,30 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADDomainController
-An RODC object is received by the *Identity* parameter.
+
+An RODC object is received by the **Identity** parameter.
 
 ## OUTPUTS
 
-### None.
+### None
 
 ## NOTES
-* This cmdlet does not work with Active Directory Lightweight Directory Services.
-* This cmdlet does not work with a read-only domain controller.
-* This cmdlet does not work with an Active Directory snapshot.
+
+- This cmdlet does not work with Active Directory Lightweight Directory Services.
+- This cmdlet does not work with a read-only domain controller.
+- This cmdlet does not work with an Active Directory snapshot.
 
 ## RELATED LINKS
 
 [Get-ADDomainController](./Get-ADDomainController.md)
 
 [Get-ADDomainControllerPasswordReplicationPolicy](./Get-ADDomainControllerPasswordReplicationPolicy.md)
-

--- a/docset/winserver2022-ps/activedirectory/Add-ADDomainControllerPasswordReplicationPolicy.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADDomainControllerPasswordReplicationPolicy.md
@@ -11,7 +11,8 @@ title: Add-ADDomainControllerPasswordReplicationPolicy
 # Add-ADDomainControllerPasswordReplicationPolicy
 
 ## SYNOPSIS
-Adds users, computers, and groups to the allowed or denied list of a read-only domain controller password replication policy.
+Adds users, computers, and groups to the allowed or denied list of a read-only domain controller
+password replication policy.
 
 ## SYNTAX
 

--- a/docset/winserver2022-ps/activedirectory/Add-ADFineGrainedPasswordPolicySubject.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADFineGrainedPasswordPolicySubject.md
@@ -17,69 +17,88 @@ Applies a fine-grained password policy to one more users and groups.
 
 ```
 Add-ADFineGrainedPasswordPolicySubject [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
- [-Credential <PSCredential>] [-Identity] <ADFineGrainedPasswordPolicy> [-Partition <String>] [-PassThru]
- [-Server <String>] [-Subjects] <ADPrincipal[]> [<CommonParameters>]
+ [-Credential <PSCredential>] [-Identity] <ADFineGrainedPasswordPolicy>
+ [-Partition <String>] [-PassThru] [-Server <String>] [-Subjects] <ADPrincipal[]>
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Add-ADFineGrainedPasswordPolicySubject** cmdlet applies a fine-grained password policy to one or more global security groups and users.
 
-The *Identity* parameter specifies the fine-grained password policy to apply.
-You can identify a fine-grained password policy by its distinguished name, GUID or name.
-You can also set the *Identity* parameter to a fine-grained password policy object variable, such as `$<localPasswordPolicyObject>`, or pass a fine-grained password policy object through the pipeline operator to the *Identity* parameter.
-For example, you can use the **Get-ADFineGrainedPasswordPolicy** cmdlet to get a fine-grained password policy object and then pass the object through the pipeline operator to the **Add-ADFineGrainedPasswordPolicySubject** cmdlet.
+The `Add-ADFineGrainedPasswordPolicySubject` cmdlet applies a fine-grained password policy to one or
+more global security groups and users.
 
-The *Subjects* parameter specifies the users and global security groups.
-You can identify a user or global security group by its distinguished name (DN), GUID, security identifier (SID), or Security Account Manager (SAM) account name.
-You can also specify user and global security group object variables, such as `$<localUserObject>`.
-If you are specifying more than one user or group, use a comma-separated list.
-To pass user and global security group objects through the pipeline to the *Subjects* parameter, use the Get-ADUser or the **Get-ADGroup** cmdlets to retrieve the user or group objects, and then pass these objects through the pipeline operator to the **Add-ADFineGrainedPasswordPolicySubject** cmdlet.
+The **Identity** parameter specifies the fine-grained password policy to apply. You can identify a
+fine-grained password policy by its distinguished name, GUID or name. You can also set the
+**Identity** parameter to a fine-grained password policy object variable, such as
+`$<localPasswordPolicyObject>`, or pass a fine-grained password policy object through the pipeline
+operator to the **Identity** parameter. For example, you can use the
+`Get-ADFineGrainedPasswordPolicy` cmdlet to get a fine-grained password policy object and then pass
+the object through the pipeline operator to the `Add-ADFineGrainedPasswordPolicySubject` cmdlet.
+
+The **Subjects** parameter specifies the users and global security groups. You can identify a user
+or global security group by its distinguished name (DN), GUID, security identifier (SID), or
+Security Account Manager (SAM) account name. You can also specify user and global security group
+object variables, such as `$<localUserObject>`. If you are specifying more than one user or group,
+use a comma-separated list. To pass user and global security group objects through the pipeline to
+the **Subjects** parameter, use the `Get-ADUser` or the `Get-ADGroup` cmdlets to retrieve the user
+or group objects, and then pass these objects through the pipeline operator to the
+`Add-ADFineGrainedPasswordPolicySubject` cmdlet.
 
 ## EXAMPLES
 
-### Example 1: Apply a fine-grained password policy to a global security group
-```
-PS C:\> Add-ADFineGrainedPasswordPolicySubject -Identity DomainUsersPSO -Subjects 'Domain Users'
+### EXAMPLE 1
+
+```powershell
+Add-ADFineGrainedPasswordPolicySubject -Identity DomainUsersPSO -Subjects 'Domain Users'
 ```
 
-This command applies the fine-grained password policy named DomainUsersPSO to the Domain Users global security group.
+This command applies the fine-grained password policy named `DomainUsersPSO` to the `Domain Users`
+global security group.
 
-### Example 2: Apply a fine-grained password policy to multiple users
-```
-PS C:\> Add-ADFineGrainedPasswordPolicySubject -Identity DlgtdAdminsPSO -Subjects BobKe,KimAb
-```
+### EXAMPLE 2
 
-This command applies the fine-grained password policy named DlgtdAdminsPSO to users with the SAM account names BobKe and KimAb.
-
-### Example 3: Apply a fine-grained password policy to a security group
-```
-PS C:\> Add-ADFineGrainedPasswordPolicySubject -Identity DlgtdAdminsPSO -Subjects DlgtdAdminGroup
+```powershell
+Add-ADFineGrainedPasswordPolicySubject -Identity DlgtdAdminsPSO -Subjects BobKe, KimAb
 ```
 
-This command applies the fine-grained password policy named DlgtdAdminsPSO to the group DlgtdAdminGroup.
+This command applies the fine-grained password policy named `DlgtdAdminsPSO` to users with the SAM
+account names `BobKe` and `KimAb`.
 
-### Example 4: Apply a fine-grained password policy to users with a specified name
-```
-PS C:\> Get-ADUser -Filter "lastname -eq 'Fuller'" | Add-ADFineGrainedPasswordPolicySubject -Identity DlgtdAdminsPSO
+### EXAMPLE 3
+
+```powershell
+Add-ADFineGrainedPasswordPolicySubject -Identity DlgtdAdminsPSO -Subjects DlgtdAdminGroup
 ```
 
-This command applies the fine-grained password policy named DlgtdAdminsPSO to any users whose last name is Fuller.
+This command applies the fine-grained password policy named `DlgtdAdminsPSO` to the group
+`DlgtdAdminGroup`.
+
+### EXAMPLE 4
+
+```powershell
+Get-ADUser -Filter "lastname -eq 'Fuller'" |
+    Add-ADFineGrainedPasswordPolicySubject -Identity DlgtdAdminsPSO
+```
+
+This command applies the fine-grained password policy named `DlgtdAdminsPSO` to any users whose last
+name is `Fuller`.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -92,10 +111,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -107,20 +127,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -132,21 +156,23 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory fine-grained password policy object by providing one of the following property values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory fine-grained password policy object by providing one of the following
+property values. The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP)
+display name for the attribute. The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID (objectGUID) 
+- A GUID (**objectGUID**)
 - A name (name)
 
 The cmdlet searches the default naming context or partition to find the object.
 If two or more objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to a fine-grained password policy object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to a
+fine-grained password policy object instance.
 
 ```yaml
-Type: ADFineGrainedPasswordPolicy
+Type: Microsoft.ActiveDirectory.Management.ADFineGrainedPasswordPolicy
 Parameter Sets: (All)
 Aliases: 
 
@@ -158,30 +184,40 @@ Accept wildcard characters: False
 ```
 
 ### -Partition
-Specifies the distinguished name of an Active Directory partition.
-The distinguished name must be one of the naming contexts on the current directory server.
-The cmdlet searches this partition to find the object defined by the *Identity* parameter.
 
-In many cases, a default value is used for the *Partition* parameter if no value is specified.
-The rules for determining the default value are given below.
-Note that rules listed first are evaluated first and once a default value can be determined, no further rules are evaluated.
+Specifies the distinguished name of an Active Directory partition. The distinguished name must be
+one of the naming contexts on the current directory server. The cmdlet searches this partition to
+find the object defined by the **Identity** parameter.
 
-In Active Directory Domain Services (AD DS) environments, a default value for *Partition* is set in the following cases: 
+In many cases, a default value is used for the **Partition** parameter if no value is specified. The
+rules for determining the default value are given below. Note that rules listed first are evaluated
+first and once a default value can be determined, no further rules are evaluated.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name. 
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If none of the previous cases apply, the default value of *Partition* is set to the default partition or naming context of the target domain.
+In Active Directory Domain Services environments, a default value for **Partition** is set in the
+following cases:
 
-In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for *Partition* is set in the following cases:
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If none of the previous cases apply, the default value of **Partition** is set to the default
+  partition or naming context of the target domain.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name.
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive.
-- If the target AD LDS instance has a default naming context, the default value of *Partition* is set to the default naming context.
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent (DSA) object (nTDSDSA) for the AD LDS instance.
-- If none of the previous cases apply, the *Partition* parameter does not take any default value.
+In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for
+**Partition** is set in the following cases:
+
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If the target AD LDS instance has a default naming context, the default value of **Partition** is
+  set to the default naming context. To specify a default naming context for an AD LDS environment,
+  set the **msDS-defaultNamingContext** property of the Active Directory directory service agent
+  (DSA) object (**nTDSDSA**) for the AD LDS instance.
+- If none of the previous cases apply, the **Partition** parameter will not take any default value.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -193,11 +229,12 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns an object representing the item with which you are working.
 By default, this cmdlet does not generate any output.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: 
 
@@ -209,30 +246,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the AD DS instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: AD LDS, AD DS, or Active Directory snapshot instance.
 
-Specify the AD DS instance in one of the following ways: 
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -244,21 +286,22 @@ Accept wildcard characters: False
 ```
 
 ### -Subjects
+
 Specifies one or more users or groups.
 To specify more than one user or group, use a comma-separated list.
 You can identify a user or group by one of the following property values:
 
-- Distinguished name (DN) 
-- GUID (objectGUID) 
-- Security Identifier (objectSid) 
-- SAM account name (sAMAccountName)
+- Distinguished name (DN)
+- GUID (**objectGUID**)
+- Security Identifier (**objectSid**)
+- SAM account name (**sAMAccountName**)
 
 Note: The identifier in parentheses is the LDAP display name for the attribute.
 
 You can also provide objects to this parameter directly.
 
 ```yaml
-Type: ADPrincipal[]
+Type: Microsoft.ActiveDirectory.Management.ADPrincipal[]
 Parameter Sets: (All)
 Aliases: 
 
@@ -270,11 +313,12 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -286,14 +330,20 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADFineGrainedPasswordPolicy, Microsoft.ActiveDirectory.Management.ADPrincipal
-A fine-grained password policy object is received by the *Identity* parameter.
-One or more principal objects that represent users and security group objects are received by the *Subjects* parameter.
-Derived principal types, such as the following, are also accepted by the *Subjects* parameter:
+
+A fine-grained password policy object is received by the **Identity** parameter. One or more
+principal objects that represent users and security group objects are received by the **Subjects**
+parameter. Derived principal types, such as the following, are also accepted by the **Subjects**
+parameter:
 
 - **Microsoft.ActiveDirectory.Management.ADGroup**
 - **Microsoft.ActiveDirectory.Management.ADUser**
@@ -301,17 +351,18 @@ Derived principal types, such as the following, are also accepted by the *Subjec
 ## OUTPUTS
 
 ### None or Microsoft.ActiveDirectory.Management.ADFineGrainedPasswordPolicy
-Returns the modified fine-grained password policy object when the *PassThru* parameter is specified.
-By default, this cmdlet does not generate any output.
+
+Returns the modified fine-grained password policy object when the **PassThru** parameter is
+specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
-* This cmdlet does not work with AD LDS.
-* This cmdlet does not work with a read-only domain controller.
-* This cmdlet does not work with an Active Directory snapshot.
+
+- This cmdlet does not work with AD LDS.
+- This cmdlet does not work with a read-only domain controller.
+- This cmdlet does not work with an Active Directory snapshot.
 
 ## RELATED LINKS
 
 [Get-ADFineGrainedPasswordPolicySubject](./Get-ADFineGrainedPasswordPolicySubject.md)
 
 [Remove-ADFineGrainedPasswordPolicySubject](./Remove-ADFineGrainedPasswordPolicySubject.md)
-

--- a/docset/winserver2022-ps/activedirectory/Add-ADFineGrainedPasswordPolicySubject.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADFineGrainedPasswordPolicySubject.md
@@ -87,8 +87,7 @@ name is `Fuller`.
 
 ### -AuthType
 
-Specifies the authentication method to use.
-The acceptable values for this parameter are:
+Specifies the authentication method to use. The acceptable values for this parameter are:
 
 - `Negotiate` or `0`
 - `Basic` or `1`
@@ -230,8 +229,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+Returns an object representing the item with which you are working. By default, this cmdlet does
+not generate any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -287,9 +286,8 @@ Accept wildcard characters: False
 
 ### -Subjects
 
-Specifies one or more users or groups.
-To specify more than one user or group, use a comma-separated list.
-You can identify a user or group by one of the following property values:
+Specifies one or more users or groups. To specify more than one user or group, use a
+comma-separated list. You can identify a user or group by one of the following property values:
 
 - Distinguished name (DN)
 - GUID (**objectGUID**)
@@ -314,8 +312,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/docset/winserver2022-ps/activedirectory/Add-ADGroupMember.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADGroupMember.md
@@ -101,8 +101,7 @@ group `CN=AccountLeads,OU=UserAccounts` in the Europe domain.
 
 ### -AuthType
 
-Specifies the authentication method to use.
-The acceptable values for this parameter are:
+Specifies the authentication method to use. The acceptable values for this parameter are:
 
 - `Negotiate` or `0`
 - `Basic` or `1`
@@ -329,8 +328,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+Returns an object representing the item with which you're working. By default, this cmdlet doesn't
+generate any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -386,8 +385,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/docset/winserver2022-ps/activedirectory/Add-ADGroupMember.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADGroupMember.md
@@ -16,85 +16,103 @@ Adds one or more members to an Active Directory group.
 ## SYNTAX
 
 ```
-Add-ADGroupMember [-WhatIf] [-Confirm] [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADGroup> [-Members] <ADPrincipal[]> [-MemberTimeToLive <TimeSpan>] [-Partition <String>]
- [-PassThru] [-Server <String>] [-DisablePermissiveModify] [<CommonParameters>]
+Add-ADGroupMember [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
+ [-Credential <PSCredential>] [-Identity] <ADGroup> [-Members] <ADPrincipal[]>
+ [-MemberTimeToLive <TimeSpan>] [-Partition <String>] [-PassThru] [-Server <String>]
+ [-DisablePermissiveModify] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Add-ADGroupMember** cmdlet adds one or more users, groups, service accounts, or computers as new members of an Active Directory group.
 
-The *Identity* parameter specifies the Active Directory group that receives the new members.
-You can identify a group by its distinguished name, GUID, security identifier, or Security Account Manager (SAM) account name.
-You can also specify group object variable, such as `$<localGroupObject>`, or pass a group object through the pipeline to the *Identity* parameter.
-For example, you can use the **Get-ADGroup** cmdlet to get a group object and then pass the object through the pipeline to the **Add-ADGroupMember** cmdlet.
+The `Add-ADGroupMember` cmdlet adds one or more users, groups, service accounts, or computers as
+new members of an Active Directory group.
 
-The *Members* parameter specifies the new members to add to a group.
-You can identify a new member by its distinguished name, GUID, security identifier, or SAM account name.
-You can also specify user, computer, and group object variables, such as `$<localUserObject>`.
-If you are specifying more than one new member, use a comma-separated list.
-You cannot pass user, computer, or group objects through the pipeline to this cmdlet.
-To add user, computer, or group objects to a group by using the pipeline, use the **Add-ADPrincipalGroupMembership** cmdlet.
+The **Identity** parameter specifies the Active Directory group that receives the new members. You
+can identify a group by its distinguished name, GUID, security identifier, or Security Account
+Manager (SAM) account name. You can also specify group object variable, such as
+`$<localGroupObject>`, or pass a group object through the pipeline to the **Identity** parameter.
+For example, you can use the `Get-ADGroup` cmdlet to get a group object and then pass the object
+through the pipeline to the `Add-ADGroupMember` cmdlet.
 
-For Active Directory Lightweight Directory Services (AD LDS) environments, the *Partition* parameter must be specified except in the following two conditions:
+The **Members** parameter specifies the new members to add to a group. You can identify a new member
+by its distinguished name, GUID, security identifier, or SAM account name. You can also specify
+user, computer, and group object variables, such as `$<localUserObject>`. If you are specifying more
+than one new member, use a comma-separated list. You cannot pass user, computer, or group objects
+through the pipeline to this cmdlet. To add user, computer, or group objects to a group by using the
+pipeline, use the `Add-ADPrincipalGroupMembership` cmdlet.
+
+For Active Directory Lightweight Directory Services (AD LDS) environments, the **Partition**
+parameter must be specified except in the following two conditions:
 
 - The cmdlet is run from an Active Directory provider drive.
 - A default naming context or partition is defined for the AD LDS environment.
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent object (nTDSDSA) for the AD LDS instance.
+- To specify a default naming context for an AD LDS environment, set the
+  **msDS-defaultNamingContext** property of the Active Directory directory service agent object
+  (nTDSDSA) for the AD LDS instance.
 
 ## EXAMPLES
 
-### Example 1: Add specified user accounts to a group
-```
-PS C:\> Add-ADGroupMember -Identity SvcAccPSOGroup -Members SQL01,SQL02
+### EXAMPLE 1
+
+```powershell
+Add-ADGroupMember -Identity SvcAccPSOGroup -Members SQL01, SQL02
 ```
 
-This command adds the user accounts with the SAM account names SQL01 and SQL02 to the group SvcAccPSOGroup.
+This command adds the user accounts with the SAM account names `SQL01` and `SQL02` to the group
+`SvcAccPSOGroup`.
 
-### Example 2: Add all user accounts to a group
-```
-PS C:\> Add-ADGroupMember
-cmdlet Add-ADGroupMember at command pipeline position 1
-Supply values for the following parameters:
-Identity: RodcAdmins
-Members[0]: DavidChew
-Members[1]: PattiFuller
-Members[2]:
-```
+### EXAMPLE 2
 
-This command adds user accounts with SAM account names DavidChew and PattiFuller to the group RodcAdmins.
-
-### Example 3: Add an account by distinguished name to a filtered group
-```
-PS C:\> Get-ADGroup -Server localhost:60000 -SearchBase "OU=AccountDeptOU,DC=AppNC" -Filter "name -like 'AccountLeads'" | Add-ADGroupMember -Members "CN=PattiFuller,OU=AccountDeptOU,DC=AppNC"
+```powershell
+$params = @{
+    Server = 'localhost:60000'
+    SearchBase = 'OU=AccountDeptOU,DC=AppNC'
+    Filter = "name -like 'AccountLeads'"
+}
+Get-ADGroup @params |
+    Add-ADGroupMember -Members 'CN=PattiFuller,OU=AccountDeptOU,DC=AppNC'
 ```
 
-This command gets a group from the organizational unit OU=AccountDeptOU,DC=AppNC in the AD LDS instance localhost:60000 that has the name AccountLeads, and then pipes it to **Add-ADGroupMember**, which then adds the user account with the distinguished name CN=PattiFuller,OU=AccountDeptOU,DC=AppNC to it.
+This command gets a group from the organizational unit `OU=AccountDeptOU,DC=AppNC` in the AD LDS
+instance `localhost:60000` that has the name `AccountLeads`, and then pipes it to
+`Add-ADGroupMember`, which then adds the user account with the distinguished name
+`CN=PattiFuller,OU=AccountDeptOU,DC=AppNC` to it.
 
-### Example 4: Add a user from a domain to a group in another domain
-```
-PS C:\> $User = Get-ADUser -Identity "CN=Chew David,OU=UserAccounts,DC=NORTHAMERICA,DC=FABRIKAM,DC=COM" -Server "northamerica.fabrikam.com"
-PS C:\> $Group = Get-ADGroup -Identity "CN=AccountLeads,OU=UserAccounts,DC=EUROPE,DC=FABRIKAM,DC=COM" -Server "europe.fabrikam.com"
-PS C:\> Add-ADGroupMember -Identity $Group -Members $User -Server "europe.fabrikam.com"
+### EXAMPLE 3
+
+```powershell
+$userParams = @{
+    Identity = 'CN=Chew David,OU=UserAccounts,DC=NORTHAMERICA,DC=FABRIKAM,DC=COM'
+    Server = 'northamerica.fabrikam.com'
+}
+$User = Get-ADUser @userParams
+$groupParams = @{
+    Identity = 'CN=AccountLeads,OU=UserAccounts,DC=EUROPE,DC=FABRIKAM,DC=COM'
+    Server = 'europe.fabrikam.com'
+}
+$Group = Get-ADGroup @groupParams
+Add-ADGroupMember -Identity $Group -Members $User -Server "europe.fabrikam.com"
 ```
 
-This command adds the user CN=Chew David,OU=UserAccounts from the North America domain to the group CN=AccountLeads,OU=UserAccounts in the Europe domain.
+This command adds the user `CN=Chew David,OU=UserAccounts` from the North America domain to the
+group `CN=AccountLeads,OU=UserAccounts` in the Europe domain.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases:
 Accepted values: Negotiate, Basic
@@ -107,10 +125,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -122,20 +141,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases:
 
@@ -147,14 +170,15 @@ Accept wildcard characters: False
 ```
 
 ### -DisablePermissiveModify
-Group membership updates use permissive modify by default. This suppresses an error when adding a member that is already member of the group.
-When this parameter is used, an error "The specified account name is already a member of the group" is returned.
+
+Group membership updates use permissive modify by default. This suppresses an error when adding a
+member that is already member of the group. When this parameter is used, an error "The specified
+account name is already a member of the group" is returned.
 
 This parameter is available in Windows Server 2019 with the September 2020 Updates.
 
-
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
@@ -166,22 +190,24 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory group object by providing one of the following values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
+
+Specifies an Active Directory group object by providing one of the following values. The identifier
+in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
 The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID (objectGUID)
-- A security identifier (objectSid)
-- A Security Account Manager account name (sAMAccountName)
+- A GUID (**objectGUID**)
+- A security identifier (**objectSid**)
+- Security Accounts Manager account name (**sAMAccountName**)
 
-The cmdlet searches the default naming context or partition to find the object.
-If two or more objects are found, the cmdlet returns a non-terminating error.
+The cmdlet searches the default naming context or partition to find the object. If two or more
+objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to an object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+object instance.
 
 ```yaml
-Type: ADGroup
+Type: Microsoft.ActiveDirectory.Management.ADGroup
 Parameter Sets: (All)
 Aliases:
 
@@ -193,10 +219,11 @@ Accept wildcard characters: False
 ```
 
 ### -MemberTimeToLive
+
 Specifies a Time to Live (TTL) for the new group members.
 
 ```yaml
-Type: TimeSpan
+Type: System.TimeSpan
 Parameter Sets: (All)
 Aliases:
 
@@ -208,30 +235,33 @@ Accept wildcard characters: False
 ```
 
 ### -Members
+
 Specifies an array of user, group, and computer objects in a comma-separated list to add to a group.
-To identify each object, use one of the following property values.
-Note: The identifier in parentheses is the LDAP display name.
-The acceptable values for this parameter are:
+To identify each object, use one of the following property values. The identifier in parentheses is
+the LDAP display name. The acceptable values for this parameter are:
 
 - Distinguished name
-- GUID (objectGUID)
-- Security identifier (objectSid)
-- SAM account name (sAMAccountName)
+- GUID (**objectGUID**)
+- Security identifier (**objectSid**)
+- SAM account name (**sAMAccountName**)
 
 You can also provide objects to this parameter directly.
 
 The following examples show how to specify this parameter.
 
-This example specifies a user and group to add by specifying the distinguished name and the SAM account name properties.
+This example specifies a user and group to add by specifying the distinguished name and the SAM
+account name properties.
 
 `-Members "CN=SaraDavis,CN=employees,CN=Users,DC=contoso,DC=com", "saradavisreports"`
 
-This example specifies a user and a group object that are defined in the current Windows PowerShell session as input for the parameter.
+This example specifies a user and a group object that are defined in the current Windows PowerShell
+session as input for the parameter.
 
 `-Members $userObject, $GroupObject`
 
-The objects specified for this parameter are processed as **Microsoft.ActiveDirectory.Management.ADPrincipal** objects.
-Derived types, such as the following are also received by this parameter.
+The objects specified for this parameter are processed as
+**Microsoft.ActiveDirectory.Management.ADPrincipal** objects. Derived types, such as the following
+are also received by this parameter.
 
 - **Microsoft.ActiveDirectory.Management.ADUser**
 - **Microsoft.ActiveDirectory.Management.ADComputer**
@@ -241,7 +271,7 @@ Derived types, such as the following are also received by this parameter.
 You cannot pass objects through the pipeline to this parameter.
 
 ```yaml
-Type: ADPrincipal[]
+Type: Microsoft.ActiveDirectory.Management.ADPrincipal[]
 Parameter Sets: (All)
 Aliases:
 
@@ -253,30 +283,40 @@ Accept wildcard characters: False
 ```
 
 ### -Partition
-Specifies the distinguished name of an Active Directory partition.
-The distinguished name must be one of the naming contexts on the current directory server.
-The cmdlet searches this partition to find the object defined by the *Identity* parameter.
 
-In many cases, a default value is used for the *Partition* parameter if no value is specified.
-The rules for determining the default value are given below.
-Note that rules listed first are evaluated first and once a default value can be determined, no further rules are evaluated.
+Specifies the distinguished name of an Active Directory partition. The distinguished name must be
+one of the naming contexts on the current directory server. The cmdlet searches this partition to
+find the object defined by the **Identity** parameter.
 
-In Active Directory Domain Services (AD DS) environments, a default value for *Partition* is set in the following cases:
+In many cases, a default value is used for the **Partition** parameter if no value is specified. The
+rules for determining the default value are given below. Note that rules listed first are evaluated
+first and once a default value can be determined, no further rules are evaluated.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name.
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive.
-- If none of the previous cases apply, the default value of *Partition* is set to the default partition or naming context of the target domain.
+In Active Directory Domain Services environments, a default value for **Partition** is set in the
+following cases:
 
-In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for *Partition* is set in the following cases:
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If none of the previous cases apply, the default value of **Partition** is set to the default
+  partition or naming context of the target domain.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name.
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive.
-- If the target AD LDS instance has a default naming context, the default value of *Partition* is set to the default naming context.
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent object (**nTDSDSA**) for the AD LDS instance.
-- If none of the previous cases apply, the *Partition* parameter does not take a default value.
+In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for
+**Partition** is set in the following cases:
+
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If the target AD LDS instance has a default naming context, the default value of **Partition** is
+  set to the default naming context. To specify a default naming context for an AD LDS environment,
+  set the **msDS-defaultNamingContext** property of the Active Directory directory service agent
+  (DSA) object (**nTDSDSA**) for the AD LDS instance.
+- If none of the previous cases apply, the **Partition** parameter will not take any default value.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -288,11 +328,12 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns an object representing the item with which you are working.
 By default, this cmdlet does not generate any output.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
@@ -304,10 +345,13 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services (AD DS) instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: Active Directory Lightweight Domain Services (AD LDS), AD DS, or Active Directory snapshot instance.
 
-Specify the AD DS instance in one of the following ways:
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
@@ -320,14 +364,16 @@ Directory server values:
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the AD DS Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 
@@ -338,27 +384,13 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DisablePermissiveModify
-Group membership updates use permissive modify by default. This suppresses an error when adding a member that is already member of the group.
-When this parameter is used, an error "The specified account name is already a member of the group" is returned.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -370,23 +402,31 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADGroup
-A group object is received by the *Identity* parameter.
+
+A group object is received by the **Identity** parameter.
 
 ## OUTPUTS
 
 ### None or Microsoft.ActiveDirectory.Management.ADGroup
-Returns the modified group object when the *PassThru* parameter is specified.
-By default, this cmdlet does not generate any output.
+
+Returns the modified group object when the **PassThru** parameter is specified. By default, this
+cmdlet does not generate any output.
 
 ## NOTES
-* This cmdlet does not work with a read-only domain controller.
-* This cmdlet does not work with an Active Directory snapshot.
-* This cmdlet will allow you to add a group as a member of itself which could lead to unstable behavior.
+
+- This cmdlet does not work with a read-only domain controller.
+- This cmdlet does not work with an Active Directory snapshot.
+- This cmdlet will allow you to add a group as a member of itself which could lead to unstable
+  behavior.
 
 ## RELATED LINKS
 
@@ -401,4 +441,3 @@ By default, this cmdlet does not generate any output.
 [Remove-ADGroupMember](./Remove-ADGroupMember.md)
 
 [Remove-ADPrincipalGroupMembership](./Remove-ADPrincipalGroupMembership.md)
-

--- a/docset/winserver2022-ps/activedirectory/Add-ADPrincipalGroupMembership.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADPrincipalGroupMembership.md
@@ -54,7 +54,7 @@ property of the Active Directory directory service agent object (nTDSDSA) for th
 
 ## EXAMPLES
 
-### EXAMPLE 1
+### Example 1: Add a member to a group
 
 ```powershell
 Add-ADPrincipalGroupMembership -Identity SQLAdmin1 -MemberOf DlgtdAdminsPSOGroup
@@ -62,7 +62,7 @@ Add-ADPrincipalGroupMembership -Identity SQLAdmin1 -MemberOf DlgtdAdminsPSOGroup
 
 This command adds the user with SAM account name `SQLAdmin1` to the group `DlgtdAdminsPSOGroup`.
 
-### EXAMPLE 2
+### Example 2: Add filtered users to a group
 
 ```powershell
 Get-ADUser -Filter 'Name -like "*SvcAccount*"' |
@@ -72,7 +72,7 @@ Get-ADUser -Filter 'Name -like "*SvcAccount*"' |
 This command gets all users with `SvcAccount` in their name and adds them to the group
 `SvcAccPSOGroup`.
 
-### EXAMPLE 3
+### Example 3: Add filtered users to a distinguished name group
 
 ```powershell
 $params = @{
@@ -91,8 +91,7 @@ This command adds all employees in `Branch1` in the AD LDS instance `localhost:6
 
 ### -AuthType
 
-Specifies the authentication method to use.
-The acceptable values for this parameter are:
+Specifies the authentication method to use. The acceptable values for this parameter are:
 
 - `Negotiate` or `0`
 - `Basic` or `1`
@@ -279,8 +278,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+Returns an object representing the item with which you're working. By default, this cmdlet doesn't
+generate any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -336,8 +335,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/docset/winserver2022-ps/activedirectory/Add-ADPrincipalGroupMembership.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADPrincipalGroupMembership.md
@@ -16,90 +16,93 @@ Adds a member to one or more Active Directory groups.
 ## SYNTAX
 
 ```
-Add-ADPrincipalGroupMembership [-WhatIf] [-Confirm] [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADPrincipal> [-MemberOf] <ADGroup[]> [-Partition <String>] [-PassThru] [-Server <String>]
- [<CommonParameters>]
+Add-ADPrincipalGroupMembership [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
+ [-Credential <PSCredential>] [-Identity] <ADPrincipal> [-MemberOf] <ADGroup[]>
+ [-Partition <String>] [-PassThru] [-Server <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Add-ADPrincipalGroupMembership** cmdlet adds a user, group, service account, or computer as a new member to one or more Active Directory groups.
 
-The *Identity* parameter specifies the new user, computer, or group to add.
-You can identify the user, group, or computer by its distinguished name, GUID, security identifier (SID), or Security Account Manager (SAM) account name.
-You can also specify a user, group, or computer object variable, such as `$<localGroupObject>`, or pass an object through the pipeline to the *Identity* parameter.
-For example, you can use the **Get-ADGroup** cmdlet to get a group object and then pass the object through the pipeline to the **Add-ADPrincipalGroupMembership** cmdlet.
-Similarly, you can use **Get-ADUser** or **Get-ADComputer** to get user and computer objects to pass through the pipeline.
+The `Add-ADPrincipalGroupMembership` cmdlet adds a user, group, service account, or computer as a
+new member to one or more Active Directory groups.
 
-This cmdlet collects all of the user, computer and group objects from the pipeline, and then adds these objects to the specified group by using one Active Directory operation.
+The **Identity** parameter specifies the new user, computer, or group to add. You can identify the
+user, group, or computer by its distinguished name, GUID, security identifier (SID), or Security
+Account Manager (SAM) account name. You can also specify a user, group, or computer object variable,
+such as `$<localGroupObject>`, or pass an object through the pipeline to the **Identity** parameter.
+For example, you can use the `Get-ADGroup` cmdlet to get a group object and then pass the object
+through the pipeline to the `Add-ADPrincipalGroupMembership` cmdlet. Similarly, you can use
+`Get-ADUser` or `Get-ADComputer` to get user and computer objects to pass through the pipeline.
 
-The *MemberOf* parameter specifies the groups that receive the new member.
-You can identify a group by its distinguished name, GUID, SID, or SAM account name.
-You can also specify group object variable, such as `$<localGroupObject>`.
-To specify more than one group, use a comma-separated list.
-You cannot pass group objects through the pipeline to the *MemberOf* parameter.
-To add to a group by passing the group through the pipeline, use the **Add-ADGroupMember** cmdlet.
+This cmdlet collects all of the user, computer and group objects from the pipeline, and then adds
+these objects to the specified group by using one Active Directory operation.
 
-For Active Directory Lightweight Directory Services (AD LDS) environments, the *Partition* parameter must be specified except in the following two conditions:
+The **MemberOf** parameter specifies the groups that receive the new member. You can identify a
+group by its distinguished name, GUID, SID, or SAM account name. You can also specify group object
+variable, such as `$<localGroupObject>`. To specify more than one group, use a comma-separated list.
+You cannot pass group objects through the pipeline to the **MemberOf** parameter. To add to a group
+by passing the group through the pipeline, use the **Add-ADGroupMember** cmdlet.
 
-- The cmdlet is run from an Active Directory provider drive. 
+For Active Directory Lightweight Directory Services (AD LDS) environments, the **Partition**
+parameter must be specified except in the following two conditions:
+
+- The cmdlet is run from an Active Directory provider drive.
 - A default naming context or partition is defined for the AD LDS environment.
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent object (nTDSDSA) for the AD LDS instance.
+
+To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext**
+property of the Active Directory directory service agent object (nTDSDSA) for the AD LDS instance.
 
 ## EXAMPLES
 
-### Example 1: Add a member to a group
-```
-PS C:\> Add-ADPrincipalGroupMembership -Identity SQLAdmin1 -MemberOf DlgtdAdminsPSOGroup
+### EXAMPLE 1
+
+```powershell
+Add-ADPrincipalGroupMembership -Identity SQLAdmin1 -MemberOf DlgtdAdminsPSOGroup
 ```
 
-This command adds the user with SAM account name SQLAdmin1 to the group DlgtdAdminsPSOGroup.
+This command adds the user with SAM account name `SQLAdmin1` to the group `DlgtdAdminsPSOGroup`.
 
-### Example 2: Add filtered users to a group
-```
-PS C:\> Get-ADUser -Filter 'Name -like "*SvcAccount*"' | Add-ADPrincipalGroupMembership -MemberOf SvcAccPSOGroup
-```
+### EXAMPLE 2
 
-This command gets all users with SvcAccount in their name and adds it to the group SvcAccPSOGroup.
-
-### Example 3: Add a member to a group without specifying parameters
-```
-PS C:\> Add-ADPrincipalGroupMembership
-cmdlet Add-ADPrincipalGroupMembership at command pipeline position 1
-Supply values for the following parameters: 
-Identity: DavidChew
-MemberOf[0]: RodcAdmins
-MemberOf[1]: Allowed RODC Password Replication Group
-MemberOf[2]:
+```powershell
+Get-ADUser -Filter 'Name -like "*SvcAccount*"' |
+    Add-ADPrincipalGroupMembership -MemberOf SvcAccPSOGroup
 ```
 
-This command demonstrates the default behavior of this cmdlet, with no parameters specified.
+This command gets all users with `SvcAccount` in their name and adds them to the group
+`SvcAccPSOGroup`.
 
-### Example 4: Add filtered users to a distinguished name group
-```
-PS C:\> Get-ADUser -Server localhost:60000 -SearchBase "DC=AppNC" -Filter "Title -eq 'Account Lead' -and Office -eq 'Branch1'" | Add-ADPrincipalGroupMembership -MemberOf "CN=AccountLeads,OU=AccountDeptOU,DC=AppNC"
+### EXAMPLE 3
+
+```powershell
+$params = @{
+    Server = 'localhost:60000'
+    SearchBase = 'DC=AppNC'
+    Filter = "Title -eq 'Account Lead' -and Office -eq 'Branch1'"
+}
+Get-ADUser @params |
+    Add-ADPrincipalGroupMembership -MemberOf "CN=AccountLeads,OU=AccountDeptOU,DC=AppNC"
 ```
 
-This command adds all employees in Branch1 in the AD LDS instance localhost:60000 whose title is Account Lead to the group with the distinguished name CN=AccountLeads,OU=AccountDeptOU,DC=AppNC.
+This command adds all employees in `Branch1` in the AD LDS instance `localhost:60000` whose title is
+`Account Lead` to the group with the distinguished name `CN=AccountLeads,OU=AccountDeptOU,DC=AppNC`.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
-
-The following example shows how to set this parameter to Basic.
-
-`-AuthType Basic`
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -112,10 +115,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -127,20 +131,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -152,19 +160,21 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
+
 Specifies an Active Directory principal object by providing one of the following property values.
-The identifier in parentheses is the LDAP display name for the attribute.
-The acceptable values for this parameter are:
+The identifier in parentheses is the LDAP display name for the attribute. The acceptable values for
+this parameter are:
 
 - Distinguished name
-- GUID (objectGUID) 
-- Security identifier (objectSid) 
-- A SAM account name (sAMAccountName)
+- GUID (**objectGUID**)
+- Security identifier (**objectSid**)
+- A SAM account name (**sAMAccountName**)
 
-The cmdlet searches the default naming context or partition to find the object.
-If two or more objects are found, the cmdlet returns a non-terminating error.
+The cmdlet searches the default naming context or partition to find the object. If two or more
+objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to an object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+object instance.
 
 Derived types, such as the following are also accepted:
 
@@ -182,7 +192,7 @@ This example shows how to set this parameter to a principal object instance name
 `-Identity $principalInstance`
 
 ```yaml
-Type: ADPrincipal
+Type: Microsoft.ActiveDirectory.Management.ADPrincipal
 Parameter Sets: (All)
 Aliases: 
 
@@ -194,15 +204,15 @@ Accept wildcard characters: False
 ```
 
 ### -MemberOf
-Specifies the Active Directory groups to add a user, computer, or group to as a member.
-You can identify a group by providing one of the following values.
-Note: The identifier in parentheses is the LDAP display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies the Active Directory groups to add a user, computer, or group to as a member. You can
+identify a group by providing one of the following values. Note: The identifier in parentheses is
+the LDAP display name for the attribute. The acceptable values for this parameter are:
 
 - Distinguished name
-- GUID (objectGUID) 
-- Security identifier (objectSid) 
-- Security Account Manager (SAM) account name (sAMAccountName)
+- GUID (**objectGUID**)
+- Security identifier (**objectSid**)
+- Security Account Manager (SAM) account name (**sAMAccountName**)
 
 If you are specifying more than one group, use commas to separate the groups in the list.
 
@@ -211,7 +221,7 @@ The following example shows how to specify this parameter by using SAM account n
 `-MemberOf "SaraDavisGroup", "JohnSmithGroup"`
 
 ```yaml
-Type: ADGroup[]
+Type: Microsoft.ActiveDirectory.Management.ADGroup[]
 Parameter Sets: (All)
 Aliases: 
 
@@ -223,30 +233,40 @@ Accept wildcard characters: False
 ```
 
 ### -Partition
-Specifies the distinguished name of an Active Directory partition.
-The distinguished name must be one of the naming contexts on the current directory server.
-The cmdlet searches this partition to find the object defined by the *Identity* parameter.
 
-In many cases, a default value is used for the *Partition* parameter if no value is specified.
-The rules for determining the default value are given below.
-Note that rules listed first are evaluated first and once a default value can be determined, no further rules are evaluated.
+Specifies the distinguished name of an Active Directory partition. The distinguished name must be
+one of the naming contexts on the current directory server. The cmdlet searches this partition to
+find the object defined by the **Identity** parameter.
 
-In Active Directory Domain Services (AD DS) environments, a default value for *Partition* is set in the following cases: 
+In many cases, a default value is used for the **Partition** parameter if no value is specified. The
+rules for determining the default value are given below. Note that rules listed first are evaluated
+first and once a default value can be determined, no further rules are evaluated.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name.
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If none of the previous cases apply, the default value of *Partition* is set to the default partition or naming context of the target domain.
+In Active Directory Domain Services environments, a default value for **Partition** is set in the
+following cases:
 
-In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for *Partition* is set in the following cases:
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If none of the previous cases apply, the default value of **Partition** is set to the default
+  partition or naming context of the target domain.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name. 
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If the target AD LDS instance has a default naming context, the default value of *Partition* is set to the default naming context.
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent object (**nTDSDSA**) for the AD LDS instance. 
-- If none of the previous cases apply, the *Partition* parameter does not take any default value.
+In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for
+**Partition** is set in the following cases:
+
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If the target AD LDS instance has a default naming context, the default value of **Partition** is
+  set to the default naming context. To specify a default naming context for an AD LDS environment,
+  set the **msDS-defaultNamingContext** property of the Active Directory directory service agent
+  (DSA) object (**nTDSDSA**) for the AD LDS instance.
+- If none of the previous cases apply, the **Partition** parameter will not take any default value.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -258,11 +278,12 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns an object representing the item with which you are working.
 By default, this cmdlet does not generate any output.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: 
 
@@ -274,30 +295,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the AD DS instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: AD LDS, AD DS, or Active Directory snapshot instance.
 
-Specify the AD DS instance in one of the following ways:  
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values:  
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the AD DS Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -309,11 +335,12 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -325,31 +352,36 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADPrincipal
-A principal object (Microsoft.ActiveDirectory.Management.ADPrincipal) that represents a user, computer or group is received by the Identity parameter.
-Derived types, such as the following are also received by this parameter.
 
-Microsoft.ActiveDirectory.Management.ADUser
+A principal object (**Microsoft.ActiveDirectory.Management.ADPrincipal**) that represents a user,
+computer or group is received by the Identity parameter. Derived types, such as the following are
+also received by this parameter.
 
-Microsoft.ActiveDirectory.Management.ADComputer
-
-Microsoft.ActiveDirectory.Management.ADServiceAccount
-
-Microsoft.ActiveDirectory.Management.ADGroup
+- **Microsoft.ActiveDirectory.Management.ADUser**
+- **Microsoft.ActiveDirectory.Management.ADComputer**
+- **Microsoft.ActiveDirectory.Management.ADServiceAccount**
+- **Microsoft.ActiveDirectory.Management.ADGroup**
 
 ## OUTPUTS
 
 ### None or Microsoft.ActiveDirectory.Management.ADPrincipal
-Returns a principal object that represents the modified user, computer or group object when the *PassThru* parameter is specified.
-By default, this cmdlet does not generate any output.
+
+Returns a principal object that represents the modified user, computer or group object when the
+**PassThru** parameter is specified. By default, this cmdlet does not generate any output.
 
 ## NOTES
-* This cmdlet does not work with a read-only domain controller.
-* This cmdlet does not work with an Active Directory snapshot.
+
+- This cmdlet does not work with a read-only domain controller.
+- This cmdlet does not work with an Active Directory snapshot.
 
 ## RELATED LINKS
 
@@ -368,4 +400,3 @@ By default, this cmdlet does not generate any output.
 [Remove-ADGroupMember](./Remove-ADGroupMember.md)
 
 [Remove-ADPrincipalGroupMembership](./Remove-ADPrincipalGroupMembership.md)
-

--- a/docset/winserver2022-ps/activedirectory/Add-ADResourcePropertyListMember.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADResourcePropertyListMember.md
@@ -28,7 +28,7 @@ property list in Active Directory.
 
 ## EXAMPLES
 
-### EXAMPLE 1
+### Example 1: Add members to a resource property list
 
 ```powershell
 $params = @{
@@ -41,7 +41,7 @@ Add-ADResourcePropertyListMember @params
 This command adds the resource members named `Country` and `Authors` to the list named
 `Global Resource Property List`.
 
-### EXAMPLE 2
+### Example 2: Add members to a filtered resource property list
 
 ```powershell
 Get-ADResourcePropertyList -Filter "Name -like 'Corporate*'" |
@@ -56,8 +56,7 @@ and `Authors` to it.
 
 ### -AuthType
 
-Specifies the authentication method to use.
-The acceptable values for this parameter are:
+Specifies the authentication method to use. The acceptable values for this parameter are:
 
 - `Negotiate` or `0`
 - `Basic` or `1`
@@ -175,8 +174,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+Returns an object representing the item with which you're working. By default, this cmdlet doesn't
+generate any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/docset/winserver2022-ps/activedirectory/Add-ADResourcePropertyListMember.md
+++ b/docset/winserver2022-ps/activedirectory/Add-ADResourcePropertyListMember.md
@@ -16,59 +16,58 @@ Adds one or more resource properties to a resource property list in Active Direc
 ## SYNTAX
 
 ```
-Add-ADResourcePropertyListMember [-WhatIf] [-Confirm] [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADResourcePropertyList> [-Members] <ADResourceProperty[]> [-PassThru] [-Server <String>]
- [<CommonParameters>]
+Add-ADResourcePropertyListMember [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
+ [-Credential <PSCredential>] [-Identity] <ADResourcePropertyList>
+ [-Members] <ADResourceProperty[]> [-PassThru] [-Server <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Add-ADResourcePropertyListMember** cmdlet adds one or more resource properties to a resource property list in Active Directory.
+
+The `Add-ADResourcePropertyListMember` cmdlet adds one or more resource properties to a resource
+property list in Active Directory.
 
 ## EXAMPLES
 
-### Example 1: Add members to a resource property list
-```
-PS C:\> Add-ADResourcePropertyListMember -Identity "Global Resource Property List" -Members Country,Authors
+### EXAMPLE 1
+
+```powershell
+$params = @{
+    Identity = 'Global Resource Property List'
+    Members = 'Country', 'Authors'
+}
+Add-ADResourcePropertyListMember @params
 ```
 
-This command adds the resource members named Country and Authors to the list named Global Resource Property List.
+This command adds the resource members named `Country` and `Authors` to the list named
+`Global Resource Property List`.
 
-### Example 2: Add members to the default resource property list
-```
-PS C:\> Add-ADResourcePropertyListMember
-cmdlet Add-ADResourcePropertyListMember at command pipeline position 1
-Supply values for the following parameters: 
-Identity: Corporate Resource Property List
-Members[0]: Country
-Members[1]: Authors
-Members[2]:
+### EXAMPLE 2
+
+```powershell
+Get-ADResourcePropertyList -Filter "Name -like 'Corporate*'" |
+    Add-ADResourcePropertyListMember -Members Country, Authors
 ```
 
-This command adds the resource members named Country and Authors to the resource property list named Corporate Resource Property List.
-This command demonstrates the default behavior for this cmdlet when no parameters are specified.
-
-### Example 3: Add members to a filtered resource property list
-```
-PS C:\> Get-ADResourcePropertyList -Filter "Name -like 'Corporate*'" | Add-ADResourcePropertyListMember -Members Country,Authors
-```
-
-This command gets any resource property list that has a name that begins with Corporate and then passes it to Add-ADResourcePropertyListMember, which then adds the resource properties Country and Authors to it.
+This command gets any resource property list that has a name that begins with `Corporate` and then
+passes it to `Add-ADResourcePropertyListMember`, which then adds the resource properties `Country`
+and `Authors` to it.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -81,10 +80,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -96,20 +96,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -121,17 +125,19 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory object by providing one of the following property values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory object by providing one of the following property values. The
+identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the
+attribute. The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID (objectGUID)
+- A GUID (**objectGUID**)
 
-This parameter can also get this object through the pipeline or you can set this parameter to an object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+object instance.
 
 ```yaml
-Type: ADResourcePropertyList
+Type: Microsoft.ActiveDirectory.Management.ADResourcePropertyList
 Parameter Sets: (All)
 Aliases: 
 
@@ -143,21 +149,20 @@ Accept wildcard characters: False
 ```
 
 ### -Members
-Specifies a set of **ADResourceProperty** objects in a comma-separated list to add to a resource property list.
-To identify each object, use one of the following property values: 
+
+Specifies a set of **ADResourceProperty** objects in a comma-separated list to add to a resource
+property list. To identify each object, use one of the following property values:
 
 - Name
 - Distinguished name
-- GUID (objectGUID) 
-
-Note: The identifier in parentheses is the LDAP display name.
+- GUID (**objectGUID**)
 
 You can also provide objects to this parameter directly.
 
 You cannot pass objects through the pipeline to this parameter.
 
 ```yaml
-Type: ADResourceProperty[]
+Type: Microsoft.ActiveDirectory.Management.ADResourceProperty[]
 Parameter Sets: (All)
 Aliases: 
 
@@ -169,11 +174,12 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns an object representing the item with which you are working.
 By default, this cmdlet does not generate any output.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: 
 
@@ -185,30 +191,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services (AD DS) instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: Active Directory Lightweight Directory Services (AD LDS), AD DS, or Active Directory snapshot instance.
 
-Specify the AD DS instance in one of the following ways:  
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values:  
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the AD DS Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -220,11 +231,12 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -236,24 +248,30 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None or Microsoft.ActiveDirectory.Management.ADClaimTypeList
-An **ADClaimTypeList** object is received by the *Identity* parameter.
+
+An **ADClaimTypeList** object is received by the **Identity** parameter.
 
 ## OUTPUTS
 
 ### None or Microsoft.ActiveDirectory.Management.ADClaimTypeList
-Returns the modified **ADClaimTypeList** object when the *PassThru* parameter is specified.
-By default, this cmdlet does not generate any output.
+
+Returns the modified **ADClaimTypeList** object when the **PassThru** parameter is specified. By
+default, this cmdlet does not generate any output.
 
 ## NOTES
-* This cmdlet does not work with a read-only domain controller.
-* This cmdlet does not work with an Active Directory snapshot.
+
+- This cmdlet does not work with a read-only domain controller.
+- This cmdlet does not work with an Active Directory snapshot.
 
 ## RELATED LINKS
 
 [Remove-ADResourcePropertyListMember](./Remove-ADResourcePropertyListMember.md)
-

--- a/docset/winserver2022-ps/activedirectory/Clear-ADAccountExpiration.md
+++ b/docset/winserver2022-ps/activedirectory/Clear-ADAccountExpiration.md
@@ -46,7 +46,7 @@ instance.
 
 ## EXAMPLES
 
-### EXAMPLE 1
+### Example 1: Clear an account expiration date for a specified user
 
 ```powershell
 Clear-ADAccountExpiration -Identity PattiFuller
@@ -54,7 +54,7 @@ Clear-ADAccountExpiration -Identity PattiFuller
 
 This command clears the account expiration date for the user with SamAccountName `PattiFuller`.
 
-### EXAMPLE 2
+### Example 2: Clear an account expiration date by using a distinguished name
 
 ```powershell
 Clear-ADAccountExpiration -Identity 'CN=PattiFuller,DC=AppNC' -Server 'PATTIFU-SVR1:60000'
@@ -67,8 +67,7 @@ This command clears the account expiration date for the user with DistinguishedN
 
 ### -AuthType
 
-Specifies the authentication method to use.
-The acceptable values for this parameter are:
+Specifies the authentication method to use. The acceptable values for this parameter are:
 
 - `Negotiate` or `0`
 - `Basic` or `1`
@@ -217,8 +216,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+Returns an object representing the item with which you're working. By default, this cmdlet doesn't
+generate any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -274,8 +273,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/docset/winserver2022-ps/activedirectory/Clear-ADAccountExpiration.md
+++ b/docset/winserver2022-ps/activedirectory/Clear-ADAccountExpiration.md
@@ -16,57 +16,69 @@ Clears the expiration date for an Active Directory account.
 ## SYNTAX
 
 ```
-Clear-ADAccountExpiration [-WhatIf] [-Confirm] [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADAccount> [-Partition <String>] [-PassThru] [-Server <String>] [<CommonParameters>]
+Clear-ADAccountExpiration [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
+ [-Credential <PSCredential>] [-Identity] <ADAccount> [-Partition <String>] [-PassThru]
+ [-Server <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Clear-ADAccountExpiration** cmdlet clears the expiration date for an Active Directory user or computer account.
-When you clear the expiration date for an account, the account does not expire.
 
-The *Identity* parameter specifies the user or computer account to modify.
-You can identify a user or group by its distinguished name, GUID, security identifier (SID), or Security Accounts Manager (SAM) account name.
-You can also set the *Identity* parameter to a user or computer object variable, such as `$<localUserObject>`, or pass a user or computer object through the pipeline to the *Identity* parameter.
-For example, you can use the Get-ADUser, Get-ADComputer, or Search-ADAccount cmdlet to retrieve an object and then pass the object through the pipeline to the Clear-ADAccountExpiration cmdlet.
+The `Clear-ADAccountExpiration` cmdlet clears the expiration date for an Active Directory user or
+computer account. When you clear the expiration date for an account, the account does not expire.
 
-For Active Directory Lightweight Directory Services (AD LDS) environments, the *Partition* parameter must be specified except in the following two conditions:
+The **Identity** parameter specifies the user or computer account to modify. You can identify a user
+or group by its distinguished name, GUID, security identifier (SID), or Security Accounts Manager
+(SAM) account name. You can also set the **Identity** parameter to a user or computer object
+variable, such as `$<localUserObject>`, or pass a user or computer object through the pipeline to
+the **Identity** parameter. For example, you can use the `Get-ADUser`, `Get-ADComputer`, or
+`Search-ADAccount` cmdlet to retrieve an object and then pass the object through the pipeline to the
+`Clear-ADAccountExpiration` cmdlet.
+
+For Active Directory Lightweight Directory Services (AD LDS) environments, the **Partition**
+parameter must be specified except in the following two conditions:
 
 - The cmdlet is run from an Active Directory provider drive.
-- A default naming context or partition is defined for the AD LDS environment. 
+- A default naming context or partition is defined for the AD LDS environment.
 
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent object (**nTDSDSA**) for the AD LDS instance.
+To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext**
+property of the Active Directory directory service agent object (**nTDSDSA**) for the AD LDS
+instance.
 
 ## EXAMPLES
 
-### Example 1: Clear an account expiration date for a specified user
-```
-PS C:\> Clear-ADAccountExpiration -Identity PattiFuller
+### EXAMPLE 1
+
+```powershell
+Clear-ADAccountExpiration -Identity PattiFuller
 ```
 
-This command clears the account expiration date for the user with SamAccountName PattiFuller.
+This command clears the account expiration date for the user with SamAccountName `PattiFuller`.
 
-### Example 2: Clear an account expiration date for a specified user using a distinguished name
-```
-PS C:\> Clear-ADAccountExpiration -Identity "CN=PattiFuller,DC=AppNC" -Server "PATTIFU-SVR1:60000"
+### EXAMPLE 2
+
+```powershell
+Clear-ADAccountExpiration -Identity 'CN=PattiFuller,DC=AppNC' -Server 'PATTIFU-SVR1:60000'
 ```
 
-This command clears the account expiration date for the user with DistinguishedName CN=PattiFuller,DC=AppNC on the AD LDS instance PATTIFU-SVR1:60000.
+This command clears the account expiration date for the user with DistinguishedName
+`CN=PattiFuller,DC=AppNC` on the AD LDS instance `PATTIFU-SVR1:60000`.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -79,10 +91,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -94,20 +107,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -119,19 +136,21 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory account object by providing one of the following property values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory account object by providing one of the following property values. The
+identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the
+attribute. The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID (objectGUID) 
-- A security identifier (objectSid) 
-- A SAM account name (sAMAccountName)
+- A GUID (**objectGUID**)
+- A security identifier (**objectSid**)
+- A SAM account name (**sAMAccountName**)
 
-The cmdlet searches the default naming context or partition to find the object.
-If two or more objects are found, the cmdlet returns a non-terminating error.
+The cmdlet searches the default naming context or partition to find the object. If two or more
+objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to an account object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+account object instance.
 
 Derived types such as the following are also accepted:
 
@@ -140,7 +159,7 @@ Derived types such as the following are also accepted:
 - **Microsoft.ActiveDirectory.Management.ADUser**
 
 ```yaml
-Type: ADAccount
+Type: Microsoft.ActiveDirectory.Management.ADAccount
 Parameter Sets: (All)
 Aliases: 
 
@@ -152,30 +171,40 @@ Accept wildcard characters: False
 ```
 
 ### -Partition
-Specifies the distinguished name of an Active Directory partition.
-The distinguished name must be one of the naming contexts on the current directory server.
-The cmdlet searches this partition to find the object defined by the *Identity* parameter.
 
-In many cases, a default value is used for the *Partition* parameter if no value is specified. 
-The rules for determining the default value are given below. 
-Note that rules listed first are evaluated first and once a default value can be determined, no further rules are evaluated.
+Specifies the distinguished name of an Active Directory partition. The distinguished name must be
+one of the naming contexts on the current directory server. The cmdlet searches this partition to
+find the object defined by the **Identity** parameter.
 
-In Active Directory Domain Services (AD DS) environments, a default value for *Partition* is set in the following cases: 
+In many cases, a default value is used for the **Partition** parameter if no value is specified. The
+rules for determining the default value are given below. Note that rules listed first are evaluated
+first and once a default value can be determined, no further rules are evaluated.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name.
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If none of the previous cases apply, the default value of *Partition* is set to the default partition or naming context of the target domain.
+In Active Directory Domain Services environments, a default value for **Partition** is set in the
+following cases:
 
-In AD LDS environments, a default value for *Partition* is set in the following cases:
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If none of the previous cases apply, the default value of **Partition** is set to the default
+  partition or naming context of the target domain.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name. 
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If the target AD LDS instance has a default naming context, the default value of *Partition* is set to the default naming context. 
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent (DSA) object (**nTDSDSA**) for the AD LDS instance. 
-- If none of the previous cases apply, the *Partition* parameter will not take any default value.
+In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for
+**Partition** is set in the following cases:
+
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If the target AD LDS instance has a default naming context, the default value of **Partition** is
+  set to the default naming context. To specify a default naming context for an AD LDS environment,
+  set the **msDS-defaultNamingContext** property of the Active Directory directory service agent
+  (DSA) object (**nTDSDSA**) for the AD LDS instance.
+- If none of the previous cases apply, the **Partition** parameter will not take any default value.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -187,11 +216,12 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns an object representing the item with which you are working.
 By default, this cmdlet does not generate any output.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: 
 
@@ -203,30 +233,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following:  Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways:  
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -238,11 +273,12 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -254,12 +290,18 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADAccount
-An account object (**Microsoft.ActiveDirectory.Management.ADAccount**) is received by the *Identity* parameter.
+
+An account object (**Microsoft.ActiveDirectory.Management.ADAccount**) is received by the
+**Identity** parameter.
 
 Derived types, such as the following are also accepted:
 
@@ -272,8 +314,9 @@ Derived types, such as the following are also accepted:
 ### None
 
 ## NOTES
-* This cmdlet does not work with an Active Directory snapshot.
-* This cmdlet does not work with a read-only domain controller.
+
+- This cmdlet does not work with an Active Directory snapshot.
+- This cmdlet does not work with a read-only domain controller.
 
 ## RELATED LINKS
 
@@ -286,4 +329,3 @@ Derived types, such as the following are also accepted:
 [Get-ADComputer](./Get-ADComputer.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
-

--- a/docset/winserver2022-ps/activedirectory/Clear-ADClaimTransformLink.md
+++ b/docset/winserver2022-ps/activedirectory/Clear-ADClaimTransformLink.md
@@ -30,7 +30,7 @@ more cross-forest trust relationships in Active Directory.
 
 ## EXAMPLES
 
-### Example 1
+### EXAMPLE 1
 
 ```powershell
 Clear-ADClaimTransformLink -Identity 'corp.contoso.com' -Policy DenyAllPolicy
@@ -38,7 +38,7 @@ Clear-ADClaimTransformLink -Identity 'corp.contoso.com' -Policy DenyAllPolicy
 
 This command removes the policy named `DenyAllPolicy` from the `corp.contoso.com` trust.
 
-### Example 2
+### EXAMPLE 2
 
 ```powershell
 Clear-ADClaimTransformLink -Identity 'corp.contoso.com' -TrustRole Trusted
@@ -48,7 +48,7 @@ This command removes any policies that are applied to where this forest acts as 
 in the `corp.contoso.com` trust. Effectively, this cmdlet removes any policies that are applied to
 claims flowing out of this forest towards it trust partner.
 
-### Example 3
+### EXAMPLE 3
 
 ```powershell
 $params = @{

--- a/docset/winserver2022-ps/activedirectory/Clear-ADClaimTransformLink.md
+++ b/docset/winserver2022-ps/activedirectory/Clear-ADClaimTransformLink.md
@@ -11,59 +11,74 @@ title: Clear-ADClaimTransformLink
 # Clear-ADClaimTransformLink
 
 ## SYNOPSIS
-Removes a claims transformation from being applied to one or more cross-forest trust relationships in Active Directory.
+Removes a claims transformation from being applied to one or more cross-forest trust relationships
+in Active Directory.
 
 ## SYNTAX
 
 ```
-Clear-ADClaimTransformLink [-WhatIf] [-Confirm] [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADTrust> [-PassThru] [-Policy <ADClaimTransformPolicy>] [-Server <String>]
- [-TrustRole <ADTrustRole>] [<CommonParameters>]
+Clear-ADClaimTransformLink [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
+ [-Credential <PSCredential>] [-Identity] <ADTrust> [-PassThru]
+ [-Policy <ADClaimTransformPolicy>] [-Server <String>] [-TrustRole <ADTrustRole>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Clear-ADClaimTransformLink** cmdlet removes a claims transformation from being applied to one or more cross-forest trust relationships in Active Directory.
+
+The `Clear-ADClaimTransformLink` cmdlet removes a claims transformation from being applied to one or
+more cross-forest trust relationships in Active Directory.
 
 ## EXAMPLES
 
-### Example 1: Remove a specified policy from a trust relationship
-```
-PS C:\> Clear-ADClaimTransformLink -Identity "corp.contoso.com" -Policy DenyAllPolicy
+### Example 1
+
+```powershell
+Clear-ADClaimTransformLink -Identity 'corp.contoso.com' -Policy DenyAllPolicy
 ```
 
-This command removes the policy named DenyAllPolicy from the corp.contoso.com trust.
+This command removes the policy named `DenyAllPolicy` from the `corp.contoso.com` trust.
 
-### Example 2: Remove all policies that are applied to a trusted forest
-```
-PS C:\> Clear-ADClaimTransformLink -Identity "corp.contoso.com" -TrustRole Trusted
-```
+### Example 2
 
-This command removes any policies that are applied to where this forest acts as the trusted forest in the corp.contoso.com trust.
-Effectively, this cmdlet removes any policies that are applied to claims flowing out of this forest towards it trust partner.
-
-### Example 3: Remove a specified claim transformation policy from being applied to the trust relationship
-```
-PS C:\> Clear-ADClaimTransformLink -Identity "corp.contoso.com" -Policy DenyAllPolicy -TrustRole Trusting
+```powershell
+Clear-ADClaimTransformLink -Identity 'corp.contoso.com' -TrustRole Trusted
 ```
 
-This command removes DenyAllPolicy that is applied to where this forest acts as the trusted domain in the corp.contoso.com trust.
-Effectively, this cmdlet removes DenyAllPolicy from applying to claims coming into this from its trust partner.
+This command removes any policies that are applied to where this forest acts as the trusted forest
+in the `corp.contoso.com` trust. Effectively, this cmdlet removes any policies that are applied to
+claims flowing out of this forest towards it trust partner.
+
+### Example 3
+
+```powershell
+$params = @{
+    Identity = 'corp.contoso.com'
+    Policy = 'DenyAllPolicy'
+    TrustRole = 'Trusting'
+}
+Clear-ADClaimTransformLink @params
+```
+
+This command removes DenyAllPolicy that is applied to where this forest acts as the trusted domain
+in the `corp.contoso.com` trust. Effectively, this cmdlet removes `DenyAllPolicy` from applying to
+claims coming into this from its trust partner.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -76,10 +91,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -91,20 +107,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -116,17 +136,19 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory trust object by providing one of the following values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
+
+Specifies an Active Directory trust object by providing one of the following values. The identifier
+in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
 The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID (objectGUID)
+- A GUID (**objectGUID**)
 
-This parameter can also get this object through the pipeline or you can set this parameter to an object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+object instance.
 
 ```yaml
-Type: ADTrust
+Type: Microsoft.ActiveDirectory.Management.ADTrust
 Parameter Sets: (All)
 Aliases: 
 
@@ -138,11 +160,12 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns an object representing the item with which you are working.
 By default, this cmdlet does not generate any output.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: 
 
@@ -154,10 +177,11 @@ Accept wildcard characters: False
 ```
 
 ### -Policy
+
 Removes the specified claim transformation policy from being applied to the trust relationship.
 
 ```yaml
-Type: ADClaimTransformPolicy
+Type: Microsoft.ActiveDirectory.Management.ADClaimTransformPolicy
 Parameter Sets: (All)
 Aliases: 
 
@@ -169,30 +193,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways: 
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -204,16 +233,15 @@ Accept wildcard characters: False
 ```
 
 ### -TrustRole
-Specifies the role of the current forest in the trust relationship specified by the *Identity* parameter.
-The allowable values for this parameter are as follows:
 
-- Trusted.
-Specify this value if the current forest is the trusted forest. 
-- Trusting.
-Specify this value if the current forest is the trusting forest.
+Specifies the role of the current forest in the trust relationship specified by the **Identity**
+parameter. The allowable values for this parameter are as follows:
+
+- `Trusted`: Specify this value if the current forest is the trusted forest.
+- `Trusting`: Specify this value if the current forest is the trusting forest.
 
 ```yaml
-Type: ADTrustRole
+Type: Microsoft.ActiveDirectory.Management.ADTrustRole
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Trusted, Trusting
@@ -226,11 +254,12 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -242,12 +271,18 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADTrust
-An account object (**Microsoft.ActiveDirectory.Management.ADTrust**) is received by the *Identity* parameter.
+
+An account object (**Microsoft.ActiveDirectory.Management.ADTrust**) is received by the **Identity**
+parameter.
 
 ## OUTPUTS
 
@@ -260,4 +295,3 @@ An account object (**Microsoft.ActiveDirectory.Management.ADTrust**) is received
 [Set-ADClaimTransformLink](./Set-ADClaimTransformLink.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
-

--- a/docset/winserver2022-ps/activedirectory/Clear-ADClaimTransformLink.md
+++ b/docset/winserver2022-ps/activedirectory/Clear-ADClaimTransformLink.md
@@ -30,7 +30,7 @@ more cross-forest trust relationships in Active Directory.
 
 ## EXAMPLES
 
-### EXAMPLE 1
+### Example 1: Remove a specified policy from a trust relationship
 
 ```powershell
 Clear-ADClaimTransformLink -Identity 'corp.contoso.com' -Policy DenyAllPolicy
@@ -38,7 +38,7 @@ Clear-ADClaimTransformLink -Identity 'corp.contoso.com' -Policy DenyAllPolicy
 
 This command removes the policy named `DenyAllPolicy` from the `corp.contoso.com` trust.
 
-### EXAMPLE 2
+### Example 2: Remove all policies that are applied to a trusted forest
 
 ```powershell
 Clear-ADClaimTransformLink -Identity 'corp.contoso.com' -TrustRole Trusted
@@ -48,7 +48,7 @@ This command removes any policies that are applied to where this forest acts as 
 in the `corp.contoso.com` trust. Effectively, this cmdlet removes any policies that are applied to
 claims flowing out of this forest towards it trust partner.
 
-### EXAMPLE 3
+### Example 3: Remove a claim transformation policy from being applied to the trust relationship
 
 ```powershell
 $params = @{
@@ -67,8 +67,7 @@ claims coming into this from its trust partner.
 
 ### -AuthType
 
-Specifies the authentication method to use.
-The acceptable values for this parameter are:
+Specifies the authentication method to use. The acceptable values for this parameter are:
 
 - `Negotiate` or `0`
 - `Basic` or `1`
@@ -161,8 +160,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+Returns an object representing the item with which you're working. By default, this cmdlet doesn't
+generate any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -255,8 +254,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/docset/winserver2022-ps/activedirectory/Disable-ADAccount.md
+++ b/docset/winserver2022-ps/activedirectory/Disable-ADAccount.md
@@ -46,7 +46,7 @@ instance.
 
 ## EXAMPLES
 
-### EXAMPLE 1
+### Example 1: Disable an account by identity
 
 ```powershell
 Disable-ADAccount -Identity PattiFul
@@ -54,7 +54,7 @@ Disable-ADAccount -Identity PattiFul
 
 This command disables the account with identity SAMAccountName `PattiFul`.
 
-### EXAMPLE 2
+### Example 2: Disable an account by Distinguished Name
 
 ```powershell
 Disable-ADAccount -Identity 'CN=Patti Fuller,OU=Finance,OU=Users,DC=FABRIKAM,DC=COM'
@@ -63,7 +63,7 @@ Disable-ADAccount -Identity 'CN=Patti Fuller,OU=Finance,OU=Users,DC=FABRIKAM,DC=
 This command disables the account with DistinguishedName
 `CN=Patti Fuller,OU=Finance,OU=Users,DC=FABRIKAM,DC=COM`.
 
-### EXAMPLE 3
+### Example 3: Disable all accounts in an organizational unit
 
 ```powershell
 Get-ADUser -Filter 'Name -like "*"' -SearchBase "OU=Finance,OU=Users,DC=FABRIKAM,DC=COM" |
@@ -77,8 +77,7 @@ This command disables all accounts in the organizational unit
 
 ### -AuthType
 
-Specifies the authentication method to use.
-The acceptable values for this parameter are:
+Specifies the authentication method to use. The acceptable values for this parameter are:
 
 - `Negotiate` or `0`
 - `Basic` or `1`
@@ -227,8 +226,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+Returns an object representing the item with which you're working. By default, this cmdlet doesn't
+generate any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -284,8 +283,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/docset/winserver2022-ps/activedirectory/Disable-ADAccount.md
+++ b/docset/winserver2022-ps/activedirectory/Disable-ADAccount.md
@@ -16,63 +16,79 @@ Disables an Active Directory account.
 ## SYNTAX
 
 ```
-Disable-ADAccount [-WhatIf] [-Confirm] [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADAccount> [-Partition <String>] [-PassThru] [-Server <String>] [<CommonParameters>]
+Disable-ADAccount [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
+ [-Credential <PSCredential>] [-Identity] <ADAccount> [-Partition <String>] [-PassThru]
+ [-Server <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Disable-ADAccount** cmdlet disables an Active Directory user, computer, or service account.
 
-The *Identity* parameter specifies the Active Directory user, computer service account, or other service account that you want to disable.
-You can identify an account by its distinguished name, GUID, security identifier (SID), or Security Accounts Manager (SAM) account name.
-You can also set the *Identity* parameter to an object variable such as `$<localADAccountObject>`, or you can pass an account object through the pipeline to the *Identity* parameter.
-For example, you can use the **Get-ADUser** cmdlet to retrieve a user account object and then pass the object through the pipeline to the **Disable-ADAccount** cmdlet.
-Similarly, you can use **Get-ADComputer** and **Search-ADAccount** to retrieve account objects.
+The `Disable-ADAccount` cmdlet disables an Active Directory user, computer, or service account.
 
-For Active Directory Lightweight Directory Services (AD LDS) environments, the *Partition* parameter must be specified except in the following two conditions:
+The **Identity** parameter specifies the Active Directory user, computer service account, or other
+service account that you want to disable. You can identify an account by its distinguished name,
+GUID, security identifier (SID), or Security Accounts Manager (SAM) account name. You can also set
+the **Identity** parameter to an object variable such as `$<localADAccountObject>`, or you can pass
+an account object through the pipeline to the **Identity** parameter. For example, you can use the
+`Get-ADUser` cmdlet to retrieve a user account object and then pass the object through the
+pipeline to the `Disable-ADAccount` cmdlet. Similarly, you can use `Get-ADComputer` and
+`Search-ADAccount` to retrieve account objects.
+
+For Active Directory Lightweight Directory Services (AD LDS) environments, the **Partition**
+parameter must be specified except in the following two conditions:
 
 - The cmdlet is run from an Active Directory provider drive.
 - A default naming context or partition is defined for the AD LDS environment.
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent (DSA) object (**nTDSDSA**) for the AD LDS instance.
+
+To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext**
+property of the Active Directory directory service agent (DSA) object (**nTDSDSA**) for the AD LDS
+instance.
 
 ## EXAMPLES
 
-### Example 1: Disable an account by identity
-```
-PS C:\> Disable-ADAccount -Identity PattiFul
+### EXAMPLE 1
+
+```powershell
+Disable-ADAccount -Identity PattiFul
 ```
 
-This command disables the account with identity SAMAccountName PattiFul.
+This command disables the account with identity SAMAccountName `PattiFul`.
 
-### Example 2: Disable an account by Distinguished Name
-```
-PS C:\> Disable-ADAccount -Identity "CN=Patti Fuller,OU=Finance,OU=UserAccounts,DC=FABRIKAM,DC=COM"
-```
+### EXAMPLE 2
 
-This command disables the account with DistinguishedName CN=Patti Fuller,OU=Finance,OU=UserAccounts,DC=FABRIKAM,DC=COM.
-
-### Example 3: Disable all accounts in an organizational unit using a filter
-```
-PS C:\> Get-ADUser -Filter 'Name -like "*"' -SearchBase "OU=Finance,OU=UserAccounts,DC=FABRIKAM,DC=COM" | Disable-ADAccount
+```powershell
+Disable-ADAccount -Identity 'CN=Patti Fuller,OU=Finance,OU=Users,DC=FABRIKAM,DC=COM'
 ```
 
-This command disables all accounts in the organizational unit OU=Finance,OU=UserAccounts,DC=FABRIKAM,DC=COM.
+This command disables the account with DistinguishedName
+`CN=Patti Fuller,OU=Finance,OU=Users,DC=FABRIKAM,DC=COM`.
+
+### EXAMPLE 3
+
+```powershell
+Get-ADUser -Filter 'Name -like "*"' -SearchBase "OU=Finance,OU=Users,DC=FABRIKAM,DC=COM" |
+    Disable-ADAccount
+```
+
+This command disables all accounts in the organizational unit
+`OU=Finance,OU=Users,DC=FABRIKAM,DC=COM`.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -85,10 +101,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -100,20 +117,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential*  parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -125,28 +146,30 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory account object by providing one of the following property values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory account object by providing one of the following property values. The
+identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the
+attribute. The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID (objectGUID) 
-- A Security Identifier (objectSid) 
-- A SAM Account Name (SAMAccountName)
+- A GUID (**objectGUID**)
+- A Security Identifier (**objectSid**)
+- A SAM Account Name (**SAMAccountName**)
 
 The cmdlet searches the default naming context or partition to find the object.
 If two or more objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to an account object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+account object instance.
 
-Derived types such as the following are also accepted: 
+Derived types such as the following are also accepted:
 
 - **Microsoft.ActiveDirectory.Management.ADServiceAccount**
 - **Microsoft.ActiveDirectory.Management.ADComputer**
 - **Microsoft.ActiveDirectory.Management.ADUser**
 
 ```yaml
-Type: ADAccount
+Type: Microsoft.ActiveDirectory.Management.ADAccount
 Parameter Sets: (All)
 Aliases: 
 
@@ -158,30 +181,40 @@ Accept wildcard characters: False
 ```
 
 ### -Partition
-Specifies the distinguished name of an Active Directory partition.
-The distinguished name must be one of the naming contexts on the current directory server.
-The cmdlet searches this partition to find the object defined by the *Identity* parameter.
 
-In many cases, a default value is used for the *Partition* parameter if no value is specified.
-The rules for determining the default value are given below.
-Note that rules listed first are evaluated first and once a default value can be determined, no further rules are evaluated.
+Specifies the distinguished name of an Active Directory partition. The distinguished name must be
+one of the naming contexts on the current directory server. The cmdlet searches this partition to
+find the object defined by the **Identity** parameter.
 
-In Active Directory Domain Services (AD DS) environments, a default value for *Partition* is set in the following cases: 
+In many cases, a default value is used for the **Partition** parameter if no value is specified. The
+rules for determining the default value are given below. Note that rules listed first are evaluated
+first and once a default value can be determined, no further rules are evaluated.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name.
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If none of the previous cases apply, the default value of *Partition* is set to the default partition or naming context of the target domain.
+In Active Directory Domain Services environments, a default value for **Partition** is set in the
+following cases:
 
-In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for *Partition* is set in the following cases: 
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If none of the previous cases apply, the default value of **Partition** is set to the default
+  partition or naming context of the target domain.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name. 
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If the target AD LDS instance has a default naming context, the default value of *Partition* is set to the default naming context.
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent object (**nTDSDSA**) for the AD LDS instance. 
-- If none of the previous cases apply, the *Partition* parameter will not take any default value.
+In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for
+**Partition** is set in the following cases:
+
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If the target AD LDS instance has a default naming context, the default value of **Partition** is
+  set to the default naming context. To specify a default naming context for an AD LDS environment,
+  set the **msDS-defaultNamingContext** property of the Active Directory directory service agent
+  (DSA) object (**nTDSDSA**) for the AD LDS instance.
+- If none of the previous cases apply, the **Partition** parameter will not take any default value.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -193,11 +226,12 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns an object representing the item with which you are working.
 By default, this cmdlet does not generate any output.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: 
 
@@ -209,30 +243,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways:  
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -244,11 +283,12 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -260,12 +300,17 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADAccount
-An account object is received by the *Identity* parameter.
+
+An account object is received by the **Identity** parameter.
 
 Derived types, such as the following are also accepted:
 
@@ -278,8 +323,9 @@ Derived types, such as the following are also accepted:
 ### None
 
 ## NOTES
-* This cmdlet does not work with an Active Directory snapshot.
-* This cmdlet does not work with a read-only domain controller.
+
+- This cmdlet does not work with an Active Directory snapshot.
+- This cmdlet does not work with a read-only domain controller.
 
 ## RELATED LINKS
 
@@ -300,4 +346,3 @@ Derived types, such as the following are also accepted:
 [Unlock-ADAccount](./Unlock-ADAccount.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
-


### PR DESCRIPTION
# PR Summary

This change fixes formatting in a handful of articles for the ActiveDirectory module

- Fixes #3480 

Articles addressed:

- Add-ADCentralAccessPolicyMember.md
- Add-ADComputerServiceAccount.md
- Add-ADDomainControllerPasswordReplicationPolicy.md
- Add-ADFineGrainedPasswordPolicySubject.md
- Add-ADGroupMember.md
- Add-ADPrincipalGroupMembership.md
- Add-ADResourcePropertyListMember.md
- Clear-ADAccountExpiration.md
- Clear-ADClaimTransformLink.md
- Disable-ADAccount.md

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
