### PR TITLE
Clarify that DN syntax can be used to set permissions on AD domain root

### DIFF
--- a/docset/winserver2019-ps/laps/Find-LapsADExtendedRights.md
+++ b/docset/winserver2019-ps/laps/Find-LapsADExtendedRights.md
@@ -104,6 +104,8 @@ resultant AD search. The supported name formats are as follows:
 - distinguishedName (begins with a `CN=`)
 - name (for all other inputs)
 
+Querying permissions on the domain root is only supported using the distinguishedName input format, for example 'DC=laps,DC=com'.
+
 ```yaml
 Type: System.String[]
 Parameter Sets: (All)

--- a/docset/winserver2019-ps/laps/Set-LapsADComputerSelfPermission.md
+++ b/docset/winserver2019-ps/laps/Set-LapsADComputerSelfPermission.md
@@ -105,6 +105,8 @@ resultant AD search. The supported name formats are as follows:
 - distinguishedName (begins with a `CN=`)
 - name (for all other inputs)
 
+Setting permissions on the domain root is only supported using the distinguishedName input format, for example 'DC=laps,DC=com'.
+
 ```yaml
 Type: System.String[]
 Parameter Sets: (All)

--- a/docset/winserver2019-ps/laps/Set-LapsADReadPasswordPermission.md
+++ b/docset/winserver2019-ps/laps/Set-LapsADReadPasswordPermission.md
@@ -177,6 +177,8 @@ resultant AD search. The supported name formats are as follows:
 - distinguishedName (begins with a `CN=`)
 - name (for all other inputs)
 
+Setting permissions on the domain root is only supported using the distinguishedName input format, for example 'DC=laps,DC=com'.
+
 ```yaml
 Type: System.String[]
 Parameter Sets: (All)

--- a/docset/winserver2019-ps/laps/Set-LapsADResetPasswordPermission.md
+++ b/docset/winserver2019-ps/laps/Set-LapsADResetPasswordPermission.md
@@ -178,6 +178,8 @@ resultant AD search. The supported name formats are as follows:
 - distinguishedName (begins with a `CN=`)
 - name (for all other inputs)
 
+Setting permissions on the domain root is only supported using the distinguishedName input format, for example 'DC=laps,DC=com'.
+
 ```yaml
 Type: System.String[]
 Parameter Sets: (All)

--- a/docset/winserver2022-ps/laps/Find-LapsADExtendedRights.md
+++ b/docset/winserver2022-ps/laps/Find-LapsADExtendedRights.md
@@ -104,6 +104,8 @@ resultant AD search. The supported name formats are as follows:
 - distinguishedName (begins with a `CN=`)
 - name (for all other inputs)
 
+Querying permissions on the domain root is only supported using the distinguishedName input format, for example 'DC=laps,DC=com'.
+
 ```yaml
 Type: System.String[]
 Parameter Sets: (All)

--- a/docset/winserver2022-ps/laps/Set-LapsADComputerSelfPermission.md
+++ b/docset/winserver2022-ps/laps/Set-LapsADComputerSelfPermission.md
@@ -105,6 +105,8 @@ resultant AD search. The supported name formats are as follows:
 - distinguishedName (begins with a `CN=`)
 - name (for all other inputs)
 
+Setting permissions on the domain root is only supported using the distinguishedName input format, for example 'DC=laps,DC=com'.
+
 ```yaml
 Type: System.String[]
 Parameter Sets: (All)

--- a/docset/winserver2022-ps/laps/Set-LapsADReadPasswordPermission.md
+++ b/docset/winserver2022-ps/laps/Set-LapsADReadPasswordPermission.md
@@ -177,6 +177,8 @@ resultant AD search. The supported name formats are as follows:
 - distinguishedName (begins with a `CN=`)
 - name (for all other inputs)
 
+Setting permissions on the domain root is only supported using the distinguishedName input format, for example 'DC=laps,DC=com'.
+
 ```yaml
 Type: System.String[]
 Parameter Sets: (All)

--- a/docset/winserver2022-ps/laps/Set-LapsADResetPasswordPermission.md
+++ b/docset/winserver2022-ps/laps/Set-LapsADResetPasswordPermission.md
@@ -178,6 +178,8 @@ resultant AD search. The supported name formats are as follows:
 - distinguishedName (begins with a `CN=`)
 - name (for all other inputs)
 
+Setting permissions on the domain root is only supported using the distinguishedName input format, for example 'DC=laps,DC=com'.
+
 ```yaml
 Type: System.String[]
 Parameter Sets: (All)


### PR DESCRIPTION
# PR Summary

Adds comments to all LAPS permission-setting cmdlets to clarify that DN syntax may be used to target the AD domain root.

## PR Checklist

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].
