### PR TITLE
(MAINT) Fix `*-VHDSnapshot` for updateable help

### DIFF
--- a/docset/winserver2022-ps/hyper-v/Get-VHDSnapshot.md
+++ b/docset/winserver2022-ps/hyper-v/Get-VHDSnapshot.md
@@ -166,4 +166,4 @@ This cmdlet returns a **VHDSnapshotInfo** object.
 
 ## RELATED LINKS
 
-- [Remove-VHDSnapshot](remove-vhdsnapshot.md)
+[Remove-VHDSnapshot](remove-vhdsnapshot.md)

--- a/docset/winserver2022-ps/hyper-v/Remove-VHDSnapshot.md
+++ b/docset/winserver2022-ps/hyper-v/Remove-VHDSnapshot.md
@@ -239,4 +239,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-- [Get-VHDSnapshot](get-vhdsnapshot.md)
+[Get-VHDSnapshot](get-vhdsnapshot.md)


### PR DESCRIPTION


# PR Summary

Prior to this change, the `*-VHDSnapshot` cmdlet reference docs included the links in the related links section as list items, which broke the updateable help build. This change returns the links to one-link-per-paragraph instead.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
