### PR TITLE
Update the descriptions of throttling rate to match the result of sample commands in New-NetQosPolicy

### DIFF
--- a/docset/winserver2012-ps/netqos/New-NetQosPolicy.md
+++ b/docset/winserver2012-ps/netqos/New-NetQosPolicy.md
@@ -140,7 +140,7 @@ AppPathName    : ftp.exe
 ThrottleRate   : 1.049 MBits/sec
 ```
 
-This example creates a QoS policy named FTP, that matches an application path at ftp.exe and throttles the traffic at 1,000,000 bytes per second.
+This example creates a QoS policy named FTP, that matches an application path at ftp.exe and throttles the traffic at 1 MBits per second.
 This policy is ActiveStore, meaning that it is not persistent after reboot of the computer. 
 
 An alias for the **ThrottleRateActionBytesPerSecond** parameter is `MaxBw`.
@@ -172,7 +172,7 @@ IPPort         : 80
 ThrottleRate   : 10.486 MBits/sec
 ```
 
-This example creates a QoS policy that matches TCP traffic sent to port 80 and rate-limits it at 10,000,000 bytes per second.
+This example creates a QoS policy that matches TCP traffic sent to port 80 and rate-limits it at 10 MBits per second.
 
 ### EXAMPLE 5
 ```
@@ -199,7 +199,7 @@ URIRecursive   : False
 ThrottleRate   : 516.096 KBits/sec
 ```
 
-This example creates a QoS policy named IIS, that matches return traffic from an HTTP server application with the specified URI and rate limit the return traffic at 500,000 bytes per second.
+This example creates a QoS policy named IIS, that matches return traffic from an HTTP server application with the specified URI and rate limit the return traffic at 500 KBits per second.
 
 ## PARAMETERS
 

--- a/docset/winserver2012r2-ps/netqos/New-NetQosPolicy.md
+++ b/docset/winserver2012r2-ps/netqos/New-NetQosPolicy.md
@@ -151,7 +151,7 @@ AppPathName    : ftp.exe
 ThrottleRate   : 1.049 MBits/sec
 ```
 
-This example creates a QoS policy named FTP, that matches an application path at ftp.exe and throttles the traffic at 1,000,000 bytes per second.
+This example creates a QoS policy named FTP, that matches an application path at ftp.exe and throttles the traffic at 1 MBits per second.
 This policy is ActiveStore, meaning that it is not persistent after reboot of the computer. 
                          
 An alias for the **ThrottleRateActionBytesPerSecond** parameter is `MaxBw`.
@@ -183,7 +183,7 @@ IPPort         : 80
 ThrottleRate   : 10.486 MBits/sec
 ```
 
-This example creates a QoS policy that matches TCP traffic sent to port 80 and rate-limits it at 10,000,000 bytes per second.
+This example creates a QoS policy that matches TCP traffic sent to port 80 and rate-limits it at 10 MBits per second.
 
 ### EXAMPLE 5
 ```
@@ -210,7 +210,7 @@ URIRecursive   : False
 ThrottleRate   : 516.096 KBits/sec
 ```
 
-This example creates a QoS policy named IIS, that matches return traffic from an HTTP server application with the specified URI and rate limit the return traffic at 500,000 bytes per second.
+This example creates a QoS policy named IIS, that matches return traffic from an HTTP server application with the specified URI and rate limit the return traffic at 500 KBits per second.
 
 ## PARAMETERS
 

--- a/docset/winserver2016-ps/netqos/New-NetQosPolicy.md
+++ b/docset/winserver2016-ps/netqos/New-NetQosPolicy.md
@@ -152,7 +152,7 @@ AppPathName    : ftp.exe
 ThrottleRate   : 1.049 MBits/sec
 ```
 
-This command creates a QoS policy named FTP that matches an application path at ftp.exe and throttles the traffic at 8,000,000 bits per second.
+This command creates a QoS policy named FTP, that matches an application path at ftp.exe and throttles the traffic at 1 MBits per second.
 This policy is ActiveStore.
 This means that it is not persistent after restart of the computer.
 
@@ -183,7 +183,7 @@ IPPort         : 80
 ThrottleRate   : 10.486 MBits/sec
 ```
 
