### PR TITLE
fix an un-escaped asterisk in rename network adapter

### DIFF
--- a/docset/winserver2022-ps/netadapter/Rename-NetAdapter.md
+++ b/docset/winserver2022-ps/netadapter/Rename-NetAdapter.md
@@ -51,8 +51,8 @@ This command renames a network adapter from the current name of Ethernet to the 
 PS C:\> Rename-NetAdapter -Name "E*t" -NewName "ManagementAdapter"
 ```
 
-This command renames a network adapter from the current name, by matching the pattern e*t, to the new name ManagementAdapter.
-A typical match of e*t is the default name Ethernet.
+This command renames a network adapter from the current name, by matching the pattern e\*t, to the new name ManagementAdapter.
+A typical match of e\*t is the default name Ethernet.
 
 ## PARAMETERS
 


### PR DESCRIPTION
fix the expression matching error

# PR Summary

fix a simple typo / error in the rename network adapter file

## PR Checklist


- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].


[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
