### PR TITLE
Quality: Address formatting in articles for some ActiveDirectory cmdlets (issue #3490)

### DIFF
--- a/docset/winserver2022-ps/activedirectory/Disable-ADOptionalFeature.md
+++ b/docset/winserver2022-ps/activedirectory/Disable-ADOptionalFeature.md
@@ -125,7 +125,6 @@ A Secure Sockets Layer (SSL) connection is required for the `Basic` authenticati
 
 ```yaml
 Type: Microsoft.ActiveDirectory.Management.ADAuthType
-Type: ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -172,7 +171,6 @@ Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
 Type: System.Management.Automation.PSCredential
-Type: PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -279,7 +277,6 @@ they are listed:
 
 ```yaml
 Type: System.String
-Type: String
 Parameter Sets: (All)
 Aliases: 
 

--- a/docset/winserver2022-ps/activedirectory/Disable-ADOptionalFeature.md
+++ b/docset/winserver2022-ps/activedirectory/Disable-ADOptionalFeature.md
@@ -304,7 +304,7 @@ The following example shows how to set this parameter to a domain naming context
 `-Target "DC=corp,DC=Fabrikam,DC=com"`
 
 ```yaml
-Type: ADEntity
+Type: Microsoft.ActiveDirectory.Management.ADEntity
 Parameter Sets: (All)
 Aliases: 
 

--- a/docset/winserver2022-ps/activedirectory/Disable-ADOptionalFeature.md
+++ b/docset/winserver2022-ps/activedirectory/Disable-ADOptionalFeature.md
@@ -16,72 +16,115 @@ Disables an Active Directory optional feature.
 ## SYNTAX
 
 ```
-Disable-ADOptionalFeature [-WhatIf] [-Confirm] [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADOptionalFeature> [-PassThru] [-Scope] <ADOptionalFeatureScope> [-Server <String>]
- [-Target] <ADEntity> [<CommonParameters>]
+Disable-ADOptionalFeature [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
+ [-Credential <PSCredential>] [-Identity] <ADOptionalFeature> [-PassThru]
+ [-Scope] <ADOptionalFeatureScope> [-Server <String>] [-Target] <ADEntity>
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Disable-ADOptionalFeature** disables an Active Directory optional feature that is associated with a particular domain mode or forest mode.
 
-The *Identity* parameter specifies the Active Directory optional feature that you want to disable.
-You can identify an optional feature by its distinguished name, feature GUID, or object GUID.
-You can also set the parameter to an optional feature object variable, such as `$<localOptionalFeatureObject>` or you can pass an optional feature object through the pipeline to the *Identity* parameter.
-For example, you can use the **Get-ADOptionalFeature** cmdlet to retrieve an optional feature object and then pass the object through the pipeline to the **Disable-ADOptionalFeature** cmdlet.
+The `Disable-ADOptionalFeature` disables an Active Directory optional feature that is associated
+with a particular domain mode or forest mode.
+
+The **Identity** parameter specifies the Active Directory optional feature that you want to disable.
+You can identify an optional feature by its distinguished name, feature GUID, or object GUID. You
+can also set the parameter to an optional feature object variable, such as
+`$<localOptionalFeatureObject>` or you can pass an optional feature object through the pipeline to
+the **Identity** parameter. For example, you can use the `Get-ADOptionalFeature` cmdlet to retrieve
+an optional feature object and then pass the object through the pipeline to the
+`Disable-ADOptionalFeature` cmdlet.
 
 The **Scope** parameter specifies the scope at which the optional feature is disabled.
 
 The **Target** parameter specifies the domain or forest on which the optional feature is disabled.
-You can identify the domain or forest by its fully-qualified domain name (FQDN), NetBIOS name, or the distinguished name of the domain naming context.
+You can identify the domain or forest by its fully-qualified domain name (FQDN), NetBIOS name, or
+the distinguished name of the domain naming context.
 
 ## EXAMPLES
 
 ### Example 1: Disable a feature for a NetBIOS target
-```
-PS C:\> Disable-ADOptionalFeature -Identity 'Feature 1' -Scope ForestOrConfigurationSet -Target 'fabrikam' -Server DC1
+
+```powershell
+$params = @{
+    Identity = 'Feature 1'
+    Scope = 'ForestOrConfigurationSet'
+    Target = 'fabrikam'
+    Server = 'DC1'
+}
+Disable-ADOptionalFeature @params 
 ```
 
-This command disables the optional feature named Feature 1 for the forest that has the NetBIOS name fabrikam.
-This operation should be performed against the domain controller that holds the naming flexible single master operations (FSMO) role.
+This command disables the optional feature named `Feature 1` for the forest that has the NetBIOS
+name `fabrikam`. This operation should be performed against the domain controller that holds the
+domain naming master flexible single master operations (FSMO) role.
 
 ### Example 2: Disable a feature by distinguished name
-```
-PS C:\> Disable-ADOptionalFeature -Identity 'CN=Feature 1,CN=Optional Features,CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,DC=fabrikam,DC=com' -Scope ForestOrConfigurationSet -Target 'fabrikam.com' -Server DC1
+
+```powershell
+$params = @{
+    Identity = 'CN=Feature 1,CN=Optional Features,CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,DC=fabrikam,DC=com'
+    Scope = ForestOrConfigurationSet
+    Target = 'fabrikam.com'
+    Server = 'DC1'
+}
+Disable-ADOptionalFeature @params
 ```
 
-This command disables the optional feature that has the distinguished name CN=Feature 1,CN=Optional Features,CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,DC=fabrikam,DC=com, for the forest named fabrikam.com.
-This operation should be performed against the domain controller that holds the naming FSMO role.
+This command disables the optional feature that has the distinguished name
+`CN=Feature 1,CN=Optional Features,CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,DC=fabrikam,DC=com`,
+for the forest named `fabrikam.com`. This operation should be performed against the domain
+controller that holds the domain naming master FSMO role.
 
 ### Example 3: Disable a feature by GUID
-```
-PS C:\> Disable-ADOptionalFeature -Identity '54ec6e43-75a8-445b-aa7b-346a1e096659' -Scope Domain -Target 'DC=fabrikam,DC=com' -Server DC1
+
+```powershell
+$params = @{
+    Identity = '54ec6e43-75a8-445b-aa7b-346a1e096659'
+    Scope = 'Domain'
+    Target = 'DC=fabrikam,DC=com'
+    Server = 'DC1'
+}
+Disable-ADOptionalFeature @params
 ```
 
-This command disables the optional feature that has the GUID 54ec6e43-75a8-445b-aa7b-346a1e096659 for the domain with the distinguished name DC=ntdev,DC=fabrikam,DC=com.
-This operation should be performed against the domain controller that holds the naming master FSMO role.
+This command disables the optional feature that has the GUID `54ec6e43-75a8-445b-aa7b-346a1e096659`
+for the domain with the distinguished name `DC=ntdev,DC=fabrikam,DC=com`. This operation should be
+performed against the domain controller that holds the domain naming naming master FSMO role.
 
 ### Example 4: Disable a feature for an AD LDS instance
-```
-PS C:\> Disable-ADOptionalFeature -Identity 'Feature 1' -Scope ForestOrConfigurationSet -Target 'CN=Configuration,CN={0241853A-6BBF-48AA-8AE0-9C35D0C91B7B}' -Server server1:50000
+
+```powershell
+$params = @{
+    Identity = 'Feature 1'
+    Scope = 'ForestOrConfigurationSet'
+    Target = 'CN=Configuration,CN={0241853A-6BBF-48AA-8AE0-9C35D0C91B7B}'
+    Server = 'server1:50000'
+}
+Disable-ADOptionalFeature @params
 ```
 
-This command disables the optional feature Feature 1 for the Active Directory Lightweight Directory Services (AD LDS) instance that has the distinguished name CN=Configuration,CN={0241853A-6BBF-48AA-8AE0-9C35D0C91B7B}.
-This operation should be performed against the AD LDS instance that holds the naming master FSMO role.
+This command disables the optional feature `Feature 1` for the Active Directory Lightweight
+Directory Services (AD LDS) instance that has the distinguished name
+`CN=Configuration,CN={0241853A-6BBF-48AA-8AE0-9C35D0C91B7B}`. This operation should be performed
+against the AD LDS instance that holds the domain naming master FSMO role.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Type: ADAuthType
 Parameter Sets: (All)
 Aliases: 
@@ -95,10 +138,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -110,19 +154,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
+Type: System.Management.Automation.PSCredential
 Type: PSCredential
 Parameter Sets: (All)
 Aliases: 
@@ -135,21 +184,23 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory optional feature object by providing one of the following values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory optional feature object by providing one of the following values. The
+identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the
+attribute. The acceptable values for this parameter are:
 
 - FQDN
-- Feature GUID (featureGUID) 
-- Object GUID (objectGUID)
+- Feature GUID (**featureGUID**)
+- Object GUID (**objectGUID**)
 
-The cmdlet searches the default naming context or partition to find the object.
-If two or more objects are found, the cmdlet returns a non-terminating error.
+The cmdlet searches the default naming context or partition to find the object. If two or more
+objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to an optional feature object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+optional feature object instance.
 
 ```yaml
-Type: ADOptionalFeature
+Type: Microsoft.ActiveDirectory.Management.ADOptionalFeature
 Parameter Sets: (All)
 Aliases: 
 
@@ -161,11 +212,12 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+
+Returns an object representing the item with which you are working. By default, this cmdlet does not
+generate any output.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: 
 
@@ -177,14 +229,15 @@ Accept wildcard characters: False
 ```
 
 ### -Scope
-Specifies the scope at which the feature is enabled or disabled. 
-The acceptable values for this parameter are:
 
-- Domain or 0
-- Forest or 1
+Specifies the scope at which the feature is enabled or disabled. The acceptable values for this
+parameter are:
+
+- `Domain` or `0`
+- `Forest` or `1`
 
 ```yaml
-Type: ADOptionalFeatureScope
+Type: Microsoft.ActiveDirectory.Management.ADOptionalFeatureScope
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Unknown, ForestOrConfigurationSet, Domain
@@ -197,29 +250,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services (AD DS) instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways:  
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
-- FQDN
+- Fully qualified domain name
 - NetBIOS name
 
-Directory server values:  
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
+Type: System.String
 Type: String
 Parameter Sets: (All)
 Aliases: 
@@ -232,8 +291,9 @@ Accept wildcard characters: False
 ```
 
 ### -Target
-Specifies the domain or forest in which to modify the optional feature.
-You can identify the target domain or forest by providing one of the following values:
+
+Specifies the domain or forest in which to modify the optional feature. You can identify the target
+domain or forest by providing one of the following values:
 
 - FQDN of the forest or domain
 - NetBIOS name of the forest or domain
@@ -256,11 +316,11 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -272,24 +332,29 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADOptionalFeature
-An optional feature object is received by the *Identity* parameter.
+
+An optional feature object is received by the **Identity** parameter.
 
 ## OUTPUTS
 
 ### None
 
 ## NOTES
-* This cmdlet does not work with an Active Directory snapshot.
-* This cmdlet does not work with a read-only domain controller.
+
+- This cmdlet does not work with an Active Directory snapshot.
+- This cmdlet does not work with a read-only domain controller.
 
 ## RELATED LINKS
 
 [Enable-ADOptionalFeature](./Enable-ADOptionalFeature.md)
 
 [Get-ADOptionalFeature](./Get-ADOptionalFeature.md)
-

--- a/docset/winserver2022-ps/activedirectory/Disable-ADOptionalFeature.md
+++ b/docset/winserver2022-ps/activedirectory/Disable-ADOptionalFeature.md
@@ -213,7 +213,7 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you are working. By default, this cmdlet does not
+Returns an object representing the item with which you're working. By default, this cmdlet does not
 generate any output.
 
 ```yaml
@@ -317,7 +317,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -350,8 +350,8 @@ An optional feature object is received by the **Identity** parameter.
 
 ## NOTES
 
-- This cmdlet does not work with an Active Directory snapshot.
-- This cmdlet does not work with a read-only domain controller.
+- This cmdlet doesn't work with an Active Directory snapshot.
+- This cmdlet doesn't work with a read-only domain controller.
 
 ## RELATED LINKS
 

--- a/docset/winserver2022-ps/activedirectory/Enable-ADAccount.md
+++ b/docset/winserver2022-ps/activedirectory/Enable-ADAccount.md
@@ -81,7 +81,6 @@ A Secure Sockets Layer (SSL) connection is required for the `Basic` authenticati
 
 ```yaml
 Type: Microsoft.ActiveDirectory.Management.ADAuthType
-Type: ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -128,7 +127,6 @@ Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
 Type: System.Management.Automation.PSCredential
-Type: PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -209,7 +207,6 @@ In Active Directory Lightweight Directory Services (AD LDS) environments, a defa
 
 ```yaml
 Type: System.String
-Type: String
 Parameter Sets: (All)
 Aliases: 
 
@@ -267,7 +264,6 @@ they are listed:
 
 ```yaml
 Type: System.String
-Type: String
 Parameter Sets: (All)
 Aliases: 
 

--- a/docset/winserver2022-ps/activedirectory/Enable-ADAccount.md
+++ b/docset/winserver2022-ps/activedirectory/Enable-ADAccount.md
@@ -16,56 +16,71 @@ Enables an Active Directory account.
 ## SYNTAX
 
 ```
-Enable-ADAccount [-WhatIf] [-Confirm] [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADAccount> [-Partition <String>] [-PassThru] [-Server <String>] [<CommonParameters>]
+Enable-ADAccount [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
+ [-Credential <PSCredential>] [-Identity] <ADAccount> [-Partition <String>] [-PassThru]
+ [-Server <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Enable-ADAccount** cmdlet enables an Active Directory user, computer, or service account.
 
-The *Identity* parameter specifies the Active Directory user, computer, or service account that you want to enable.
-You can identify an account by its distinguished name, GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.
-You can also set the *Identity* parameter to an object variable such as `$<localADAccountObject>`, or you can pass an account object through the pipeline to the *Identity* parameter.
-For example, you can use the **Get-ADUser** cmdlet to retrieve an account object and then pass the object through the pipeline to the **Enable-ADAccount** cmdlet.
-Similarly, you can use **Get-ADComputer** and **Search-ADAccount** to retrieve account objects.
+The `Enable-ADAccount` cmdlet enables an Active Directory user, computer, or service account.
+
+The **Identity** parameter specifies the Active Directory user, computer, or service account that
+you want to enable. You can identify an account by its distinguished name, GUID, security identifier
+(SID) or Security Accounts Manager (SAM) account name. You can also set the **Identity** parameter
+to an object variable such as `$<localADAccountObject>`, or you can pass an account object through
+the pipeline to the **Identity** parameter. For example, you can use the `Get-ADUser` cmdlet to
+retrieve an account object and then pass the object through the pipeline to the `Enable-ADAccount`
+cmdlet. Similarly, you can use `Get-ADComputer` and `Search-ADAccount` to retrieve account objects.
 
 ## EXAMPLES
 
 ### Example 1: Enable an account by identity
-```
-PS C:\> Enable-ADAccount -Identity "PattiFul"
+
+```powershell
+Enable-ADAccount -Identity 'PattiFul'
 ```
 
-This command enables the account with identity SamAccountName PattiFul.
+This command enables the account with identity SamAccountName `PattiFul`.
 
 ### Example 2: Enable an account by Distinguished Name
-```
-PS C:\> Enable-ADAccount -Identity "CN=Patti Fuller,OU=Finance,OU=UserAccounts,DC=FABRIKAM,DC=COM"
+
+```powershell
+Enable-ADAccount -Identity 'CN=Patti Fuller,OU=Finance,OU=UserAccounts,DC=FABRIKAM,DC=COM'
 ```
 
-This command enables the account with DistinguishedName CN=Patti Fuller,OU=Finance,OU=UserAccounts,DC=FABRIKAM,DC=COM.
+This command enables the account with DistinguishedName
+`CN=Patti Fuller,OU=Finance,OU=UserAccounts,DC=FABRIKAM,DC=COM`.
 
 ### Example 3: Enable all accounts in an organizational unit using a filter
-```
-PS C:\> Get-ADUser -Filter 'Name -like "*"' -SearchBase "OU=Finance,OU=UserAccounts,DC=FABRIKAM,DC=COM" | Enable-ADAccount
+
+```powershell
+$params = @{
+    Filter = 'Name -like "*"'
+    SearchBase = 'OU=Finance,OU=UserAccounts,DC=FABRIKAM,DC=COM'
+}
+Get-ADUser @params | Enable-ADAccount
 ```
 
-This command enables all accounts in the organizational unit: OU=Finance,OU=UserAccounts,DC=FABRIKAM,DC=COM.
+This command enables all accounts in the organizational unit:
+`OU=Finance,OU=UserAccounts,DC=FABRIKAM,DC=COM`.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Type: ADAuthType
 Parameter Sets: (All)
 Aliases: 
@@ -79,10 +94,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -94,19 +110,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
+Type: System.Management.Automation.PSCredential
 Type: PSCredential
 Parameter Sets: (All)
 Aliases: 
@@ -119,19 +140,21 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory account object by providing one of the following property values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory account object by providing one of the following property values. The
+identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the
+attribute. The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID (objectGUID) 
-- A Security Identifier (objectSid) 
-- A SAM account name (sAMAccountName)
+- A GUID (**objectGUID**)
+- A Security Identifier (**objectSid**)
+- A SAM account name (**sAMAccountName**)
 
-The cmdlet searches the default naming context or partition to find the object.
-If two or more objects are found, the cmdlet returns a non-terminating error.
+The cmdlet searches the default naming context or partition to find the object. If two or more
+objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to an account object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+account object instance.
 
 Derived types such as the following are also accepted:
 
@@ -140,7 +163,7 @@ Derived types such as the following are also accepted:
 - **Microsoft.ActiveDirectory.Management.ADServiceAccount**
 
 ```yaml
-Type: ADAccount
+Type: Microsoft.ActiveDirectory.Management.ADAccount
 Parameter Sets: (All)
 Aliases: 
 
@@ -152,29 +175,40 @@ Accept wildcard characters: False
 ```
 
 ### -Partition
-Specifies the distinguished name of an Active Directory partition.
-The distinguished name must be one of the naming contexts on the current directory server.
-The cmdlet searches this partition to find the object defined by the *Identity* parameter.
 
-In many cases, a default value is used for the *Partition* parameter if no value is specified.
-The rules for determining the default value are given below.
-Note that rules listed first are evaluated first and once a default value can be determined, no further rules are evaluated.
+Specifies the distinguished name of an Active Directory partition. The distinguished name must be
+one of the naming contexts on the current directory server. The cmdlet searches this partition to
+find the object defined by the **Identity** parameter.
 
-In Active Directory Domain Services (AD DS) environments, a default value for *Partition* is set in the following cases: 
+In many cases, a default value is used for the **Partition** parameter if no value is specified. The
+rules for determining the default value are given below. Note that rules listed first are evaluated
+first and once a default value can be determined, no further rules are evaluated.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name.
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If none of the previous cases apply, the default value of *Partition* is set to the default partition or naming context of the target domain.
+In Active Directory Domain Services environments, a default value for **Partition** is set in the
+following cases:
 
-In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for *Partition* is set in the following cases:
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If none of the previous cases apply, the default value of **Partition** is set to the default
+  partition or naming context of the target domain.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name.
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive.
-- If the target AD LDS instance has a default naming context, the default value of *Partition* is set to the default naming context.
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent (DSA) object (**nTDSDSA**) for the AD LDS instance. 
-- If none of the previous cases apply, the *Partition* parameter will not take any default value.
+In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for
+**Partition** is set in the following cases:
+
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If the target AD LDS instance has a default naming context, the default value of **Partition** is
+  set to the default naming context. To specify a default naming context for an AD LDS environment,
+  set the **msDS-defaultNamingContext** property of the Active Directory directory service agent
+  (DSA) object (**nTDSDSA**) for the AD LDS instance.
+- If none of the previous cases apply, the **Partition** parameter will not take any default value.
 
 ```yaml
+Type: System.String
 Type: String
 Parameter Sets: (All)
 Aliases: 
@@ -187,11 +221,12 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+
+Returns an object representing the item with which you're working. By default, this cmdlet does not
+generate any output.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: 
 
@@ -203,29 +238,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways: 
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
+Type: System.String
 Type: String
 Parameter Sets: (All)
 Aliases: 
@@ -238,11 +279,11 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -254,12 +295,17 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADAccount
-An account object is received by the *Identity* parameter.
+
+An account object is received by the **Identity** parameter.
 
 Derived types, such as the following, are also accepted:
 
@@ -272,8 +318,9 @@ Derived types, such as the following, are also accepted:
 ### None
 
 ## NOTES
-* This cmdlet does not work with an Active Directory snapshot.
-* This cmdlet does not work with a read-only domain controller.
+
+- This cmdlet doesn't work with an Active Directory snapshot.
+- This cmdlet doesn't work with a read-only domain controller.
 
 ## RELATED LINKS
 
@@ -292,4 +339,3 @@ Derived types, such as the following, are also accepted:
 [Set-ADAccountPassword](./Set-ADAccountPassword.md)
 
 [Unlock-ADAccount](./Unlock-ADAccount.md)
-

--- a/docset/winserver2022-ps/activedirectory/Enable-ADOptionalFeature.md
+++ b/docset/winserver2022-ps/activedirectory/Enable-ADOptionalFeature.md
@@ -16,65 +16,83 @@ Enables an Active Directory optional feature.
 ## SYNTAX
 
 ```
-Enable-ADOptionalFeature [-WhatIf] [-Confirm] [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADOptionalFeature> [-PassThru] [-Scope] <ADOptionalFeatureScope> [-Server <String>]
- [-Target] <ADEntity> [<CommonParameters>]
+Enable-ADOptionalFeature [-WhatIf] [-Confirm] [-AuthType <ADAuthType>]
+ [-Credential <PSCredential>] [-Identity] <ADOptionalFeature> [-PassThru]
+ [-Scope] <ADOptionalFeatureScope> [-Server <String>] [-Target] <ADEntity>
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Enable-ADOptionalFeature** cmdlet enables an Active Directory optional feature that is associated with a particular domain mode or forest mode.
-Active Directory optional features that depend on a specified domain mode or forest mode must be explicitly enabled after the domain mode or forest mode is set.
 
-The *Identity* parameter specifies the Active Directory optional feature that you want to enable.
-You can identify an optional feature by its distinguished name, feature GUID, or object GUID.
-You can also set the parameter to an optional feature object variable, such as `$<localOptionalFeatureObject>` or you can pass an optional feature object through the pipeline to the *Identity* parameter.
-For example, you can use the **Get-ADOptionalFeature** cmdlet to retrieve an optional feature object and then pass the object through the pipeline to the **Enable-ADOptionalFeature** cmdlet.
+The `Enable-ADOptionalFeature` cmdlet enables an Active Directory optional feature that is
+associated with a particular domain mode or forest mode. Active Directory optional features that
+depend on a specified domain mode or forest mode must be explicitly enabled after the domain mode or
+forest mode is set.
 
-The *Scope* parameter specifies the scope at which the optional feature is enabled.
+The **Identity** parameter specifies the Active Directory optional feature that you want to enable.
+You can identify an optional feature by its distinguished name, feature GUID, or object GUID. You
+can also set the parameter to an optional feature object variable, such as
+`$<localOptionalFeatureObject>` or you can pass an optional feature object through the pipeline to
+the **Identity** parameter. For example, you can use the `Get-ADOptionalFeature` cmdlet to retrieve
+an optional feature object and then pass the object through the pipeline to the
+`Enable-ADOptionalFeature` cmdlet.
 
-The *Target* parameter specifies the domain or forest on which the optional feature is enabled.
-You can identify the domain or forest by its fully-qualified domain name (FQDN), NetBIOS name, or distinguished name of the domain naming context.
+The **Scope** parameter specifies the scope at which the optional feature is enabled.
+
+The **Target** parameter specifies the domain or forest on which the optional feature is enabled.
+You can identify the domain or forest by its fully-qualified domain name (FQDN), NetBIOS name, or
+distinguished name of the domain naming context.
 
 ## EXAMPLES
 
 ### Example 1: Enable the Recycle Bin feature for a forest
-```
-PS C:\> Enable-ADOptionalFeature -Identity 'Recycle Bin Feature' -Scope ForestOrConfigurationSet -Target 'fabrikam.com' -Server dc1
+
+```powershell
+$params = @{
+    Identity = 'Recycle Bin Feature'
+    Scope = 'ForestOrConfigurationSet'
+    Target = 'fabrikam.com'
+    Server = 'dc1'
+}
+Enable-ADOptionalFeature @params
 ```
 
-This command enables the optional feature Recycle Bin feature for the forest fabrikam.com.
-This operation must be performed on the domain controller that holds the naming flexible single master operations (FSMO) role.
+This command enables the optional feature `Recycle Bin Feature` for the forest `fabrikam.com`. This
+operation must be performed on the domain controller that holds the domain naming master flexible
+single master operations (FSMO) role.
 
 ### Example 2: Enable the Recycle bin for an AD LDS instance
-```
-PS C:\> Enable-ADOptionalFeature -Identity 'Feature 1' -Scope ForestOrConfigurationSet -Target 'CN=Configuration,CN={0241853A-6BBF-48AA-8AE0-9C35D0C91B7B}' -Server lds.fabrikam.com:50000
+
+```powershell
+$params = @{
+    Identity = 'Feature 1'
+    Scope = 'ForestOrConfigurationSet'
+    Target = 'CN=Configuration,CN={0241853A-6BBF-48AA-8AE0-9C35D0C91B7B}'
+    Server = 'lds.fabrikam.com:50000'
+}
+Enable-ADOptionalFeature @params
 ```
 
-This command enables the optional feature Recycle Bin feature for the AD LDS instance lds.fabrikam.com.
-This operation must be performed on the AD LDS instance that holds the naming FSMO role.
-
-### Example 3: Set the ForestMode on an AD LDS instance
-```
-PS C:\> Set-ADObject -Identity "CN=Partitions,CN=Configuration,CN={4F971828-5BE4-4E94-B532-58F2BFB6A3A5}" -Replace @{"msDS-Behavior-Version"=4}
-```
-
-This command sets the **ForestMode** (Forest Functional Level) to Windows2008R2Forest on an AD LDS instance.
-The **ForestMode** must be Windows2008R2Forest or later in order to enable the Recycle Bin feature for AD LDS.
+This command enables the optional feature `Feature 1` for the AD LDS instance `lds.fabrikam.com`.
+This operation must be performed on the AD LDS instance that holds the domain naming master FSMO
+role.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Type: ADAuthType
 Parameter Sets: (All)
 Aliases: 
@@ -88,10 +106,11 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
@@ -103,19 +122,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
+Type: System.Management.Automation.PSCredential
 Type: PSCredential
 Parameter Sets: (All)
 Aliases: 
@@ -128,21 +152,23 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory optional feature object by providing one of the following values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory optional feature object by providing one of the following values. The
+identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the
+attribute. The acceptable values for this parameter are:
 
 - A FQDN
-- A feature GUID (featureGUID)
-- An object GUID (objectGUID)
+- A feature GUID (**featureGUID**)
+- An object GUID (**objectGUID**)
 
-The cmdlet searches the default naming context or partition to find the object.
-If two or more objects are found, the cmdlet returns a non-terminating error.
+The cmdlet searches the default naming context or partition to find the object. If two or more
+objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to an optional feature object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+optional feature object instance.
 
 ```yaml
-Type: ADOptionalFeature
+Type: Microsoft.ActiveDirectory.Management.ADOptionalFeature
 Parameter Sets: (All)
 Aliases: 
 
@@ -154,11 +180,12 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+
+Returns an object representing the item with which you're working. By default, this cmdlet doesn't
+generate any output.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: 
 
@@ -170,14 +197,15 @@ Accept wildcard characters: False
 ```
 
 ### -Scope
-Specifies the scope at which the feature is enabled or disabled.
-The acceptable values for this parameter are:
 
-- Domain or 0
-- Forest or 1
+Specifies the scope at which the feature is enabled or disabled. The acceptable values for this
+parameter are:
+
+- `Domain` or `0`
+- `Forest` or `1`
 
 ```yaml
-Type: ADOptionalFeatureScope
+Type: Microsoft.ActiveDirectory.Management.ADOptionalFeatureScope
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Unknown, ForestOrConfigurationSet, Domain
@@ -190,29 +218,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services (AD DS) instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: Active Directory Lightweight Domain Services (AD LDS), AD DS, or Active Directory snapshot instance.
 
-Specify the AD DS instance in one of the following ways:  
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
-- FQDN
+- Fully qualified domain name
 - NetBIOS name
 
-Directory server values:  
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the AD DS Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
+Type: System.String
 Type: String
 Parameter Sets: (All)
 Aliases: 
@@ -225,18 +259,19 @@ Accept wildcard characters: False
 ```
 
 ### -Target
-Specifies the domain or forest in which to modify the optional feature.
-You can identify the target domain or forest by providing one of the following values: 
+
+Specifies the domain or forest in which to modify the optional feature. You can identify the target
+domain or forest by providing one of the following values:
 
 - FQDN of the forest or domain
 - NetBIOS name of the forest or domain
 
-You can also, where *Scope* is set to domain (not forest), use the following: 
+When **Scope** is set to `Domain`, you can use the following value:
 
 - Distinguished name of the domain naming context
 
 ```yaml
-Type: ADEntity
+Type: Microsoft.ActiveDirectory.Management.ADEntity
 Parameter Sets: (All)
 Aliases: 
 
@@ -248,11 +283,11 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
@@ -264,25 +299,34 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADOptionalFeature
-An optional feature object is received by the *Identity* parameter.
+
+An optional feature object is received by the **Identity** parameter.
 
 ## OUTPUTS
 
 ### None
 
 ## NOTES
-* This cmdlet does not work with an Active Directory snapshot.
-* This cmdlet does not work with a read-only domain controller.
-* Recycle Bin Feature: Once the Active Directory Recycle Bin is enabled, all objects deleted before the Active Directory Recycle Bin was enabled (tombstone objects) become recycled objects. They are no longer visible in the Deleted Objects container and they cannot be recovered using Active Directory Recycle Bin. The only way to restore these objects is through an authoritative restore from an AD DS backup taken before the Active Directory Recycle Bin was enabled.
+
+- This cmdlet doesn't work with an Active Directory snapshot.
+- This cmdlet doesn't work with a read-only domain controller.
+- Recycle Bin Feature: Once the Active Directory Recycle Bin is enabled, all objects deleted before
+  the Active Directory Recycle Bin was enabled (tombstone objects) become recycled objects. They are
+  no longer visible in the Deleted Objects container and they cannot be recovered using Active
+  Directory Recycle Bin. The only way to restore these objects is through an authoritative restore
+  from an AD DS backup taken before the Active Directory Recycle Bin was enabled.
 
 ## RELATED LINKS
 
 [Disable-ADOptionalFeature](./Disable-ADOptionalFeature.md)
 
 [Get-ADOptionalFeature](./Get-ADOptionalFeature.md)
-

--- a/docset/winserver2022-ps/activedirectory/Enable-ADOptionalFeature.md
+++ b/docset/winserver2022-ps/activedirectory/Enable-ADOptionalFeature.md
@@ -93,7 +93,6 @@ A Secure Sockets Layer (SSL) connection is required for the `Basic` authenticati
 
 ```yaml
 Type: Microsoft.ActiveDirectory.Management.ADAuthType
-Type: ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -140,7 +139,6 @@ Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
 Type: System.Management.Automation.PSCredential
-Type: PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -247,7 +245,6 @@ they are listed:
 
 ```yaml
 Type: System.String
-Type: String
 Parameter Sets: (All)
 Aliases: 
 

--- a/docset/winserver2022-ps/activedirectory/Get-ADAccountAuthorizationGroup.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADAccountAuthorizationGroup.md
@@ -16,25 +16,34 @@ Gets the accounts token group information.
 ## SYNTAX
 
 ```
-Get-ADAccountAuthorizationGroup [-AuthType <ADAuthType>] [-Credential <PSCredential>] [-Identity] <ADAccount>
- [-Partition <String>] [-Server <String>] [<CommonParameters>]
+Get-ADAccountAuthorizationGroup [-AuthType <ADAuthType>] [-Credential <PSCredential>]
+ [-Identity] <ADAccount> [-Partition <String>] [-Server <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-ADAccountAuthorizationGroup** cmdlet gets the security groups from the specified user, computer, or service accounts token.
-This cmdlet requires a global catalog to perform the group search.
-If the forest that contains the account does not have a global catalog, the cmdlet returns a non-terminating error.
 
-The *Identity* parameter specifies the user, computer, or service account.
-You can identify a user, computer, or service account object by its distinguished name, GUID, security identifier (SID), Security Account Manager (SAM) account name or user principal name.
-You can also set the *Identity* parameter to an account object variable, such as `$<localAccountObject>`, or pass an account object through the pipeline to the *Identity* parameter.
-For example, you can use the Get-ADUser, Get-ADComputer, Get-ADServiceAccount or Search-ADAccount cmdlets to retrieve an account object and then pass the object through the pipeline to the Get-ADAccountAuthorizationGroup cmdlet.
+The `Get-ADAccountAuthorizationGroup` cmdlet gets the security groups from the specified user,
+computer, or service accounts token. This cmdlet requires a global catalog to perform the group
+search. If the forest that contains the account doesn't have a global catalog, the cmdlet returns a
+non-terminating error.
+
+The **Identity** parameter specifies the user, computer, or service account. You can identify a
+user, computer, or service account object by its distinguished name, GUID, security identifier
+(SID), Security Account Manager (SAM) account name or user principal name. You can also set the
+**Identity** parameter to an account object variable, such as `$<localAccountObject>`, or pass an
+account object through the pipeline to the **Identity** parameter. For example, you can use the
+`Get-ADUser`, `Get-ADComputer`, `Get-ADServiceAccount` or `Search-ADAccount` cmdlets to retrieve an account
+object and then pass the object through the pipeline to the `Get-ADAccountAuthorizationGroup` cmdlet.
 
 ## EXAMPLES
 
 ### Example 1: Get all security groups for a specified account
+
+```powershell
+Get-ADAccountAuthorizationGroup -Identity DavidCh
 ```
-PS C:\> Get-ADAccountAuthorizationGroup -Identity DavidCh
+
+```output
 GroupScope        : DomainLocal
 objectGUID        : 00000000-0000-0000-0000-000000000000
 GroupCategory     : Security
@@ -75,11 +84,16 @@ SID               : S-1-5-32-545
 distinguishedName : CN=Users,CN=Builtin,DC=Fabrikam,DC=com
 ```
 
-This command returns all security groups for the specified account with SamAccountName DavidCh.
+This command returns all security groups for the specified account with **SamAccountName**
+`DavidCh`.
 
 ### Example 2: Get all security groups for a specified account using a distinguished name
+
+```powershell
+Get-ADAccountAuthorizationGroup -Identity "CN=DavidCh,DC=AppNC" -Server "<Server>:50000"
 ```
-PS C:\> Get-ADAccountAuthorizationGroup -Identity "CN=DavidCh,DC=AppNC" -Server "<Server>:50000"
+
+```output
 distinguishedName : CN=AdminGroup,DC=AppNC
 GroupCategory     : Security
 GroupScope        : Global
@@ -89,11 +103,18 @@ objectGUID        : 4d72873f-fe09-4834-9ada-a905636d10df
 SamAccountName    : SID               : S-1-510474493-936115905-4021890855-1253703389-3958791574-3542197427
 ```
 
-This command returns all security groups for the specified account with DistinguishedName cn=DavidCh,dc=AppNC in the AD LDS instance \<Server\>:50000.
+This command returns all security groups for the specified account with **DistinguishedName**
+`CN=DavidCh,DC=AppNC` in the AD LDS instance `<Server>:50000`.
 
 ### Example 3: Get a filtered list of security groups
+
+```powershell
+Get-ADAccountAuthorizationGroup -Server "<Server>:50000" -Identity Administrator |
+    Where-Object { $_.objectClass -ne $null } |
+    Select-Object name, objectClass
 ```
-PS C:\> Get-ADAccountAuthorizationGroup -Server "<Server>:50000" -Identity Administrator | where { $_.objectClass -ne $null } | ft name, objectClass
+
+```output
 name                                                        objectClass
 ----                                                        -----------
 Domain Users                                                group
@@ -107,23 +128,29 @@ Schema Admins                                               group
 Denied RODC Password Replication Group                      group
 ```
 
-This command returns a filtered list of built-in security groups that do not have an empty or null setting for objectclass, such as Everyone or Authenticated Users.
-Note: This type of filtering of groups in output can be useful when piping the output of this cmdlet to be used as input to other Active Directory cmdlets.
+This command returns a filtered list of built-in security groups that do not have an empty or null
+setting for **objectClass**, such as **Everyone** or **Authenticated Users**.
+
+> [!NOTE]:
+> This type of filtering of groups in output can be useful when piping the output of this
+> cmdlet to be used as input to other Active Directory cmdlets.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Type: ADAuthType
 Parameter Sets: (All)
 Aliases: 
@@ -137,19 +164,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
+Type: System.Management.Automation.PSCredential
 Type: PSCredential
 Parameter Sets: (All)
 Aliases: 
@@ -162,28 +194,30 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory account object by providing one of the following property values.
-The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory account object by providing one of the following property values. The
+identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the
+attribute. The acceptable values for this parameter are:
 
 - A distinguished name
-- A GUID (objectGUID) 
-- A Security Identifier (objectSid) 
-- A SAM Account Name (SAMAccountName)
+- A GUID (**objectGUID**)
+- A Security Identifier (**objectSid**)
+- A SAM Account Name (**SAMAccountName**)
 
-The cmdlet searches the default naming context or partition to find the object.
-If two or more objects are found, the cmdlet returns a non-terminating error.
+The cmdlet searches the default naming context or partition to find the object. If two or more
+objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to an account object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+account object instance.
 
-Derived types such as the following are also accepted: 
+Derived types such as the following are also accepted:
 
 - **Microsoft.ActiveDirectory.Management.ADServiceAccount**
 - **Microsoft.ActiveDirectory.Management.ADComputer**
 - **Microsoft.ActiveDirectory.Management.ADUser**
 
 ```yaml
-Type: ADAccount
+Type: Microsoft.ActiveDirectory.Management.ADAccount
 Parameter Sets: (All)
 Aliases: 
 
@@ -195,29 +229,40 @@ Accept wildcard characters: False
 ```
 
 ### -Partition
-Specifies the distinguished name of an Active Directory partition.
-The distinguished name must be one of the naming contexts on the current directory server.
-The cmdlet searches this partition to find the object defined by the *Identity* parameter.
 
-In many cases, a default value is used for the *Partition* parameter if no value is specified.
-The rules for determining the default value are given below.
-Note that rules listed first are evaluated first and once a default value can be determined, no further rules are evaluated.
+Specifies the distinguished name of an Active Directory partition. The distinguished name must be
+one of the naming contexts on the current directory server. The cmdlet searches this partition to
+find the object defined by the **Identity** parameter.
 
-In Active Directory Domain Services (AD DS) environments, a default value for *Partition* is set in the following cases: 
+In many cases, a default value is used for the **Partition** parameter if no value is specified. The
+rules for determining the default value are given below. Note that rules listed first are evaluated
+first and once a default value can be determined, no further rules are evaluated.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name.
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If none of the previous cases apply, the default value of *Partition* is set to the default partition or naming context of the target domain.
+In Active Directory Domain Services environments, a default value for **Partition** is set in the
+following cases:
 
-In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for *Partition* is set in the following cases: 
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If none of the previous cases apply, the default value of **Partition** is set to the default
+  partition or naming context of the target domain.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name. 
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If the target AD LDS instance has a default naming context, the default value of *Partition* is set to the default naming context.
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent object (**nTDSDSA**) for the AD LDS instance. 
-- If none of the previous cases apply, the *Partition* parameter will not take any default value.
+In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for
+**Partition** is set in the following cases:
+
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If the target AD LDS instance has a default naming context, the default value of **Partition** is
+  set to the default naming context. To specify a default naming context for an AD LDS environment,
+  set the **msDS-defaultNamingContext** property of the Active Directory directory service agent
+  (DSA) object (**nTDSDSA**) for the AD LDS instance.
+- If none of the previous cases apply, the **Partition** parameter will not take any default value.
 
 ```yaml
+Type: System.String
 Type: String
 Parameter Sets: (All)
 Aliases: 
@@ -230,29 +275,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways: 
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
-- By using the *Server* value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the **Server** value from objects passed through the pipeline
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
+Type: System.String
 Type: String
 Parameter Sets: (All)
 Aliases: 
@@ -265,13 +316,18 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADAccount
-An account object that represents the user, computer or service account is received by the *Identity* parameter.
-Derived types, such as the following are also accepted:
+
+An account object that represents the user, computer or service account is received by the
+**Identity** parameter. Derived types, such as the following are also accepted:
 
 - **Microsoft.ActiveDirectory.Management.ADUser**
 - **Microsoft.ActiveDirectory.Management.ADComputer**
@@ -280,10 +336,12 @@ Derived types, such as the following are also accepted:
 ## OUTPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADGroup
+
 Returns group objects that represent the security groups for the account.
 
 ## NOTES
-* This cmdlet does not work with an Active Directory snapshot.
+
+- This cmdlet doesn't work with an Active Directory snapshot.
 
 ## RELATED LINKS
 
@@ -296,4 +354,3 @@ Returns group objects that represent the security groups for the account.
 [Search-ADAccount](./Search-ADAccount.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
-

--- a/docset/winserver2022-ps/activedirectory/Get-ADAccountAuthorizationGroup.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADAccountAuthorizationGroup.md
@@ -133,7 +133,7 @@ Denied RODC Password Replication Group                      group
 This command returns a filtered list of built-in security groups that do not have an empty or null
 setting for **objectClass**, such as **Everyone** or **Authenticated Users**.
 
-> [!NOTE]:
+> [!NOTE]
 > This type of filtering of groups in output can be useful when piping the output of this
 > cmdlet to be used as input to other Active Directory cmdlets.
 

--- a/docset/winserver2022-ps/activedirectory/Get-ADAccountAuthorizationGroup.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADAccountAuthorizationGroup.md
@@ -153,7 +153,6 @@ A Secure Sockets Layer (SSL) connection is required for the `Basic` authenticati
 
 ```yaml
 Type: Microsoft.ActiveDirectory.Management.ADAuthType
-Type: ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -184,7 +183,6 @@ Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
 Type: System.Management.Automation.PSCredential
-Type: PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -265,7 +263,6 @@ In Active Directory Lightweight Directory Services (AD LDS) environments, a defa
 
 ```yaml
 Type: System.String
-Type: String
 Parameter Sets: (All)
 Aliases: 
 
@@ -306,7 +303,6 @@ they are listed:
 
 ```yaml
 Type: System.String
-Type: String
 Parameter Sets: (All)
 Aliases: 
 

--- a/docset/winserver2022-ps/activedirectory/Get-ADAccountAuthorizationGroup.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADAccountAuthorizationGroup.md
@@ -32,8 +32,9 @@ user, computer, or service account object by its distinguished name, GUID, secur
 (SID), Security Account Manager (SAM) account name or user principal name. You can also set the
 **Identity** parameter to an account object variable, such as `$<localAccountObject>`, or pass an
 account object through the pipeline to the **Identity** parameter. For example, you can use the
-`Get-ADUser`, `Get-ADComputer`, `Get-ADServiceAccount` or `Search-ADAccount` cmdlets to retrieve an account
-object and then pass the object through the pipeline to the `Get-ADAccountAuthorizationGroup` cmdlet.
+`Get-ADUser`, `Get-ADComputer`, `Get-ADServiceAccount` or `Search-ADAccount` cmdlets to retrieve an
+account object and then pass the object through the pipeline to the
+`Get-ADAccountAuthorizationGroup` cmdlet.
 
 ## EXAMPLES
 
@@ -100,7 +101,8 @@ GroupScope        : Global
 name              : AdminGroup
 objectClass       : group
 objectGUID        : 4d72873f-fe09-4834-9ada-a905636d10df
-SamAccountName    : SID               : S-1-510474493-936115905-4021890855-1253703389-3958791574-3542197427
+SamAccountName    : AdminGroup
+SID               : S-1-510474493-936115905-4021890855-1253703389-3958791574-3542197427
 ```
 
 This command returns all security groups for the specified account with **DistinguishedName**

--- a/docset/winserver2022-ps/activedirectory/Get-ADAccountResultantPasswordReplicationPolicy.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADAccountResultantPasswordReplicationPolicy.md
@@ -16,62 +16,80 @@ Gets the resultant password replication policy for an Active Directory account.
 ## SYNTAX
 
 ```
-Get-ADAccountResultantPasswordReplicationPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-DomainController] <ADDomainController> [-Identity] <ADAccount> [-Partition <String>] [-Server <String>]
- [<CommonParameters>]
+Get-ADAccountResultantPasswordReplicationPolicy [-AuthType <ADAuthType>]
+ [-Credential <PSCredential>] [-DomainController] <ADDomainController>
+ [-Identity] <ADAccount> [-Partition <String>] [-Server <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-ADAccountResultantPasswordReplicationPolicy** cmdlet gets the resultant password replication policy for a user, computer, or service account on the specified read-only domain controller.
+
+The `Get-ADAccountResultantPasswordReplicationPolicy` cmdlet gets the resultant password replication
+policy for a user, computer, or service account on the specified read-only domain controller.
 
 The policy is one of the following values:
 
-- Allow or 1
-- DenyExplicit or 0
-- DenyImplicit or 2
-- Unknown or -1
+- `Allow` or `1`
+- `DenyExplicit` or `0`
+- `DenyImplicit` or `2`
+- `Unknown` or `-1`
 
-The *Identity* parameter specifies the account.
-You can identify a user, computer, or service account object by its distinguished name, GUID, security identifier (SID), or Security Account Manager (SAM) account name.
-You can also set the *Identity* parameter to an account object variable, such as `$<localAccountObject>`, or pass an account object through the pipeline to the *Identity* parameter.
-For example, you can use the Get-ADUser, Get-ADComputer, Get-ADServiceAccount, or Search-ADAccount cmdlets to retrieve an account object and then pass the object through the pipeline to the Get-ADAccountResultantPasswordReplicationPolicy cmdlet.
+The **Identity** parameter specifies the account. You can identify a user, computer, or service
+account object by its distinguished name, GUID, security identifier (SID), or Security Account
+Manager (SAM) account name. You can also set the **Identity** parameter to an account object
+variable, such as `$<localAccountObject>`, or pass an account object through the pipeline to the
+**Identity** parameter. For example, you can use the `Get-ADUser`, `Get-ADComputer`,
+`Get-ADServiceAccount`, or `Search-ADAccount` cmdlets to retrieve an account object and then pass
+the object through the pipeline to the `Get-ADAccountResultantPasswordReplicationPolicy` cmdlet.
 
-The **DomainController** parameter specifies the read-only domain controller.
-You can identify a domain controller by its IPV4Address, global IPV6Address, or DNS host name.
-You can also identify a domain controller by the distinguished name of the NT Directory Services (NTDS) settings object or the server object, the GUID of the NTDS settings object or the server object under the configuration partition, or the distinguished name, SamAccountName, GUID, SID of the computer object that represents the domain controller.
-You can also set the *DomainController* parameter to a domain controller object variable, such as `$<localDomainControllerObject>`.
+The **DomainController** parameter specifies the read-only domain controller. You can identify a
+domain controller by its IPV4Address, global IPV6Address, or DNS host name. You can also identify a
+domain controller by the distinguished name of the NT Directory Services (NTDS) settings object or
+the server object, the GUID of the NTDS settings object or the server object under the configuration
+partition, or the distinguished name, **SamAccountName**, GUID, SID of the computer object that
+represents the domain controller. You can also set the **DomainController** parameter to a domain
+controller object variable, such as `$<localDomainControllerObject>`.
 
 ## EXAMPLES
 
 ### Example 1: Get the password replication policy for a specified user
-```
-PS C:\> Get-ADAccountResultantPasswordReplicationPolicy -Identity DavidChe -DomainController "DOMAIN01"
+
+```powershell
+ Get-ADAccountResultantPasswordReplicationPolicy -Identity DavidChe -DomainController DC1
 ```
 
-This command gets the password replication policy on the domain specified by the **DomainController** parameter for the user account specified by the *Identity* parameter.
+This command gets the password replication policy on the domain specified by the
+**DomainController** parameter for the user account specified by the **Identity** parameter.
 
 ### Example 2: Get the password replication policy for a specified user using a distinguished name
-```
-PS C:\> Get-ADAccountResultantPasswordReplicationPolicy -Identity "CN=Elisa Daugherty,OU=Europe,OU=Sales,OU=UserAccounts,DC=FABRIKAM,DC=COM" -DomainController "DOMAIN01"
+
+```powershell
+params = @{
+    Identity = 'CN=Elisa Daugherty,OU=Europe,OU=Sales,OU=UserAccounts,DC=FABRIKAM,DC=COM'
+    DomainController = 'DC1'
+}
+ Get-ADAccountResultantPasswordReplicationPolicy @params
 ```
 
-This command gets the password replication policy on the domain controller specified by the *DomainController* parameter for the user account distinguished name specified by the *Identity* parameter.
+This command gets the password replication policy on the domain controller specified by the
+**DomainController** parameter for the user account distinguished name specified by the **Identity**
+parameter.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -84,20 +102,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -109,25 +131,28 @@ Accept wildcard characters: False
 ```
 
 ### -DomainController
-Specifies a read-only domain controller (RODC).
-The cmdlet returns the password replication policy of the account for this RODC.
-You can identify the domain controller by providing one of the following values:
 
-- GUID (objectGUID) 
+Specifies a read-only domain controller (RODC). The cmdlet returns the password replication policy
+of the account for this RODC. You can identify the domain controller by providing one of the
+following values:
+
+- GUID (**objectGUID**)
 - IPV4Address
 - Global IPV6Address
-- DNS Host Name (dNSHostName) 
+- DNS Host Name (**dNSHostName**)
 - Name of the server object
 - A distinguished name of the NTDS Settings object
-- A distinguished name  of the server object that represents the domain controller
+- A distinguished name of the server object that represents the domain controller
 - GUID of NTDS settings object under the configuration partition
 - GUID of server object under the configuration partition
 - A distinguished Name of the computer object that represents the domain controller
 
-Note: The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for the attribute.
+> [!NOTE]
+> The identifier in parentheses is the Lightweight Directory Access Protocol (LDAP) display name for
+> the attribute.
 
 ```yaml
-Type: ADDomainController
+Type: Microsoft.ActiveDirectory.Management.ADDomainController
 Parameter Sets: (All)
 Aliases: 
 
@@ -139,19 +164,21 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory account object by providing one of the following property values.
-The identifier in parentheses is the LDAP display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory account object by providing one of the following property values. The
+identifier in parentheses is the LDAP display name for the attribute. The acceptable values for this
+parameter are:
 
 - A distinguished name
-- A GUID (objectGUID) 
-- A security identifier (objectSid) 
-- A SAM account name (sAMAccountName)
+- A GUID (**objectGUID**)
+- A security identifier (**objectSid**)
+- A SAM account name (**sAMAccountName**)
 
 The cmdlet searches the default naming context or partition to find the object.
 If two or more objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to an account object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+account object instance.
 
 Derived types such as the following are also accepted:
 
@@ -160,7 +187,7 @@ Derived types such as the following are also accepted:
 - **Microsoft.ActiveDirectory.Management.ADServiceAccount**
 
 ```yaml
-Type: ADAccount
+Type: Microsoft.ActiveDirectory.Management.ADAccount
 Parameter Sets: (All)
 Aliases: 
 
@@ -172,30 +199,40 @@ Accept wildcard characters: False
 ```
 
 ### -Partition
-Specifies the distinguished name of an Active Directory partition.
-The distinguished name must be one of the naming contexts on the current directory server.
-The cmdlet searches this partition to find the object defined by the *Identity* parameter.
 
-In many cases, a default value is used for the *Partition* parameter if no value is specified. 
-The rules for determining the default value are given below. 
-Note that rules listed first are evaluated first and once a default value can be determined, no further rules are evaluated.
+Specifies the distinguished name of an Active Directory partition. The distinguished name must be
+one of the naming contexts on the current directory server. The cmdlet searches this partition to
+find the object defined by the **Identity** parameter.
 
-In Active Directory Domain Services environments, a default value for *Partition* is set in the following cases: 
+In many cases, a default value is used for the **Partition** parameter if no value is specified. The
+rules for determining the default value are given below. Note that rules listed first are evaluated
+first and once a default value can be determined, no further rules are evaluated.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of *Partition* is automatically generated from this distinguished name. 
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If none of the previous cases apply, the default value of *Partition* is set to the default partition or naming context of the target domain.
+In Active Directory Domain Services environments, a default value for **Partition** is set in the
+following cases:
 
-In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for *Partition* is set in the following cases:
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If none of the previous cases apply, the default value of **Partition** is set to the default
+  partition or naming context of the target domain.
 
-- If the *Identity* parameter is set to a distinguished name, the default value of  is automatically generated from this distinguished name. 
-- If running cmdlets from an Active Directory provider drive, the default value of *Partition* is automatically generated from the current path in the drive. 
-- If the target AD LDS instance has a default naming context, the default value of *Partition* is set to the default naming context.
-To specify a default naming context for an AD LDS environment, set the **msDS-defaultNamingContext** property of the Active Directory directory service agent object (**nTDSDSA**) for the AD LDS instance. 
-- If none of the previous cases apply, the *Partition* parameter will not take any default value.
+In Active Directory Lightweight Directory Services (AD LDS) environments, a default value for
+**Partition** is set in the following cases:
+
+- If the **Identity** parameter is set to a distinguished name, the default value of **Partition**
+  is automatically generated from this distinguished name.
+- If running cmdlets from an Active Directory provider drive, the default value of **Partition** is
+  automatically generated from the current path in the drive.
+- If the target AD LDS instance has a default naming context, the default value of **Partition** is
+  set to the default naming context. To specify a default naming context for an AD LDS environment,
+  set the `msDS-defaultNamingContext` property of the Active Directory directory service agent
+  (DSA) object (**nTDSDSA**) for the AD LDS instance.
+- If none of the previous cases apply, the **Partition** parameter will not take any default value.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -207,12 +244,17 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following:  Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
+
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
-- Fully qualified domain name (FQDN)
+- Fully qualified domain name
 - NetBIOS name
 
 Directory server values:
@@ -221,14 +263,16 @@ Directory server values:
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for the *Server* parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
-- By using Server value from objects passed through the pipeline. 
-- By using the server information associated with the Active Directory module for Windows PowerShell provider drive, when running under that drive. 
-- By using the domain of the computer running Windows PowerShell.
+- By using the **Server** value from objects passed through the pipeline
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
+- By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -245,7 +289,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADAccount
-An account object is received by the *Identity* parameter.
+An account object is received by the **Identity** parameter.
 
 Derived types, such as the following are also accepted:
 
@@ -259,8 +303,8 @@ Derived types, such as the following are also accepted:
 This cmdlet returns an **ADResultantPasswordReplicationPolicy** enum value that represents the resultant password replication policy for an account on the specified domain controller.
 
 ## NOTES
-* This cmdlet does not work with AD LDS.
-* This cmdlet does not work with an Active Directory snapshot.
+* This cmdlet doesn't work with AD LDS.
+* This cmdlet doesn't work with an Active Directory snapshot.
 
 ## RELATED LINKS
 
@@ -273,4 +317,5 @@ This cmdlet returns an **ADResultantPasswordReplicationPolicy** enum value that 
 [Search-ADAccount](./Search-ADAccount.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
+
 

--- a/docset/winserver2022-ps/activedirectory/Get-ADAccountResultantPasswordReplicationPolicy.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADAccountResultantPasswordReplicationPolicy.md
@@ -284,11 +284,16 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADAccount
+
 An account object is received by the **Identity** parameter.
 
 Derived types, such as the following are also accepted:
@@ -300,11 +305,14 @@ Derived types, such as the following are also accepted:
 ## OUTPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADResultantPasswordReplicationPolicy
-This cmdlet returns an **ADResultantPasswordReplicationPolicy** enum value that represents the resultant password replication policy for an account on the specified domain controller.
+
+This cmdlet returns an **ADResultantPasswordReplicationPolicy** enum value that represents the
+resultant password replication policy for an account on the specified domain controller.
 
 ## NOTES
-* This cmdlet doesn't work with AD LDS.
-* This cmdlet doesn't work with an Active Directory snapshot.
+
+- This cmdlet doesn't work with AD LDS.
+- This cmdlet doesn't work with an Active Directory snapshot.
 
 ## RELATED LINKS
 
@@ -317,5 +325,3 @@ This cmdlet returns an **ADResultantPasswordReplicationPolicy** enum value that 
 [Search-ADAccount](./Search-ADAccount.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
-
-

--- a/docset/winserver2022-ps/activedirectory/Get-ADAuthenticationPolicy.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADAuthenticationPolicy.md
@@ -280,7 +280,7 @@ Specifies the number of objects to include in one page for an Active Directory D
 query. The default value is `256` objects per page.
 
 ```yaml
-Type: Int32
+Type: System.Int32
 Parameter Sets: Filter, LdapFilter
 Aliases: 
 
@@ -300,7 +300,7 @@ query and the return of objects.
 The default value is `$null`.
 
 ```yaml
-Type: Int32
+Type: System.Int32
 Parameter Sets: Filter, LdapFilter
 Aliases: 
 

--- a/docset/winserver2022-ps/activedirectory/Get-ADAuthenticationPolicy.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADAuthenticationPolicy.md
@@ -16,94 +16,118 @@ Gets one or more Active Directory Domain Services authentication policies.
 ## SYNTAX
 
 ### Filter (Default)
+
 ```
-Get-ADAuthenticationPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>] -Filter <String>
- [-Properties <String[]>] [-ResultPageSize <Int32>] [-ResultSetSize <Int32>] [-Server <String>]
- [<CommonParameters>]
+Get-ADAuthenticationPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>]
+ -Filter <String> [-Properties <String[]>] [-ResultPageSize <Int32>]
+ [-ResultSetSize <Int32>] [-Server <String>] [<CommonParameters>]
 ```
 
 ### Identity
+
 ```
 Get-ADAuthenticationPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADAuthenticationPolicy> [-Properties <String[]>] [-Server <String>] [<CommonParameters>]
-```
-
-### LdapFilter
-```
-Get-ADAuthenticationPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>] -LDAPFilter <String>
- [-Properties <String[]>] [-ResultPageSize <Int32>] [-ResultSetSize <Int32>] [-Server <String>]
+ [-Identity] <ADAuthenticationPolicy> [-Properties <String[]>] [-Server <String>]
  [<CommonParameters>]
 ```
 
+### LdapFilter
+
+```
+Get-ADAuthenticationPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>]
+ -LDAPFilter <String> [-Properties <String[]>] [-ResultPageSize <Int32>]
+ [-ResultSetSize <Int32>] [-Server <String>] [<CommonParameters>]
+```
+
 ## DESCRIPTION
-The **Get-ADAuthenticationPolicy** cmdlet gets an authentication policy or performs a search to get authentication policies.
 
-The *Identity* parameter specifies the Active Directory Domain Services authentication policy to get.
-You can identify an authentication policy by its distinguished name, GUID or name.
-You can also use the *Identity* parameter to specify a variable that contains an authentication policy object, or you can use the pipeline operator to pass an authentication policy object to the *Identity* parameter.
+The `Get-ADAuthenticationPolicy` cmdlet gets an authentication policy or performs a search to get
+authentication policies.
 
-You can search for and use multiple authentication policies by specifying the *Filter* parameter or the *LDAPFilter* parameter.
-The *Filter* parameter uses the Windows PowerShell® expression language to write query strings for Active Directory Domain Services.
-Windows PowerShell expression language syntax provides rich type conversion support for value types received by the *Filter* parameter.
-For more information about the *Filter* parameter syntax, type `Get-Help  about_ActiveDirectory_Filter`.
-If you have existing Lightweight Directory Access Protocol (LDAP) query strings, you can use the *LDAPFilter* parameter.
+The **Identity** parameter specifies the Active Directory Domain Services authentication policy to
+get. You can identify an authentication policy by its distinguished name, GUID or name. You can also
+use the **Identity** parameter to specify a variable that contains an authentication policy object,
+or you can use the pipeline operator to pass an authentication policy object to the **Identity**
+parameter.
+
+You can search for and use multiple authentication policies by specifying the **Filter** parameter
+or the **LDAPFilter** parameter. The **Filter** parameter uses the Windows PowerShell expression
+language to write query strings for Active Directory Domain Services. Windows PowerShell expression
+language syntax provides rich type conversion support for value types received by the **Filter**
+parameter. For more information about the **Filter** parameter syntax, type
+`Get-Help  about_ActiveDirectory_Filter`. If you have existing Lightweight Directory Access Protocol
+(LDAP) query strings, you can use the **LDAPFilter** parameter.
 
 ## EXAMPLES
 
 ### Example 1: Get an authentication policy
-```
-PS C:\> Get-ADAuthenticationPolicy -Identity AuthenticationPolicy01
+
+```powershell
+Get-ADAuthenticationPolicy -Identity AuthenticationPolicy01
 ```
 
 This command gets an authentication policy object by specifying the object name.
 
 ### Example 2: Get an authentication policy by using an LDAP filter
-```
-PS C:\> Get-ADAuthenticationPolicy -LDAPFilter "(name=AuthenticationPolicy*)" -Server Server01.Contoso.com
+
+```powershell
+Get-ADAuthenticationPolicy -LDAPFilter "(name=AuthenticationPolicy*)" -Server Server01
 ```
 
-This command gets all authentication policies that match the LDAP filter specified by the *LDAPFilter* parameter.
+This command gets all authentication policies that match the LDAP filter specified by the
+**LDAPFilter** parameter.
 
 ### Example 3: Get an authentication policy by using a filter
-```
-PS C:\> Get-ADAuthenticationPolicy -Filter "Name -like 'AuthenticationPolicy*'" -Server Server02.Contoso.com
+
+```powershell
+Get-ADAuthenticationPolicy -Filter "Name -like 'AuthenticationPolicy*'" -Server Server02
 ```
 
-This command gets all authentication policies that match the filter specified by the *Filter* parameter.
+This command gets all authentication policies that match the filter specified by the **Filter**
+parameter.
 
 ### Example 4: Get all authentication policy objects that match a filter
+
+```powershell
+Get-ADAuthenticationPolicy -Filter * | Format-Table Name, Enforce -AutoSize
 ```
-PS C:\> Get-ADAuthenticationPolicy -Filter * | Format-Table Name, Enforce -AutoSize
+
+```output
 Name                   Enforce
 ----                   -------
 AuthenticationPolicy1   False
 AuthenticationPolicy2   False
 ```
 
-This command gets all the authentication policies available.
-The output is then passed to the Format-Table cmdlet to display the name of the policy and the value for **Enforce** on each policy.
+This command gets all the authentication policies available. The output is then passed to the
+`Format-Table` cmdlet to display the name of the policy and the value for **Enforce** on each
+policy.
 
 ### Example 5: Get all properties for an authentication policy
-```
-PS C:\> Get-ADAuthenticationPolicy -Identity "AuthenticationPolicy01" -Properties "*"
+
+```powershell
+Get-ADAuthenticationPolicy -Identity "AuthenticationPolicy01" -Properties "*"
 ```
 
-This command gets all properties of the authentication policy specified by the *Identity* parameter.
+This command gets all properties of the authentication policy specified by the **Identity**
+parameter.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+The default authentication method is `Negotiate`.
+
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -116,17 +140,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies a user account that has permission to perform the task.
-The default is the current user.
-Type a user name, such as User01 or Domain01\User01, or enter a **PSCredential** object, such as one generated by the **Get-Credential** cmdlet.
 
-By default, the cmdlet uses the credentials of the currently logged on user unless the cmdlet is run from an Active Directory Domain Services Windows PowerShell provider drive.
-If you run the cmdlet in a provider drive, the account associated with the drive is the default.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-If you specify credentials that do not have permission to perform the task, the cmdlet returns an error.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
+
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -138,32 +169,36 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
-Specifies a query string that retrieves Active Directory Domain Services objects.
-This string uses the Windows PowerShell expression language syntax.
-The Windows PowerShell expression language syntax provides rich type-conversion support for value types received by the *Filter* parameter.
 
-Specify the Filter parameter in one of the following formats: 
+Specifies a query string that retrieves Active Directory Domain Services objects. This string uses
+the Windows PowerShell expression language syntax. The Windows PowerShell expression language syntax
+provides rich type-conversion support for value types received by the **Filter** parameter.
 
-- To match a single filter element: {Attributeoperator  "value"} 
-- To match multiple filter elements: {(Attribute1operator1 "value1") joinOperator (Attribute2operator2 "value2")}
+Specify the **Filter** parameter in one of the following formats:
 
-Windows PowerShell wildcards other than "*", such as "?" are not supported by the Filter syntax.
+- To match a single filter element: `{Attribute operator "value"}`
+- To match multiple filter elements:
+  `{(Attribute1 operator1 "value1") joinOperator (Attribute2 operator2 "value2")}`
 
-Valid filter operators are: 
+Windows PowerShell wildcards other than `*`, such as `?`, are not supported by the **Filter**
+syntax.
 
- -eq, -le, -ge, -ne, -lt, -gt, -approx, -bor, -band, -recursivematch, -like, -notlike
+Valid filter operators are:
 
-Valid join operators are: 
+ `-eq`, `-le`, `-ge`, `-ne`, `-lt`, `-gt`, `-approx`, `-bor`, `-band`, `-recursivematch`, `-like`,
+ `-notlike`
 
--and, -or
+Valid join operators are:
 
-The not operator is -not
+`-and`, `-or`
 
-For a list of supported types for values, see about_ActiveDirectory_ObjectModel.
-For more information about the Filter parameter, see about_ActiveDirectory_Filter.
+The not operator is `-not`.
+
+For a list of supported types for values, see `about_ActiveDirectory_ObjectModel`. For more
+information about the **Filter** parameter, see `about_ActiveDirectory_Filter`.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: Filter
 Aliases: 
 
@@ -175,20 +210,22 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory Domain Services authentication policy object.
-Specify the authentication policy object in one of the following formats: 
+
+Specifies an Active Directory Domain Services authentication policy object. Specify the
+authentication policy object in one of the following formats:
 
 - A distinguished name
 - GUID
 - Name
 
-This parameter can also get this object through the pipeline or you can set this parameter to an object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+object instance.
 
-The cmdlet searches the default naming context or partition to find the object.
-If the cmdlet finds two or more objects, the cmdlet returns a non-terminating error.
+The cmdlet searches the default naming context or partition to find the object. If the cmdlet finds
+two or more objects, the cmdlet returns a non-terminating error.
 
 ```yaml
-Type: ADAuthenticationPolicy
+Type: Microsoft.ActiveDirectory.Management.ADAuthenticationPolicy
 Parameter Sets: Identity
 Aliases: 
 
@@ -200,11 +237,12 @@ Accept wildcard characters: False
 ```
 
 ### -LDAPFilter
-Specifies an LDAP query string used to filter Active Directory Domain Services objects.
-Use this parameter to run your existing LDAP queries.
+
+Specifies a filter using the LDAP search filter syntax defined in RFC2254 to filter Active Directory
+Domain Services objects.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: LdapFilter
 Aliases: 
 
@@ -216,17 +254,16 @@ Accept wildcard characters: False
 ```
 
 ### -Properties
-Specifies the properties of the output object to get from the server.
-Use this parameter to get properties that are not included in the default set.
 
-Specify the properties to get as a comma separated list of names.
-For properties that are not default or extended properties, you must specify the LDAP display name of the property.
-To display all of the properties that are set on the object, specify an asterisk wildcard.
+Specifies the properties of the output object to get from the server. Use this parameter to get
+properties that are not included in the default set.
 
-To get properties for an object and display them, you can use this cmdlet and pass the output to the [Get-Member](https://go.microsoft.com/fwlink/?LinkID=293971) cmdlet by using the pipeline operator.
+Specify the properties to get as a comma separated list of names. For properties that are not
+default or extended properties, you must specify the LDAP display name of the property. To display
+all of the properties that are set on the object, specify an asterisk wildcard.
 
 ```yaml
-Type: String[]
+Type: System.String[]
 Parameter Sets: (All)
 Aliases: Property
 
@@ -238,8 +275,9 @@ Accept wildcard characters: False
 ```
 
 ### -ResultPageSize
-Specifies the number of objects to include in one page for an Active Directory Domain Services query.
-The default value is 256 objects per page.
+
+Specifies the number of objects to include in one page for an Active Directory Domain Services
+query. The default value is `256` objects per page.
 
 ```yaml
 Type: Int32
@@ -254,11 +292,12 @@ Accept wildcard characters: False
 ```
 
 ### -ResultSetSize
-Specifies the maximum number of objects to return for an Active Directory Domain Services query.
-If you want to get all of the objects, set this parameter to $Null.
-You can use Ctrl+C to stop the query and the return of objects.
 
-The default value is $Null.
+Specifies the maximum number of objects to return for an Active Directory Domain Services query. If
+you want to get all of the objects, set this parameter to `$null`. You can use Ctrl+C to stop the
+query and the return of objects.
+
+The default value is `$null`.
 
 ```yaml
 Type: Int32
@@ -273,30 +312,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to which to connect, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following:  Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways:  
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
 - By using the **Server** value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -308,19 +352,25 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None or Microsoft.ActiveDirectory.Management.ADAuthenticationPolicy
+
 This cmdlet accepts an authentication policy object.
 
 ## OUTPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADAuthenticationPolicy
-This cmdlet returns one or more authentication policy objects.
-This cmdlet returns a default set of **ADAuthenticationPolicy** property values.
-To retrieve additional **ADAuthenticationPolicy** properties, use the *Properties* parameter.
+
+This cmdlet returns one or more authentication policy objects. This cmdlet returns a default set of
+**ADAuthenticationPolicy** property values. To retrieve additional **ADAuthenticationPolicy**
+properties, use the **Properties** parameter.
 
 ## NOTES
 
@@ -333,4 +383,3 @@ To retrieve additional **ADAuthenticationPolicy** properties, use the *Propertie
 [Set-ADAuthenticationPolicy](./Set-ADAuthenticationPolicy.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
-

--- a/docset/winserver2022-ps/activedirectory/Get-ADAuthenticationPolicy.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADAuthenticationPolicy.md
@@ -260,7 +260,7 @@ properties that are not included in the default set.
 
 Specify the properties to get as a comma separated list of names. For properties that are not
 default or extended properties, you must specify the LDAP display name of the property. To display
-all of the properties that are set on the object, specify an asterisk wildcard.
+all of the properties that are set on the object, specify an asterisk (`*`) wildcard.
 
 ```yaml
 Type: System.String[]

--- a/docset/winserver2022-ps/activedirectory/Get-ADAuthenticationPolicySilo.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADAuthenticationPolicySilo.md
@@ -16,80 +16,100 @@ Gets one or more Active Directory Domain Services authentication policy silos.
 ## SYNTAX
 
 ### Filter (Default)
+
 ```
-Get-ADAuthenticationPolicySilo [-AuthType <ADAuthType>] [-Credential <PSCredential>] -Filter <String>
- [-Properties <String[]>] [-ResultPageSize <Int32>] [-ResultSetSize <Int32>] [-Server <String>]
- [<CommonParameters>]
+Get-ADAuthenticationPolicySilo [-AuthType <ADAuthType>] [-Credential <PSCredential>] 
+ -Filter <String> [-Properties <String[]>] [-ResultPageSize <Int32>]
+ [-ResultSetSize <Int32>] [-Server <String>] [<CommonParameters>]
 ```
 
 ### Identity
+
 ```
 Get-ADAuthenticationPolicySilo [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADAuthenticationPolicySilo> [-Properties <String[]>] [-Server <String>] [<CommonParameters>]
-```
-
-### LdapFilter
-```
-Get-ADAuthenticationPolicySilo [-AuthType <ADAuthType>] [-Credential <PSCredential>] -LDAPFilter <String>
- [-Properties <String[]>] [-ResultPageSize <Int32>] [-ResultSetSize <Int32>] [-Server <String>]
+ [-Identity] <ADAuthenticationPolicySilo> [-Properties <String[]>] [-Server <String>]
  [<CommonParameters>]
 ```
 
+### LdapFilter
+
+```
+Get-ADAuthenticationPolicySilo [-AuthType <ADAuthType>] [-Credential <PSCredential>]
+ -LDAPFilter <String> [-Properties <String[]>] [-ResultPageSize <Int32>]
+ [-ResultSetSize <Int32>] [-Server <String>] [<CommonParameters>]
+```
+
 ## DESCRIPTION
-The **Get-ADAuthenticationPolicySilo** cmdlet gets an authentication policy silo or performs a search to get authentication policy silos.
 
-The *Identity* parameter specifies the Active Directory Domain Services authentication policy silo to get.
-You can identify an authentication policy silo by its distinguished name (DN), GUID or name.
-You can also use the *Identity* parameter to specify a variable that contains an authentication policy silo object, or you can use the pipeline operator to pass an authentication policy silo object to the *Identity* parameter.
+The `Get-ADAuthenticationPolicySilo` cmdlet gets an authentication policy silo or performs a search
+to get authentication policy silos.
 
-You can search for and use multiple authentication policies by specifying the *Filter* parameter or the *LDAPFilter* parameter.
-The *Filter* parameter uses the Windows PowerShell® expression language to write query strings for Active Directory Domain Services.
-Windows PowerShell expression language syntax provides rich type conversion support for value types received by the *Filter* parameter.
-For more information about the *Filter* parameter syntax, type `Get-Help about_ActiveDirectory_Filter`.
-If you have existing Lightweight Directory Access Protocol (LDAP) query strings, you can use the *LDAPFilter* parameter.
+The **Identity** parameter specifies the Active Directory Domain Services authentication policy silo
+to get. You can identify an authentication policy silo by its distinguished name (DN), GUID or name.
+You can also use the **Identity** parameter to specify a variable that contains an authentication
+policy silo object, or you can use the pipeline operator to pass an authentication policy silo
+object to the **Identity** parameter.
+
+You can search for and use multiple authentication policies by specifying the **Filter** parameter
+or the **LDAPFilter** parameter. The **Filter** parameter uses the Windows PowerShell expression
+language to write query strings for Active Directory Domain Services. Windows PowerShell expression
+language syntax provides rich type conversion support for value types received by the **Filter**
+parameter. For more information about the **Filter** parameter syntax, type
+`Get-Help about_ActiveDirectory_Filter`. If you have existing Lightweight Directory Access Protocol
+(LDAP) query strings, you can use the **LDAPFilter** parameter.
 
 ## EXAMPLES
 
 ### Example 1: Get an authentication policy silo object
-```
-PS C:\> Get-ADAuthenticationPolicySilo -Identity AuthenticationPolicySilo01
+
+```powershell
+Get-ADAuthenticationPolicySilo -Identity AuthenticationPolicySilo01
 ```
 
 This command gets an authentication policy silo object named AuthenticationPolicySilo01.
 
 ### Example 2: Get all authentication policy silo objects that match a filter
-```
-PS C:\> Get-ADAuthenticationPolicySilo -Filter 'Name -like "*AuthenticationPolicySilo*"' | Format-Table Name, Enforce -AutoSize
+
+```powershell
+Get-ADAuthenticationPolicySilo -Filter 'Name -like "*AuthenticationPolicySilo*"' |
+    Format-Table Name, Enforce -AutoSize
+
+```output
 Name  Enforce
 ----  -------
 silo     True
 silos   False
 ```
 
-This command gets all the authentication policy silos that match the filter specified by the Filter parameter.
-The output is then passed to the Format-Table cmdlet to display the name of the policy and the value for Enforce on each policy.
+This command gets all the authentication policy silos that match the filter specified by the
+**Filter** parameter. The output is then passed to the `Format-Table` cmdlet to display the name of
+the policy and the value for Enforce on each policy.
 
 ### Example 3: Get all properties of a specific authentication policy silo
-```
-PS C:\> Get-ADAuthenticationPolicySilo -Identity AuthenticationPolicySilo02 -Properties *
+
+```powershell
+Get-ADAuthenticationPolicySilo -Identity AuthenticationPolicySilo02 -Properties *
 ```
 
-This command gets all properties for the authentication policy silo named AuthenticationPolicySilo02.
+This command gets all properties for the authentication policy silo named
+`AuthenticationPolicySilo02`.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+The default authentication method is `Negotiate`.
+
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -102,17 +122,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies a user account that has permission to perform the task.
-The default is the current user.
-Type a user name, such as User01 or Domain01\User01, or enter a **PSCredential** object, such as one generated by the **Get-Credential** cmdlet.
 
-By default, the cmdlet uses the credentials of the currently logged on user unless the cmdlet is run from an Active Directory Domain Services Windows PowerShell provider drive.
-If you run the cmdlet in a provider drive, the account associated with the drive is the default.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-If you specify credentials that do not have permission to perform the task, the cmdlet returns an error.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
+
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -124,32 +151,36 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
-Specifies a query string that retrieves Active Directory Domain Services objects.
-This string uses the Windows PowerShell expression language syntax.
-The Windows PowerShell expression language syntax provides rich type-conversion support for value types received by the *Filter* parameter.
 
-Specify the *Filter* parameter in one of the following formats: 
+Specifies a query string that retrieves Active Directory Domain Services objects. This string uses
+the Windows PowerShell expression language syntax. The Windows PowerShell expression language syntax
+provides rich type-conversion support for value types received by the **Filter** parameter.
 
-- To match a single filter element: {Attributeoperator  "value"} 
-- To match multiple filter elements: {(Attribute1operator1 "value1") joinOperator (Attribute2operator2 "value2")}
+Specify the **Filter** parameter in one of the following formats:
 
-Windows PowerShell wildcards other than "*", such as "?" are not supported by the *Filter* syntax.
+- To match a single filter element: `{Attribute operator "value"}`
+- To match multiple filter elements:
+  `{(Attribute1 operator1 "value1") joinOperator (Attribute2 operator2 "value2")}`
 
-Valid filter operators are: 
+Windows PowerShell wildcards other than `*`, such as `?`, are not supported by the **Filter**
+syntax.
 
- -eq, -le, -ge, -ne, -lt, -gt, -approx, -bor, -band, -recursivematch, -like, -notlike
+Valid filter operators are:
 
-Valid join operators are: 
+ `-eq`, `-le`, `-ge`, `-ne`, `-lt`, `-gt`, `-approx`, `-bor`, `-band`, `-recursivematch`, `-like`,
+ `-notlike`
 
--and, -or
+Valid join operators are:
 
-The not operator is -not
+`-and`, `-or`
 
-For a list of supported types for values, type `Get-Help  about_ActiveDirectory_ObjectModel`.
-For more information about the *Filter* parameter, type `Get-Help about_ActiveDirectory_Filter`.
+The not operator is `-not`.
+
+For a list of supported types for values, see `about_ActiveDirectory_ObjectModel`. For more
+information about the **Filter** parameter, see `about_ActiveDirectory_Filter`.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: Filter
 Aliases: 
 
@@ -161,20 +192,22 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory Domain Services authentication policy silo object.
-Specify the authentication policy silo object in one of the following formats: 
+
+Specifies an Active Directory Domain Services authentication policy silo object. Specify the
+authentication policy silo object in one of the following formats:
 
 - A distinguished name
 - A GUID
 - A Name
 
-This parameter can also get this object through the pipeline or you can set this parameter to an object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+object instance.
 
-The cmdlet searches the default naming context or partition to find the object.
-If the cmdlet finds two or more objects, the cmdlet returns a non-terminating error.
+The cmdlet searches the default naming context or partition to find the object. If the cmdlet finds
+two or more objects, the cmdlet returns a non-terminating error.
 
 ```yaml
-Type: ADAuthenticationPolicySilo
+Type: Microsoft.ActiveDirectory.Management.ADAuthenticationPolicySilo
 Parameter Sets: Identity
 Aliases: 
 
@@ -186,11 +219,12 @@ Accept wildcard characters: False
 ```
 
 ### -LDAPFilter
-Specifies an LDAP query string used to filter Active Directory Domain Services objects.
-Use this parameter to run your existing LDAP queries.
+
+Specifies a filter using the LDAP search filter syntax defined in RFC2254 to filter Active Directory
+Domain Services objects.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: LdapFilter
 Aliases: 
 
@@ -202,17 +236,16 @@ Accept wildcard characters: False
 ```
 
 ### -Properties
-Specifies the properties of the output object to get from the server.
-Use this parameter to get properties that are not included in the default set.
 
-Specify the properties to get as a comma separated list of names.
-For properties that are not default or extended properties, you must specify the LDAP display name of the property.
-To display all of the properties that are set on the object, specify an asterisk wildcard.
+Specifies the properties of the output object to get from the server. Use this parameter to get
+properties that are not included in the default set.
 
-To get properties for an object and display them, you can use this cmdlet and pass the output to the **Get-Member** cmdlet by using the pipeline operator.
+Specify the properties to get as a comma separated list of names. For properties that are not
+default or extended properties, you must specify the LDAP display name of the property. To display
+all of the properties that are set on the object, specify an asterisk (`*`) wildcard.
 
 ```yaml
-Type: String[]
+Type: System.String[]
 Parameter Sets: (All)
 Aliases: Property
 
@@ -224,8 +257,9 @@ Accept wildcard characters: False
 ```
 
 ### -ResultPageSize
-Specifies the number of objects to include in one page for an Active Directory Domain Services query.
-The default value is 256 objects per page.
+
+Specifies the number of objects to include in one page for an Active Directory Domain Services
+query. The default value is `256` objects per page.
 
 ```yaml
 Type: Int32
@@ -240,11 +274,12 @@ Accept wildcard characters: False
 ```
 
 ### -ResultSetSize
-Specifies the maximum number of objects to return for an Active Directory Domain Services query.
-If you want to get all of the objects, set this parameter to $Null.
-You can use Ctrl+C to stop the query and the return of objects.
 
-The default value is $Null.
+Specifies the maximum number of objects to return for an Active Directory Domain Services query. If
+you want to get all of the objects, set this parameter to `$null`. You can use Ctrl+C to stop the
+query and the return of objects.
+
+The default value is `$null`.
 
 ```yaml
 Type: Int32
@@ -259,28 +294,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to which to connect, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following:  Active Directory Lightweight Domain Services, Active Directory Domain Services, or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways:  
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
 
-Domain name values: 
+Specify the Active Directory Domain Services instance in one of the following ways:
+
+Domain name values:
+
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values:  
+Directory server values:
+
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
-- By using the *Server* value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the **Server** value from objects passed through the pipeline
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -292,19 +334,25 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None or Microsoft.ActiveDirectory.Management.ADAuthenticationPolicySilo
+
 This cmdlet accepts an authentication policy silo object.
 
 ## OUTPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADAuthenticationPolicySilo
-Returns one or more authentication policy silo objects.
-This cmdlet returns a default set of **ADAuthenticationPolicySilo** property values.
-To retrieve additional **ADAuthenticationPolicySilo** properties, use the *Properties* parameter.
+
+Returns one or more authentication policy silo objects. This cmdlet returns a default set of
+**ADAuthenticationPolicySilo** property values. To retrieve additional
+**ADAuthenticationPolicySilo** properties, use the **Properties** parameter.
 
 ## NOTES
 
@@ -317,4 +365,3 @@ To retrieve additional **ADAuthenticationPolicySilo** properties, use the *Prope
 [Set-ADAuthenticationPolicySilo](./Set-ADAuthenticationPolicySilo.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
-

--- a/docset/winserver2022-ps/activedirectory/Get-ADAuthenticationPolicySilo.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADAuthenticationPolicySilo.md
@@ -73,6 +73,7 @@ This command gets an authentication policy silo object named AuthenticationPolic
 ```powershell
 Get-ADAuthenticationPolicySilo -Filter 'Name -like "*AuthenticationPolicySilo*"' |
     Format-Table Name, Enforce -AutoSize
+```
 
 ```output
 Name  Enforce

--- a/docset/winserver2022-ps/activedirectory/Get-ADCentralAccessPolicy.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADCentralAccessPolicy.md
@@ -16,66 +16,76 @@ Retrieves central access policies from Active Directory.
 ## SYNTAX
 
 ### Filter (Default)
+
 ```
-Get-ADCentralAccessPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>] -Filter <String>
- [-Properties <String[]>] [-ResultPageSize <Int32>] [-ResultSetSize <Int32>] [-Server <String>]
- [<CommonParameters>]
+Get-ADCentralAccessPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>]
+ -Filter <String> [-Properties <String[]>] [-ResultPageSize <Int32>]
+ [-ResultSetSize <Int32>] [-Server <String>] [<CommonParameters>]
 ```
 
 ### Identity
+
 ```
 Get-ADCentralAccessPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [-Identity] <ADCentralAccessPolicy> [-Properties <String[]>] [-Server <String>] [<CommonParameters>]
-```
-
-### LdapFilter
-```
-Get-ADCentralAccessPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>] -LDAPFilter <String>
- [-Properties <String[]>] [-ResultPageSize <Int32>] [-ResultSetSize <Int32>] [-Server <String>]
+ [-Identity] <ADCentralAccessPolicy> [-Properties <String[]>] [-Server <String>]
  [<CommonParameters>]
 ```
 
+### LdapFilter
+
+```
+Get-ADCentralAccessPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>]
+ -LDAPFilter <String> [-Properties <String[]>] [-ResultPageSize <Int32>]
+ [-ResultSetSize <Int32>] [-Server <String>] [<CommonParameters>]
+```
+
 ## DESCRIPTION
-The **Get-ADCentralAccessPolicy** cmdlet retrieves central access policies from Active Directory.
+
+The `Get-ADCentralAccessPolicy` cmdlet retrieves central access policies from Active Directory.
 
 ## EXAMPLES
 
 ### Example 1: Get a list off all central access policies
-```
-PS C:\> Get-ADCentralAccessPolicy -Filter *
+
+```powershell
+Get-ADCentralAccessPolicy -Filter *
 ```
 
 This command retrieves a list of all central access policies.
 
 ### Example 2: Get a list of specific central access policies using a filter
-```
-PS C:\> Get-ADCentralAccessPolicy -Filter "Members -eq 'Finance Documents Rule'"
+
+```powershell
+Get-ADCentralAccessPolicy -Filter "Members -eq 'Finance Documents Rule'"
 ```
 
-This command gets the central access policies that have the central access rule Finance Documents Rule as its members.
+This command gets the central access policies that have the central access rule
+`Finance Documents Rule` as its members.
 
 ### Example 3: Get information for a central access policy for a specific Active Directory object
-```
-PS C:\> Get-ADCentralAccessPolicy -Identity "Finance Policy"
+
+```powershell
+Get-ADCentralAccessPolicy -Identity "Finance Policy"
 ```
 
-This command gets information for a central access policy named Finance Policy.
+This command gets information for a central access policy named `Finance Policy`.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -88,20 +98,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -113,40 +127,36 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
-Specifies a query string that retrieves Active Directory objects.
-This string uses the PowerShell Expression Language syntax.
-The PowerShell Expression Language syntax provides rich type-conversion support for value types received by the *Filter* parameter.
-The syntax uses an in-order representation, which means that the operator is placed between the operand and the value.
-For more information about the *Filter* parameter, type `Get-Help about_ActiveDirectory_Filter`.
 
-Syntax:
+Specifies a query string that retrieves Active Directory Domain Services objects. This string uses
+the Windows PowerShell expression language syntax. The Windows PowerShell expression language syntax
+provides rich type-conversion support for value types received by the **Filter** parameter.
 
-The following syntax uses Backus-Naur form to show how to use the PowerShell Expression Language for this parameter.
+Specify the **Filter** parameter in one of the following formats:
 
-\<filter\>  ::= "{" \<FilterComponentList\> "}"
+- To match a single filter element: `{Attribute operator "value"}`
+- To match multiple filter elements:
+  `{(Attribute1 operator1 "value1") joinOperator (Attribute2 operator2 "value2")}`
 
-\<FilterComponentList\> ::= \<FilterComponent\> | \<FilterComponent\> \<JoinOperator\> \<FilterComponent\> | \<NotOperator\>  \<FilterComponent\>
+Windows PowerShell wildcards other than `*`, such as `?`, are not supported by the **Filter**
+syntax.
 
-\<FilterComponent\> ::= \<attr\> \<FilterOperator\> \<value\> | "(" \<FilterComponent\> ")"
+Valid filter operators are:
 
-\<FilterOperator\> ::= "-eq" | "-le" | "-ge" | "-ne" | "-lt" | "-gt"| "-approx" | "-bor" | "-band" | "-recursivematch" | "-like" | "-notlike"
+ `-eq`, `-le`, `-ge`, `-ne`, `-lt`, `-gt`, `-approx`, `-bor`, `-band`, `-recursivematch`, `-like`,
+ `-notlike`
 
-\<JoinOperator\> ::= "-and" | "-or"
+Valid join operators are:
 
-\<NotOperator\> ::= "-not"
+`-and`, `-or`
 
-\<attr\> ::= \<PropertyName\> | \<LDAPDisplayName of the attribute\>
+The not operator is `-not`.
 
-\<value\>::= \<compare this value with an \<attr\> by using the specified \<FilterOperator\>\>
-
-For a list of supported types for \<value\>, type `Get-Help about_ActiveDirectory_ObjectModel`.
-
-Note: PowerShell wildcards other than *, such as ?, are not supported by the *Filter* syntax.
-
-Note: To query using Lightweight Directory Access Protocol (LDAP) query strings, use the *LDAPFilter* parameter.
+For a list of supported types for values, see `about_ActiveDirectory_ObjectModel`. For more
+information about the **Filter** parameter, see `about_ActiveDirectory_Filter`.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: Filter
 Aliases: 
 
@@ -158,16 +168,18 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory object by providing one of the following property values.
-The identifier in parentheses is the LDAP display name for the attribute.The acceptable values for this parameter are:
+
+Specifies an Active Directory object by providing one of the following property values. The
+identifier in parentheses is the LDAP display name for the attribute.The acceptable values for this
+parameter are:
 
 - A distinguished name
-- A GUID (objectGUID) 
-- A Security Identifier (objectSid) 
-- A SAM account name (sAMAccountName)
+- A GUID (**objectGUID**)
+- A Security Identifier (**objectSid**)
+- A SAM account name (**sAMAccountName**)
 
 ```yaml
-Type: ADCentralAccessPolicy
+Type: Microsoft.ActiveDirectory.Management.ADCentralAccessPolicy
 Parameter Sets: Identity
 Aliases: 
 
@@ -179,13 +191,12 @@ Accept wildcard characters: False
 ```
 
 ### -LDAPFilter
-Specifies an LDAP query string that is used to filter Active Directory objects.
-You can use this parameter to run your existing LDAP queries.
-The Filter parameter syntax supports the same functionality as the LDAP syntax.
-For more information, see the *Filter* parameter description or type `Get-Help about_ActiveDirectory_Filter`.
+
+Specifies a filter using the LDAP search filter syntax defined in RFC2254 to filter Active Directory
+Domain Services objects.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: LdapFilter
 Aliases: 
 
@@ -197,19 +208,18 @@ Accept wildcard characters: False
 ```
 
 ### -Properties
-Specifies the properties of the output object to retrieve from the server.
-Use this parameter to retrieve properties that are not included in the default set.
 
-Specify properties for this parameter as a comma-separated list of names.
-To display all of the attributes that are set on the object, specify * (asterisk).
+Specifies the properties of the output object to get from the server. Use this parameter to get
+properties that are not included in the default set.
 
-To specify an individual extended property, use the name of the property.
-For properties that are not default or extended properties, you must specify the LDAP display name of the attribute.
+Specify the properties to get as a comma separated list of names. To display
+all of the properties that are set on the object, specify an asterisk (`*`) wildcard.
 
-To retrieve properties and display them for an object, you can use the Get-* cmdlet associated with the object and pass the output to the **Get-Member** cmdlet.
+To specify an individual extended property, use the name of the property. For properties that are
+not default or extended properties, you must specify the LDAP display name of the attribute.
 
 ```yaml
-Type: String[]
+Type: System.String[]
 Parameter Sets: (All)
 Aliases: Property
 
@@ -221,12 +231,12 @@ Accept wildcard characters: False
 ```
 
 ### -ResultPageSize
-Specifies the number of objects to include in one page for an Active Directory Domain Services query.
 
-The default is 256 objects per page.
+Specifies the number of objects to include in one page for an Active Directory Domain Services
+query. The default value is `256` objects per page.
 
 ```yaml
-Type: Int32
+Type: System.Int32
 Parameter Sets: Filter, LdapFilter
 Aliases: 
 
@@ -238,14 +248,15 @@ Accept wildcard characters: False
 ```
 
 ### -ResultSetSize
-Specifies the maximum number of objects to return for an Active Directory Domain Services query.
-If you want to receive all of the objects, set this parameter to $Null (null value).
-You can use Ctrl+C to stop the query and return of objects.
 
-The default is $Null.
+Specifies the maximum number of objects to return for an Active Directory Domain Services query. If
+you want to get all of the objects, set this parameter to `$null`. You can use Ctrl+C to stop the
+query and the return of objects.
+
+The default value is `$null`.
 
 ```yaml
-Type: Int32
+Type: System.Int32
 Parameter Sets: Filter, LdapFilter
 Aliases: 
 
@@ -257,30 +268,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following:  Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways: 
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
-- By using the *Server* value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the **Server** value from objects passed through the pipeline
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -292,31 +308,27 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None or Microsoft.ActiveDirectory.Management.ADCentralAccessPolicy
-An **ADCentralAccessPolicy** object is received by the *Identity* parameter.
+
+An **ADCentralAccessPolicy** object is received by the **Identity** parameter.
 
 ## OUTPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADCentralAccessPolicy
+
 This cmdlet returns one or more **ADCentralAccessPolicy** objects.
 
-The **Get-ADCentralAccessPolicy** cmdlet returns a default set of **ADCentralAccessPolicy** property values.
-To retrieve additional **ADCentralAccessPolicy** properties, use the *Properties* parameter of the cmdlet.
-
-To view the properties for an **ADCentralAccessPolicy** object, see the following examples.
-To run these examples, replace \<object\> with an Active Directory object identifier.
-
-To get a list of the default set of properties of an **ADCentralAccessPolicy** object, use the following command:
-
-`Get-ADCentralAccessPolicy`\<object\>
-
-To get a list of all the properties of an **ADCentralAccessPolicy** object, use the following command:
-
-`Get-ADCentralAccessPolicy`\<object\>`-Properties *`
+The cmdlet returns a default set of **ADCentralAccessPolicy** property
+values. To retrieve additional **ADCentralAccessPolicy** properties, use the **Properties**
+parameter of the cmdlet.
 
 ## NOTES
 
@@ -329,4 +341,3 @@ To get a list of all the properties of an **ADCentralAccessPolicy** object, use 
 [Set-ADCentralAccessPolicy](./Set-ADCentralAccessPolicy.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
-

--- a/docset/winserver2022-ps/activedirectory/Get-ADCentralAccessRule.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADCentralAccessRule.md
@@ -16,66 +16,75 @@ Retrieves central access rules from Active Directory.
 ## SYNTAX
 
 ### Filter (Default)
+
 ```
-Get-ADCentralAccessRule [-AuthType <ADAuthType>] [-Credential <PSCredential>] -Filter <String>
- [-Properties <String[]>] [-ResultPageSize <Int32>] [-ResultSetSize <Int32>] [-Server <String>]
- [<CommonParameters>]
+Get-ADCentralAccessRule [-AuthType <ADAuthType>] [-Credential <PSCredential>]
+ -Filter <String> [-Properties <String[]>] [-ResultPageSize <Int32>]
+ [-ResultSetSize <Int32>] [-Server <String>] [<CommonParameters>]
 ```
 
 ### Identity
-```
-Get-ADCentralAccessRule [-AuthType <ADAuthType>] [-Credential <PSCredential>] [-Identity] <ADCentralAccessRule>
- [-Properties <String[]>] [-Server <String>] [<CommonParameters>]
-```
 
-### LdapFilter
 ```
-Get-ADCentralAccessRule [-AuthType <ADAuthType>] [-Credential <PSCredential>] -LDAPFilter <String>
- [-Properties <String[]>] [-ResultPageSize <Int32>] [-ResultSetSize <Int32>] [-Server <String>]
+Get-ADCentralAccessRule [-AuthType <ADAuthType>] [-Credential <PSCredential>]
+ [-Identity] <ADCentralAccessRule> [-Properties <String[]>] [-Server <String>]
  [<CommonParameters>]
 ```
 
+### LdapFilter
+
+```
+Get-ADCentralAccessRule [-AuthType <ADAuthType>] [-Credential <PSCredential>]
+ -LDAPFilter <String> [-Properties <String[]>] [-ResultPageSize <Int32>]
+ [-ResultSetSize <Int32>] [-Server <String>] [<CommonParameters>]
+```
+
 ## DESCRIPTION
-The **Get-ADCentralAccessRule** cmdlet retrieves central access rules from Active Directory.
+
+The `Get-ADCentralAccessRule` cmdlet retrieves central access rules from Active Directory.
 
 ## EXAMPLES
 
 ### Example 1: Get a list of all central access rules
-```
-PS C:\> Get-ADCentralAccessRule -Filter *
+
+```powershell
+Get-ADCentralAccessRule -Filter *
 ```
 
 This command retrieves a list of all central access rules.
 
 ### Example 2: Get central access rules that have a specific resource condition
-```
-PS C:\> Get-ADCentralAccessRule -Filter "ResourceCondition -like '*Department*'"
+
+```powershell
+Get-ADCentralAccessRule -Filter "ResourceCondition -like '*Department*'"
 ```
 
-This command retrieves the central access rules that have Department in its resource condition.
+This command retrieves the central access rules that have `Department` in its resource condition.
 
 ### Example 3: Get a specific central access rule by name
-```
-PS C:\> Get-ADCentralAccessRule -Identity "Financial Documents Rule"
+
+```powershell
+Get-ADCentralAccessRule -Identity "Financial Documents Rule"
 ```
 
-This command retrieves a central access rule named Finance Documents Rule.
+This command retrieves a central access rule named `Finance Documents Rule`.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -88,20 +97,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -113,40 +126,36 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
-Specifies a query string that retrieves Active Directory objects.
-This string uses the PowerShell Expression Language syntax.
-The PowerShell Expression Language syntax provides rich type-conversion support for value types received by the *Filter* parameter.
-The syntax uses an in-order representation, which means that the operator is placed between the operand and the value.
-For more information about the *Filter* parameter, type `Get-Help about_ActiveDirectory_Filter`.
 
-Syntax:
+Specifies a query string that retrieves Active Directory Domain Services objects. This string uses
+the Windows PowerShell expression language syntax. The Windows PowerShell expression language syntax
+provides rich type-conversion support for value types received by the **Filter** parameter.
 
-The following syntax uses Backus-Naur form to show how to use the PowerShell Expression Language for this parameter.
+Specify the **Filter** parameter in one of the following formats:
 
-\<filter\>  ::= "{" \<FilterComponentList\> "}"
+- To match a single filter element: `{Attribute operator "value"}`
+- To match multiple filter elements:
+  `{(Attribute1 operator1 "value1") joinOperator (Attribute2 operator2 "value2")}`
 
-\<FilterComponentList\> ::= \<FilterComponent\> | \<FilterComponent\> \<JoinOperator\> \<FilterComponent\> | \<NotOperator\>  \<FilterComponent\>
+Windows PowerShell wildcards other than `*`, such as `?`, are not supported by the **Filter**
+syntax.
 
-\<FilterComponent\> ::= \<attr\> \<FilterOperator\> \<value\> | "(" \<FilterComponent\> ")"
+Valid filter operators are:
 
-\<FilterOperator\> ::= "-eq" | "-le" | "-ge" | "-ne" | "-lt" | "-gt"| "-approx" | "-bor" | "-band" | "-recursivematch" | "-like" | "-notlike"
+ `-eq`, `-le`, `-ge`, `-ne`, `-lt`, `-gt`, `-approx`, `-bor`, `-band`, `-recursivematch`, `-like`,
+ `-notlike`
 
-\<JoinOperator\> ::= "-and" | "-or"
+Valid join operators are:
 
-\<NotOperator\> ::= "-not"
+`-and`, `-or`
 
-\<attr\> ::= \<PropertyName\> | \<LDAPDisplayName of the attribute\>
+The not operator is `-not`.
 
-\<value\>::= \<compare this value with an \<attr\> by using the specified \<FilterOperator\>\>
-
-For a list of supported types for \<value\>, type `Get-Help about_ActiveDirectory_ObjectModel`.
-
-Note: PowerShell wildcards other than *, such as ?, are not supported by the *Filter* syntax.
-
-Note: To query using Lightweight Directory Access Protocol (LDAP) query strings, use the *LDAPFilter* parameter.
+For a list of supported types for values, see `about_ActiveDirectory_ObjectModel`. For more
+information about the **Filter** parameter, see `about_ActiveDirectory_Filter`.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: Filter
 Aliases: 
 
@@ -158,19 +167,21 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory object by providing one of the following property values.
-The identifier in parentheses is the LDAP display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory object by providing one of the following property values. The
+identifier in parentheses is the LDAP display name for the attribute. The acceptable values for this
+parameter are:
 
 - A distinguished name
-- A GUID (objectGUID) 
-- A security identifier (objectSid) 
-- A SAM account name (sAMAccountName)
+- A GUID (**objectGUID**)
+- A security identifier (**objectSid**)
+- A SAM account name (**sAMAccountName**)
 
-This parameter can also get this object through the pipeline or you can set this parameter to an object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+object instance.
 
 ```yaml
-Type: ADCentralAccessRule
+Type: Microsoft.ActiveDirectory.Management.ADCentralAccessRule
 Parameter Sets: Identity
 Aliases: 
 
@@ -182,13 +193,12 @@ Accept wildcard characters: False
 ```
 
 ### -LDAPFilter
-Specifies an LDAP query string that is used to filter Active Directory objects.
-You can use this parameter to run your existing LDAP queries.
-The *Filter* parameter syntax supports the same functionality as the LDAP syntax.
-For more information, see the *Filter* parameter description or type `Get-Help about_ActiveDirectory_Filter`.
+
+Specifies a filter using the LDAP search filter syntax defined in RFC2254 to filter Active Directory
+Domain Services objects.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: LdapFilter
 Aliases: 
 
@@ -200,19 +210,18 @@ Accept wildcard characters: False
 ```
 
 ### -Properties
-Specifies the properties of the output object to retrieve from the server.
-You can use this parameter to retrieve properties that are not included in the default set.
 
-Specify properties for this parameter as a comma-separated list of names.
-To display all of the attributes that are set on the object, specify * (asterisk).
+Specifies the properties of the output object to get from the server. Use this parameter to get
+properties that are not included in the default set.
 
-To specify an individual extended property, use the name of the property.
-For properties that are not default or extended properties, you must specify the LDAP display name of the attribute.
+Specify the properties to get as a comma separated list of names. To display
+all of the properties that are set on the object, specify an asterisk (`*`) wildcard.
 
-To retrieve properties and display them for an object, you can use the Get-* cmdlet associated with the object and pass the output to the **Get-Member** cmdlet.
+To specify an individual extended property, use the name of the property. For properties that are
+not default or extended properties, you must specify the LDAP display name of the attribute.
 
 ```yaml
-Type: String[]
+Type: System.String[]
 Parameter Sets: (All)
 Aliases: Property
 
@@ -224,12 +233,12 @@ Accept wildcard characters: False
 ```
 
 ### -ResultPageSize
-Specifies the number of objects to include in one page for an Active Directory Domain Services query.
 
-The default is 256 objects per page.
+Specifies the number of objects to include in one page for an Active Directory Domain Services
+query. The default value is `256` objects per page.
 
 ```yaml
-Type: Int32
+Type: System.Int32
 Parameter Sets: Filter, LdapFilter
 Aliases: 
 
@@ -241,14 +250,15 @@ Accept wildcard characters: False
 ```
 
 ### -ResultSetSize
-Specifies the maximum number of objects to return for an Active Directory Domain Services query.
-If you want to receive all of the objects, set this parameter to $Null (null value).
-You can use Ctrl+C to stop the query and return of objects.
 
-The default is $Null.
+Specifies the maximum number of objects to return for an Active Directory Domain Services query. If
+you want to get all of the objects, set this parameter to `$null`. You can use Ctrl+C to stop the
+query and the return of objects.
+
+The default value is `$null`.
 
 ```yaml
-Type: Int32
+Type: System.Int32
 Parameter Sets: Filter, LdapFilter
 Aliases: 
 
@@ -260,30 +270,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways:  
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
-- By using the *Server* value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the **Server** value from objects passed through the pipeline
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -295,31 +310,27 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None or Microsoft.ActiveDirectory.Management.ADCentralAccessPolicyEntry
-An **ADCentralAccessPolicyEntry** object is received by the *Identity* parameter.
+
+An **ADCentralAccessPolicyEntry** object is received by the **Identity** parameter.
 
 ## OUTPUTS
 
 ### Microsoft.ActiveDirectory.Management.ADCentralAccessRule
+
 Returns one or more **ADCentralAccessRule** objects.
 
-The **Get-ADCentralAccessRule** cmdlet returns a default set of **ADCentralAccessRule** property values.
-To retrieve additional **ADCentralAccessRule** properties, use the *Properties* parameter of the cmdlet.
-
-To view the properties for an **ADCentralAccessRule** object, see the following examples.
-To run these examples, replace \<object\> with an Active Directory object identifier.
-
-To get a list of the default set of properties of an **ADCentralAccessRule** object, use the following command:
-
-`Get-ADCentralAccessRule`\<object\>
-
-To get a list of all the properties of an **ADCentralAccessRule** object, use the following command:
-
-`Get-ADCentralAccessRule`\<object\>`-Properties *`
+The cmdlet returns a default set of **ADCentralAccessRule** property
+values. To retrieve additional **ADCentralAccessRule** properties, use the **Properties** parameter
+of the cmdlet.
 
 ## NOTES
 
@@ -332,4 +343,3 @@ To get a list of all the properties of an **ADCentralAccessRule** object, use th
 [Set-ADCentralAccessRule](./Set-ADCentralAccessRule.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
-

--- a/docset/winserver2022-ps/activedirectory/Get-ADClaimTransformPolicy.md
+++ b/docset/winserver2022-ps/activedirectory/Get-ADClaimTransformPolicy.md
@@ -16,72 +16,86 @@ Returns one or more Active Directory claim transform objects based on a specifie
 ## SYNTAX
 
 ### Filter (Default)
+
 ```
-Get-ADClaimTransformPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>] -Filter <String>
- [-Properties <String[]>] [-Server <String>] [<CommonParameters>]
+Get-ADClaimTransformPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>]
+ -Filter <String> [-Properties <String[]>] [-Server <String>] [<CommonParameters>]
 ```
 
 ### Identity
+
 ```
 Get-ADClaimTransformPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>]
- [[-Identity] <ADClaimTransformPolicy>] [-Properties <String[]>] [-Server <String>] [<CommonParameters>]
+ [[-Identity] <ADClaimTransformPolicy>] [-Properties <String[]>] [-Server <String>]
+ [<CommonParameters>]
 ```
 
 ### LdapFilter
+
 ```
-Get-ADClaimTransformPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>] -LDAPFilter <String>
- [-Properties <String[]>] [-Server <String>] [<CommonParameters>]
+Get-ADClaimTransformPolicy [-AuthType <ADAuthType>] [-Credential <PSCredential>]
+ -LDAPFilter <String> [-Properties <String[]>] [-Server <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-ADClaimTransformPolicy** cmdlet returns one or more Active Directory claim transform objects based on a specified filter.
+
+The `Get-ADClaimTransformPolicy` cmdlet returns one or more Active Directory claim transform objects
+based on a specified filter.
 
 ## EXAMPLES
 
 ### Example 1: Get a list of all claims transformation policies
-```
-PS C:\> Get-ADClaimTransformPolicy -Filter *
+
+```powershell
+Get-ADClaimTransformPolicy -Filter *
 ```
 
 This command retrieves a list of all claims transformation policies.
 
 ### Example 2: Get all the claims transformation policies that are applied to a specific trust
-```
-PS C:\> $Contoso = Get-ADTrust -Identity "corp.contoso.com"
-PS C:\> Get-ADClaimTransformPolicy -Filter "IncomingTrust -eq '$Contoso' -or OutgoingTrust -eq '$Contoso'"
+
+```powershell
+$trust = Get-ADTrust -Identity "corp.contoso.com"
+$filter = "IncomingTrust -eq '$trust' -or OutgoingTrust -eq '$trust'"
+Get-ADClaimTransformPolicy -Filter $filter
 ```
 
-This example gets all the claims transformation policies that are applied to trusts made with corp.contoso.com.
+This example gets all the claims transformation policies that are applied to trusts made with
+`corp.contoso.com`.
 
 ### Example 3: Get the claims transformation policy with a specify policy name
-```
-PS C:\> Get-ADClaimTransformPolicy -Identity DenyAllPolicy
+
+```powershell
+Get-ADClaimTransformPolicy -Identity DenyAllPolicy
 ```
 
-This command gets the claims transformation policy with the name DenyAllPolicy.
+This command gets the claims transformation policy with the name `DenyAllPolicy`.
 
 ### Example 4: Get information on claims using a LDAP based query filter
-```
-PS C:\> Get-ADClaimTransformPolicy -LDAPFilter "(name=DenyAll*)"
+
+```powershell
+Get-ADClaimTransformPolicy -LDAPFilter "(name=DenyAll*)"
 ```
 
-This command gets information on any claims transformation policies using an LDAP-based query filter that looks for matches where policies have a name that starts with the word DenyAll.
+This command gets information on any claims transformation policies using an LDAP-based query filter
+that looks for matches where policies have a name that starts with the word `DenyAll`.
 
 ## PARAMETERS
 
 ### -AuthType
+
 Specifies the authentication method to use.
 The acceptable values for this parameter are:
 
-- Negotiate or 0
-- Basic or 1
+- `Negotiate` or `0`
+- `Basic` or `1`
 
-The default authentication method is Negotiate.
+The default authentication method is `Negotiate`.
 
-A Secure Sockets Layer (SSL) connection is required for the Basic authentication method.
+A Secure Sockets Layer (SSL) connection is required for the `Basic` authentication method.
 
 ```yaml
-Type: ADAuthType
+Type: Microsoft.ActiveDirectory.Management.ADAuthType
 Parameter Sets: (All)
 Aliases: 
 Accepted values: Negotiate, Basic
@@ -94,20 +108,24 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the user account credentials to use to perform this task.
-The default credentials are the credentials of the currently logged on user unless the cmdlet is run from an Active Directory module for Windows PowerShell provider drive.
-If the cmdlet is run from such a provider drive, the account associated with the drive is the default.
 
-To specify this parameter, you can type a user name, such as User1 or Domain01\User01 or you can specify a **PSCredential** object.
-If you specify a user name for this parameter, the cmdlet prompts for a password.
+Specifies the user account credentials to use to perform this task. The default credentials are the
+credentials of the currently logged on user unless the cmdlet is run from an Active Directory module
+for Windows PowerShell provider drive. If the cmdlet is run from such a provider drive, the account
+associated with the drive is the default.
 
-You can also create a **PSCredential** object by using a script or by using the **Get-Credential** cmdlet.
-You can then set the *Credential* parameter to the **PSCredential** object.
+To specify this parameter, you can type a user name, such as `User1` or `Domain01\User01` or you can
+specify a **PSCredential** object. If you specify a user name for this parameter, the cmdlet prompts
+for a password.
 
-If the acting credentials do not have directory-level permission to perform the task, Active Directory module for Windows PowerShell returns a terminating error.
+You can also create a **PSCredential** object by using a script or by using the `Get-Credential`
+cmdlet. You can then set the **Credential** parameter to the **PSCredential** object.
+
+If the acting credentials do not have directory-level permission to perform the task, Active
+Directory module for Windows PowerShell returns a terminating error.
 
 ```yaml
-Type: PSCredential
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases: 
 
@@ -119,38 +137,36 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
-Specifies a query string that retrieves Active Directory objects.
-This string uses the Windows PowerShell Expression Language syntax.
-The Windows PowerShell Expression Language syntax provides rich type-conversion support for value types received by the *Filter* parameter.
-The syntax uses an in-order representation, which means that the operator is placed between the operand and the value.
-For more information about the *Filter* parameter, type `Get-Help about_ActiveDirectory_Filter`.
 
-Syntax:
+Specifies a query string that retrieves Active Directory Domain Services objects. This string uses
+the Windows PowerShell expression language syntax. The Windows PowerShell expression language syntax
+provides rich type-conversion support for value types received by the **Filter** parameter.
 
-The following syntax uses Backus-Naur form to show how to use the Windows PowerShell Expression Language for this parameter.
+Specify the **Filter** parameter in one of the following formats:
 
-\<filter\>  ::= "{" \<FilterComponentList\> "}"
+- To match a single filter element: `{Attribute operator "value"}`
+- To match multiple filter elements:
+  `{(Attribute1 operator1 "value1") joinOperator (Attribute2 operator2 "value2")}`
 
-\<FilterComponentList\> ::= \<FilterComponent\> | \<FilterComponent\> \<JoinOperator\> \<FilterComponent\> | \<NotOperator\>  \<FilterComponent\>
+Windows PowerShell wildcards other than `*`, such as `?`, are not supported by the **Filter**
+syntax.
 
-\<FilterComponent\> ::= \<attr\> \<FilterOperator\> \<value\> | "(" \<FilterComponent\> ")"
+Valid filter operators are:
 
-\<FilterOperator\> ::= "-eq" | "-le" | "-ge" | "-ne" | "-lt" | "-gt"| "-approx" | "-bor" | "-band" | "-recursivematch" | "-like" | "-notlike"
+ `-eq`, `-le`, `-ge`, `-ne`, `-lt`, `-gt`, `-approx`, `-bor`, `-band`, `-recursivematch`, `-like`,
+ `-notlike`
 
-\<JoinOperator\> ::= "-and" | "-or"
+Valid join operators are:
 
-\<NotOperator\> ::= "-not"
+`-and`, `-or`
 
-\<attr\> ::= \<PropertyName\> | \<LDAPDisplayName of the attribute\>
+The not operator is `-not`.
 
-\<value\>::= \<compare this value with an \<attr\> by using the specified \<FilterOperator\>\>
-
-For a list of supported types for \<value\>, see about_ActiveDirectory_ObjectModel.
-
-Note: To query using Lightweight Directory Access Protocol (LDAP) query strings, use the *LDAPFilter* parameter.
+For a list of supported types for values, see `about_ActiveDirectory_ObjectModel`. For more
+information about the **Filter** parameter, see `about_ActiveDirectory_Filter`.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: Filter
 Aliases: 
 
@@ -162,19 +178,21 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specifies an Active Directory object by providing one of the following property values.
-The identifier in parentheses is the LDAP display name for the attribute.
-The acceptable values for this parameter are:
+
+Specifies an Active Directory object by providing one of the following property values. The
+identifier in parentheses is the LDAP display name for the attribute. The acceptable values for this
+parameter are:
 
 - A distinguished name
 
-The cmdlet searches the default naming context or partition to find the object.
-If two or more objects are found, the cmdlet returns a non-terminating error.
+The cmdlet searches the default naming context or partition to find the object. If two or more
+objects are found, the cmdlet returns a non-terminating error.
 
-This parameter can also get this object through the pipeline or you can set this parameter to an object instance.
+This parameter can also get this object through the pipeline or you can set this parameter to an
+object instance.
 
 ```yaml
-Type: ADClaimTransformPolicy
+Type: Microsoft.ActiveDirectory.Management.ADClaimTransformPolicy
 Parameter Sets: Identity
 Aliases: 
 
@@ -186,13 +204,12 @@ Accept wildcard characters: False
 ```
 
 ### -LDAPFilter
-Specifies an LDAP query string that is used to filter Active Directory objects.
-You can use this parameter to run your existing LDAP queries.
-The *Filter* parameter syntax supports the same functionality as the LDAP syntax.
-For more information, see the *Filter* parameter description or type `Get-Help about_ActiveDirectory_Filter`.
+
+Specifies a filter using the LDAP search filter syntax defined in RFC2254 to filter Active Directory
+Domain Services objects.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: LdapFilter
 Aliases: 
 
@@ -204,19 +221,18 @@ Accept wildcard characters: False
 ```
 
 ### -Properties
-Specifies the properties of the output object to retrieve from the server.
-Use this parameter to retrieve properties that are not included in the default set.
 
-Specify properties for this parameter as a comma-separated list of names.
-To display all of the attributes that are set on the object, specify * (asterisk).
+Specifies the properties of the output object to get from the server. Use this parameter to get
+properties that are not included in the default set.
 
-To specify an individual extended property, use the name of the property.
-For properties that are not default or extended properties, you must specify the LDAP display name of the attribute.
+Specify the properties to get as a comma separated list of names. To display
+all of the properties that are set on the object, specify an asterisk (`*`) wildcard.
 
-To retrieve properties and display them for an object, you can use the Get-* cmdlet associated with the object and pass the output to the **Get-Member** cmdlet.
+To specify an individual extended property, use the name of the property. For properties that are
+not default or extended properties, you must specify the LDAP display name of the attribute.
 
 ```yaml
-Type: String[]
+Type: System.String[]
 Parameter Sets: (All)
 Aliases: Property
 
@@ -228,30 +244,35 @@ Accept wildcard characters: False
 ```
 
 ### -Server
-Specifies the Active Directory Domain Services instance to connect to, by providing one of the following values for a corresponding domain name or directory server.
-The service may be any of the following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active Directory snapshot instance.
 
-Specify the Active Directory Domain Services instance in one of the following ways:  
+Specifies the Active Directory Domain Services instance to connect to, by providing one of the
+following values for a corresponding domain name or directory server. The service may be any of the
+following: Active Directory Lightweight Domain Services, Active Directory Domain Services or Active
+Directory snapshot instance.
+
+Specify the Active Directory Domain Services instance in one of the following ways:
 
 Domain name values:
 
 - Fully qualified domain name
 - NetBIOS name
 
-Directory server values: 
+Directory server values:
 
 - Fully qualified directory server name
 - NetBIOS name
 - Fully qualified directory server name and port
 
-The default value for this parameter is determined by one of the following methods in the order that they are listed:
+The default value for this parameter is determined by one of the following methods in the order that
+they are listed:
 
-- By using the *Server* value from objects passed through the pipeline
-- By using the server information associated with the Active Directory Domain Services Windows PowerShell provider drive, when the cmdlet runs in that drive
+- By using the **Server** value from objects passed through the pipeline
+- By using the server information associated with the Active Directory Domain Services Windows
+  PowerShell provider drive, when the cmdlet runs in that drive
 - By using the domain of the computer running Windows PowerShell
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: (All)
 Aliases: 
 
@@ -263,12 +284,17 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None or Microsoft.ActiveDirectory.Management.ADClaimTransformPolicy
-A claim transform policy object is received by the *Identity* parameter.
+
+A claim transform policy object is received by the **Identity** parameter.
 
 ## OUTPUTS
 
@@ -285,4 +311,3 @@ A claim transform policy object is received by the *Identity* parameter.
 [Set-ADClaimTransformPolicy](./Set-ADClaimTransformPolicy.md)
 
 [AD DS Administration Cmdlets in Windows PowerShell](./activedirectory.md)
-


### PR DESCRIPTION
# PR Summary

This change fixes formatting in a handful of articles for the ActiveDirectory module

- Fixes #3490 

Articles Addressed:

- Disable-ADOptionalFeature.md
- Enable-ADAccount.md
- Enable-ADOptionalFeature.md
- Get-ADAccountAuthorizationGroup.md
- Get-ADAccountResultantPasswordReplicationPolicy.md
- Get-ADAuthenticationPolicy.md
- Get-ADAuthenticationPolicySilo.md
- Get-ADCentralAccessPolicy.md
- Get-ADCentralAccessRule.md
- Get-ADClaimTransformPolicy.md

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
