### PR TITLE
Update New-IscsiServerTarget.md

### DIFF
--- a/docset/winserver2022-ps/iscsitarget/New-IscsiServerTarget.md
+++ b/docset/winserver2022-ps/iscsitarget/New-IscsiServerTarget.md
@@ -114,7 +114,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetName
-Specifies the name of the iSCSI target.
+Specifies the name of the iSCSI target. Note that the underscore character is not supported in the target name.
 
 ```yaml
 Type: String


### PR DESCRIPTION
During my testing, I found that the underscore character is not allowed in the target name. Attempting to include it results in the following error:

> New-IscsiServerTarget : Unable to create the iSCSI target.

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [ ] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [ ] **Summary:** This PR's summary describes the scope and intent of the change.
- [ ] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [ ] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
