### PR TITLE
Update Set-DnsServerRecursion.md

### DIFF
--- a/docset/winserver2012-ps/dnsserver/Set-DnsServerRecursion.md
+++ b/docset/winserver2012-ps/dnsserver/Set-DnsServerRecursion.md
@@ -197,7 +197,7 @@ Accept wildcard characters: False
 ### -Timeout
 Determines the number of seconds that a DNS server waits before it stops trying to contact a remote server.
 The valid value is in the range of 0x1 to 0xFFFFFFFF (1 second to 15 seconds).
-The default setting is 0xF (15 seconds).
+The default setting is 0x8 (8 seconds).
 We recommend that you increase this value when recursion occurs over a slow link.
 
 ```yaml

--- a/docset/winserver2012r2-ps/dnsserver/Set-DnsServerRecursion.md
+++ b/docset/winserver2012r2-ps/dnsserver/Set-DnsServerRecursion.md
@@ -214,7 +214,7 @@ Accept wildcard characters: False
 ### -Timeout
 Determines the number of seconds that a DNS server waits before it stops trying to contact a remote server.
 The valid value is in the range of 0x1 to 0xFFFFFFFF (1 second to 15 seconds).
-The default setting is 0xF (15 seconds).
+The default setting is 0x8 (8 seconds).
 We recommend that you increase this value when recursion occurs over a slow link.
 
 ```yaml

--- a/docset/winserver2016-ps/dnsserver/Set-DnsServerRecursion.md
+++ b/docset/winserver2016-ps/dnsserver/Set-DnsServerRecursion.md
@@ -219,7 +219,7 @@ Accept wildcard characters: False
 ### -Timeout
 Specifies the number of seconds that a DNS server waits before it stops trying to contact a remote server.
 The valid value is in the range of 0x1 to 0xFFFFFFFF (1 second to 15 seconds).
-The default setting is 0xF (15 seconds).
+The default setting is 0x8 (8 seconds).
 We recommend that you increase this value when recursion occurs over a slow link.
 
 ```yaml

--- a/docset/winserver2019-ps/dnsserver/Set-DnsServerRecursion.md
+++ b/docset/winserver2019-ps/dnsserver/Set-DnsServerRecursion.md
@@ -219,7 +219,7 @@ Accept wildcard characters: False
 ### -Timeout
 Specifies the number of seconds that a DNS server waits before it stops trying to contact a remote server.
 The valid value is in the range of 0x1 to 0xFFFFFFFF (1 second to 15 seconds).
-The default setting is 0xF (15 seconds).
+The default setting is 0x8 (8 seconds).
 We recommend that you increase this value when recursion occurs over a slow link.
 
 ```yaml

--- a/docset/winserver2022-ps/dnsserver/Set-DnsServerRecursion.md
+++ b/docset/winserver2022-ps/dnsserver/Set-DnsServerRecursion.md
@@ -219,7 +219,7 @@ Accept wildcard characters: False
 ### -Timeout
 Specifies the number of seconds that a DNS server waits before it stops trying to contact a remote server.
 The valid value is in the range of 0x1 to 0xFFFFFFFF (1 second to 15 seconds).
-The default setting is 0xF (15 seconds).
+The default setting is 0x8 (8 seconds).
 We recommend that you increase this value when recursion occurs over a slow link.
 
 ```yaml


### PR DESCRIPTION
Changed the default value for the recursive timeout to 8 seconds

fixes https://github.com/MicrosoftDocs/windows-powershell-docs/issues/3152