### PR TITLE
Add the missing critical info for the two BitLocker cmdlets

### DIFF
--- a/docset/winserver2012-ps/bitlocker/Add-BitLockerKeyProtector.md
+++ b/docset/winserver2012-ps/bitlocker/Add-BitLockerKeyProtector.md
@@ -275,10 +275,19 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPassword
-Specifies a recovery password.
-If you do not specify this parameter, the cmdlet creates a random password.
-You can enter a 48 digit password.
-The cmdlet adds the password specified or created as a protector for the volume encryption key.
+Specifies a recovery password. The cmdlet adds the password specified or created as a protector for the volume encryption key.
+If you do not specify this parameter (but specify `-RecoveryPasswordProtector`, the cmdlet creates a random recovery password.
+
+A recovery password has rigid requirements. It must consist of 48 digits. Each six must be divisible by 11. For example, the
+following is acceptable:
+
+    '147279-525107-204677-117612-367510-356554-273911-527274'
+
+The following is **not** acceptable:
+
+    '702510-071786-013337-543770-555603-414075-635673-114355'
+
+In the example above, only the second segment is divisible by 11. The others are not.
 
 ```yaml
 Type: String

--- a/docset/winserver2012-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2012-ps/bitlocker/Enable-BitLocker.md
@@ -395,12 +395,19 @@ Accept wildcard characters: False
 
 ### -RecoveryPassword
 
-Specifies a recovery password.
-If you do not specify this parameter but include the *RecoveryPasswordProtector* parameter, the cmdlet creates a random password.
+Specifies a recovery password. The cmdlet adds the password specified or created as a protector for the volume encryption key.
+If you do not specify this parameter (but specify `-RecoveryPasswordProtector`, the cmdlet creates a random recovery password.
 
-You can enter a 48-digit password.
+A recovery password has rigid requirements. It must consist of 48 digits. Each six must be divisible by 11. For example, the
+following is acceptable:
 
-The password specified or created acts as a protector for the volume encryption key.
+    '147279-525107-204677-117612-367510-356554-273911-527274'
+
+The following is **not** acceptable:
+
+    '702510-071786-013337-543770-555603-414075-635673-114355'
+
+In the example above, only the second segment is divisible by 11. The others are not.
 
 ```yaml
 Type: String

--- a/docset/winserver2012r2-ps/bitlocker/Add-BitLockerKeyProtector.md
+++ b/docset/winserver2012r2-ps/bitlocker/Add-BitLockerKeyProtector.md
@@ -294,10 +294,19 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPassword
-Specifies a recovery password.
-If you do not specify this parameter, the cmdlet creates a random password.
-You can enter a 48 digit password.
-The cmdlet adds the password specified or created as a protector for the volume encryption key.
+Specifies a recovery password. The cmdlet adds the password specified or created as a protector for the volume encryption key.
+If you do not specify this parameter (but specify `-RecoveryPasswordProtector`, the cmdlet creates a random recovery password.
+
+A recovery password has rigid requirements. It must consist of 48 digits. Each six must be divisible by 11. For example, the
+following is acceptable:
+
+    '147279-525107-204677-117612-367510-356554-273911-527274'
+
+The following is **not** acceptable:
+
+    '702510-071786-013337-543770-555603-414075-635673-114355'
+
+In the example above, only the second segment is divisible by 11. The others are not.
 
 ```yaml
 Type: String

--- a/docset/winserver2012r2-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2012r2-ps/bitlocker/Enable-BitLocker.md
@@ -395,12 +395,19 @@ Accept wildcard characters: False
 
 ### -RecoveryPassword
 
-Specifies a recovery password.
-If you do not specify this parameter but include the *RecoveryPasswordProtector* parameter, the cmdlet creates a random password.
+Specifies a recovery password. The cmdlet adds the password specified or created as a protector for the volume encryption key.
+If you do not specify this parameter (but specify `-RecoveryPasswordProtector`, the cmdlet creates a random recovery password.
 
-You can enter a 48-digit password.
+A recovery password has rigid requirements. It must consist of 48 digits. Each six must be divisible by 11. For example, the
+following is acceptable:
 
-The password specified or created acts as a protector for the volume encryption key.
+    '147279-525107-204677-117612-367510-356554-273911-527274'
+
+The following is **not** acceptable:
+
+    '702510-071786-013337-543770-555603-414075-635673-114355'
+
+In the example above, only the second segment is divisible by 11. The others are not.
 
 ```yaml
 Type: String

--- a/docset/winserver2016-ps/bitlocker/Add-BitLockerKeyProtector.md
+++ b/docset/winserver2016-ps/bitlocker/Add-BitLockerKeyProtector.md
@@ -295,10 +295,19 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPassword
-Specifies a recovery password.
-If you do not specify this parameter, the cmdlet creates a random password.
-You can enter a 48 digit password.
-The cmdlet adds the password specified or created as a protector for the volume encryption key.
+Specifies a recovery password. The cmdlet adds the password specified or created as a protector for the volume encryption key.
+If you do not specify this parameter (but specify `-RecoveryPasswordProtector`, the cmdlet creates a random recovery password.
+
+A recovery password has rigid requirements. It must consist of 48 digits. Each six must be divisible by 11. For example, the
+following is acceptable:
+
+    '147279-525107-204677-117612-367510-356554-273911-527274'
+
+The following is **not** acceptable:
+
+    '702510-071786-013337-543770-555603-414075-635673-114355'
+
+In the example above, only the second segment is divisible by 11. The others are not.
 
 ```yaml
 Type: String

--- a/docset/winserver2016-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2016-ps/bitlocker/Enable-BitLocker.md
@@ -395,10 +395,19 @@ Accept wildcard characters: False
 
 ### -RecoveryPassword
 
-Specifies a recovery password.
-If you do not specify this parameter, but you do include the *RecoveryPasswordProtector* parameter, the cmdlet creates a random password.
-You can enter a 48-digit password.
-The password specified or created acts as a protector for the volume encryption key.
+Specifies a recovery password. The cmdlet adds the password specified or created as a protector for the volume encryption key.
+If you do not specify this parameter (but specify `-RecoveryPasswordProtector`, the cmdlet creates a random recovery password.
+
+A recovery password has rigid requirements. It must consist of 48 digits. Each six must be divisible by 11. For example, the
+following is acceptable:
+
+    '147279-525107-204677-117612-367510-356554-273911-527274'
+
+The following is **not** acceptable:
+
+    '702510-071786-013337-543770-555603-414075-635673-114355'
+
+In the example above, only the second segment is divisible by 11. The others are not.
 
 ```yaml
 Type: String

--- a/docset/winserver2019-ps/bitlocker/Add-BitLockerKeyProtector.md
+++ b/docset/winserver2019-ps/bitlocker/Add-BitLockerKeyProtector.md
@@ -295,10 +295,19 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPassword
-Specifies a recovery password.
-If you do not specify this parameter, the cmdlet creates a random password.
-You can enter a 48 digit password.
-The cmdlet adds the password specified or created as a protector for the volume encryption key.
+Specifies a recovery password. The cmdlet adds the password specified or created as a protector for the volume encryption key.
+If you do not specify this parameter (but specify `-RecoveryPasswordProtector`, the cmdlet creates a random recovery password.
+
+A recovery password has rigid requirements. It must consist of 48 digits. Each six must be divisible by 11. For example, the
+following is acceptable:
+
+    '147279-525107-204677-117612-367510-356554-273911-527274'
+
+The following is **not** acceptable:
+
+    '702510-071786-013337-543770-555603-414075-635673-114355'
+
+In the example above, only the second segment is divisible by 11. The others are not.
 
 ```yaml
 Type: String

--- a/docset/winserver2019-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2019-ps/bitlocker/Enable-BitLocker.md
@@ -394,11 +394,19 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPassword
+Specifies a recovery password. The cmdlet adds the password specified or created as a protector for the volume encryption key.
+If you do not specify this parameter (but specify `-RecoveryPasswordProtector`, the cmdlet creates a random recovery password.
 
-Specifies a recovery password.
-If you do not specify this parameter, but you do include the *RecoveryPasswordProtector* parameter, the cmdlet creates a random password.
-You can enter a 48-digit password.
-The password specified or created acts as a protector for the volume encryption key.
+A recovery password has rigid requirements. It must consist of 48 digits. Each six must be divisible by 11. For example, the
+following is acceptable:
+
+    '147279-525107-204677-117612-367510-356554-273911-527274'
+
+The following is **not** acceptable:
+
+    '702510-071786-013337-543770-555603-414075-635673-114355'
+
+In the example above, only the second segment is divisible by 11. The others are not.
 
 ```yaml
 Type: String

--- a/docset/winserver2022-ps/bitlocker/Add-BitLockerKeyProtector.md
+++ b/docset/winserver2022-ps/bitlocker/Add-BitLockerKeyProtector.md
@@ -295,10 +295,19 @@ Accept wildcard characters: False
 ```
 
 ### -RecoveryPassword
-Specifies a recovery password.
+Specifies a recovery password. The cmdlet adds the password specified or created as a protector for the volume encryption key.
 If you do not specify this parameter, the cmdlet creates a random password.
-You can enter a 48 digit password.
-The cmdlet adds the password specified or created as a protector for the volume encryption key.
+
+A recovery password has rigid requirements. It must consist of 48 digits. Each 6 must be divisible by 11. For example, the
+following is acceptable:
+
+    '147279-525107-204677-117612-367510-356554-273911-527274'
+
+The following is **not** acceptable:
+
+    '702510-071786-013337-543770-555603-414075-635673-114355'
+
+In the example above, only the second segment is divisible by 11. The others are not.
 
 ```yaml
 Type: String

--- a/docset/winserver2022-ps/bitlocker/Add-BitLockerKeyProtector.md
+++ b/docset/winserver2022-ps/bitlocker/Add-BitLockerKeyProtector.md
@@ -296,9 +296,9 @@ Accept wildcard characters: False
 
 ### -RecoveryPassword
 Specifies a recovery password. The cmdlet adds the password specified or created as a protector for the volume encryption key.
-If you do not specify this parameter, the cmdlet creates a random password.
+If you do not specify this parameter (but specify `-RecoveryPasswordProtector`, the cmdlet creates a random recovery password.
 
-A recovery password has rigid requirements. It must consist of 48 digits. Each 6 must be divisible by 11. For example, the
+A recovery password has rigid requirements. It must consist of 48 digits. Each six must be divisible by 11. For example, the
 following is acceptable:
 
     '147279-525107-204677-117612-367510-356554-273911-527274'

--- a/docset/winserver2022-ps/bitlocker/Enable-BitLocker.md
+++ b/docset/winserver2022-ps/bitlocker/Enable-BitLocker.md
@@ -395,10 +395,19 @@ Accept wildcard characters: False
 
 ### -RecoveryPassword
 
-Specifies a recovery password.
-If you do not specify this parameter, but you do include the *RecoveryPasswordProtector* parameter, the cmdlet creates a random password.
-You can enter a 48-digit password.
-The password specified or created acts as a protector for the volume encryption key.
+Specifies a recovery password. The cmdlet adds the password specified or created as a protector for the volume encryption key.
+If you do not specify this parameter (but specify `-RecoveryPasswordProtector`, the cmdlet creates a random recovery password.
+
+A recovery password has rigid requirements. It must consist of 48 digits. Each six must be divisible by 11. For example, the
+following is acceptable:
+
+    '147279-525107-204677-117612-367510-356554-273911-527274'
+
+The following is **not** acceptable:
+
+    '702510-071786-013337-543770-555603-414075-635673-114355'
+
+In the example above, only the second segment is divisible by 11. The others are not.
 
 ```yaml
 Type: String


### PR DESCRIPTION
# PR Summary

This PR modifies the docs for `Add-BitLockerKeyProtector.md` and `Enable-BitLocker.md` to add critical information that was previously missing. Both cmdlets have a `-RecoveryPassword` parameter that accepts a 48-digit recovery password. However, a recovery password has rigid requirements. It must consist of 48 digits. Each six digit must be divisible by eleven (11). For example, the following is acceptable:

    '147279-525107-204677-117612-367510-356554-273911-527274'

The following is **not** acceptable:

    '702510-071786-013337-543770-555603-414075-635673-114355'

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