-This command creates a QoS policy that matches TCP traffic sent to port 80 and rate-limits it at 80,000,000 bits per second.
+This command creates a QoS policy that matches TCP traffic sent to port 80 and rate-limits it at 10 MBits per second.
 
 ### Example 5: Create a default QoS policy
 ```
@@ -210,7 +210,7 @@ URIRecursive   : False
 ThrottleRate   : 516.096 KBits/sec
 ```
 
-This command creates a QoS policy named IIS that matches return traffic from an HTTP server application with the specified URI and rate limit the return traffic at 4,000,000 bits per second.
+This command creates a QoS policy named IIS that matches return traffic from an HTTP server application with the specified URI and rate limit the return traffic at 516.096 KBits per second.
 
 ## PARAMETERS
 

--- a/docset/winserver2019-ps/netqos/New-NetQosPolicy.md
+++ b/docset/winserver2019-ps/netqos/New-NetQosPolicy.md
@@ -152,7 +152,7 @@ AppPathName    : ftp.exe
 ThrottleRate   : 1.049 MBits/sec
 ```
 
-This command creates a QoS policy named FTP that matches an application path at ftp.exe and throttles the traffic at 8,000,000 bits per second.
+This command creates a QoS policy named FTP that matches an application path at ftp.exe and throttles the traffic at 1.049 MBits per second.
 This policy is ActiveStore.
 This means that it is not persistent after restart of the computer.
 
@@ -183,7 +183,7 @@ IPPort         : 80
 ThrottleRate   : 10.486 MBits/sec
 ```
 
-This command creates a QoS policy that matches TCP traffic sent to port 80 and rate-limits it at 80,000,000 bits per second.
+This command creates a QoS policy that matches TCP traffic sent to port 80 and rate-limits it at 10.486 MBits per second.
 
 ### Example 5: Create a default QoS policy
 ```
@@ -210,7 +210,7 @@ URIRecursive   : False
 ThrottleRate   : 516.096 KBits/sec
 ```
 
-This command creates a QoS policy named IIS that matches return traffic from an HTTP server application with the specified URI and rate limit the return traffic at 4,000,000 bits per second.
+This command creates a QoS policy named IIS that matches return traffic from an HTTP server application with the specified URI and rate limit the return traffic at 516.096 KBits per second.
 
 ## PARAMETERS
 

--- a/docset/winserver2022-ps/netqos/New-NetQosPolicy.md
+++ b/docset/winserver2022-ps/netqos/New-NetQosPolicy.md
@@ -152,7 +152,7 @@ AppPathName    : ftp.exe
 ThrottleRate   : 1.049 MBits/sec
 ```
 
-This command creates a QoS policy named FTP that matches an application path at ftp.exe and throttles the traffic at 8,000,000 bits per second.
+This command creates a QoS policy named FTP that matches an application path at ftp.exe and throttles the traffic at 1.049 MBits per second.
 This policy is ActiveStore.
 This means that it is not persistent after restart of the computer.
 
@@ -183,7 +183,7 @@ IPPort         : 80
 ThrottleRate   : 10.486 MBits/sec
 ```
 
-This command creates a QoS policy that matches TCP traffic sent to port 80 and rate-limits it at 80,000,000 bits per second.
+This command creates a QoS policy that matches TCP traffic sent to port 80 and rate-limits it at 10.486 MBits per second.
 
 ### Example 5: Create a default QoS policy
 ```
@@ -210,7 +210,7 @@ URIRecursive   : False
 ThrottleRate   : 516.096 KBits/sec
 ```
 
-This command creates a QoS policy named IIS that matches return traffic from an HTTP server application with the specified URI and rate limit the return traffic at 4,000,000 bits per second.
+This command creates a QoS policy named IIS that matches return traffic from an HTTP server application with the specified URI and rate limit the return traffic at 516.096 KBits per second.
 
 ## PARAMETERS
 


### PR DESCRIPTION
# PR Summary

The throttling rate shows in bits, not bytes.
#2559 corrects the result of the sample commands, but the descriptions are still incorrect.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
