### PR TITLE
Improves 'RemoteAddress' description for '*-NetFirewall*' cmdlets on supported OSes

### DIFF
--- a/docset/winserver2016-ps/netsecurity/New-NetFirewallRule.md
+++ b/docset/winserver2016-ps/netsecurity/New-NetFirewallRule.md
@@ -812,11 +812,11 @@ The acceptable formats for this parameter are:
 - Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice.
 
 > [!TIP]
-> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword `LocalSubnet4` means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
 > Querying for rules with this parameter can only be performed using filter objects.
-> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
+> See the [`Get-NetFirewallAddressFilter`](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2016-ps/netsecurity/New-NetFirewallRule.md
+++ b/docset/winserver2016-ps/netsecurity/New-NetFirewallRule.md
@@ -798,21 +798,25 @@ Accept wildcard characters: False
 ```
 
 ### -RemoteAddress
-Specifies that network packets with matching IP addresses match this rule. 
-This parameter value is an IPv4 or IPv6 address, subnet, range or keyword. 
-The acceptable formats for this parameter are: 
+Specifies that network packets with matching IP addresses match this rule.
+This parameter value is an IPv4 or IPv6 address, subnet, range or keyword.
+The acceptable formats for this parameter are:
 
-- Single IPv4 Address: 1.2.3.4 
-- Single IPv6 Address: fe80::1 
-- IPv4 Subnet (by network bit count):  1.2.3.4/24 
-- IPv6 Subnet (by network bit count):  fe80::1/48 
-- IPv4 Subnet (by network mask):  1.2.3.4/255.255.255.0 
-- IPv4 Range: 1.2.3.4-1.2.3.7 
-- IPv6 Range: fe80::1-fe80::9 
-- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice. NOTE: Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+- Single IPv4 Address: 1.2.3.4
+- Single IPv6 Address: fe80::1
+- IPv4 Subnet (by network bit count): 1.2.3.4/24
+- IPv6 Subnet (by network bit count): fe80::1/48
+- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0
+- IPv4 Range: 1.2.3.4-1.2.3.7
+- IPv6 Range: fe80::1-fe80::9
+- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice.
 
-Querying for rules with this parameter can only be performed using filter objects.
-See the Get-NetFirewallAddressFilter cmdlet for more information.
+> [!TIP]
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+
+> [!NOTE]
+> Querying for rules with this parameter can only be performed using filter objects.
+> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2016-ps/netsecurity/Set-NetFirewallAddressFilter.md
+++ b/docset/winserver2016-ps/netsecurity/Set-NetFirewallAddressFilter.md
@@ -260,11 +260,11 @@ The acceptable formats for this parameter are:
 - Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice.
 
 > [!TIP]
-> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword `LocalSubnet4` means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
 > Querying for rules with this parameter can only be performed using filter objects.
-> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
+> See the [`Get-NetFirewallAddressFilter`](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2016-ps/netsecurity/Set-NetFirewallAddressFilter.md
+++ b/docset/winserver2016-ps/netsecurity/Set-NetFirewallAddressFilter.md
@@ -246,20 +246,25 @@ Accept wildcard characters: False
 ```
 
 ### -RemoteAddress
-Specifies that network packets with matching IP addresses match this rule. 
-This parameter value is the second end point of an IPsec rule and specifies the computers that are subject to the requirements of this rule. 
-This parameter value is an IPv4 or IPv6 address, hostname, subnet, range, or the following keyword: Any. 
-The acceptable formats for this parameter are: 
-- Single IPv4 Address: 1.2.3.4 
-- Single IPv6 Address: fe80::1 
-- IPv4 Subnet (by network bit count): 1.2.3.4/24 
-- IPv6 Subnet (by network bit count): fe80::1/48 
-- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0 
-- IPv4 Range: 1.2.3.4 through 1.2.3.7 
-- IPv6 Range: fe80::1 through fe80::9 
+Specifies that network packets with matching IP addresses match this rule.
+This parameter value is an IPv4 or IPv6 address, subnet, range or keyword.
+The acceptable formats for this parameter are:
+
+- Single IPv4 Address: 1.2.3.4
+- Single IPv6 Address: fe80::1
+- IPv4 Subnet (by network bit count): 1.2.3.4/24
+- IPv6 Subnet (by network bit count): fe80::1/48
+- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0
+- IPv4 Range: 1.2.3.4-1.2.3.7
+- IPv6 Range: fe80::1-fe80::9
+- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice.
+
+> [!TIP]
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
-> Querying for rules with this parameter can only be performed using filter objects. See the **Get-NetFirewallAddressFilter** cmdlet for more information.
+> Querying for rules with this parameter can only be performed using filter objects.
+> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2016-ps/netsecurity/Set-NetFirewallRule.md
+++ b/docset/winserver2016-ps/netsecurity/Set-NetFirewallRule.md
@@ -898,19 +898,25 @@ Accept wildcard characters: False
 ```
 
 ### -RemoteAddress
-Specifies that network packets with matching IP addresses match this rule. 
-This parameter value is the second end point of an IPsec rule and specifies the computers that are subject to the requirements of this rule. 
-This parameter value is an IPv4 or IPv6 address, subnet, range, or the following keyword: Any. 
-The acceptable formats for this parameter are: 
-- Single IPv4 Address: 1.2.3.4 
-- Single IPv6 Address: fe80::1 
-- IPv4 Subnet (by network bit count): 1.2.3.4/24 
-- IPv6 Subnet (by network bit count): fe80::1/48 
-- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0 
-- IPv4 Range: 1.2.3.4 through 1.2.3.7 
-- IPv6 Range: fe80::1 through fe80::9 
-Querying for rules with this parameter can only be performed using filter objects.
-See the Get-NetFirewallAddressFilter cmdlet for more information.
+Specifies that network packets with matching IP addresses match this rule.
+This parameter value is an IPv4 or IPv6 address, subnet, range or keyword.
+The acceptable formats for this parameter are:
+
+- Single IPv4 Address: 1.2.3.4
+- Single IPv6 Address: fe80::1
+- IPv4 Subnet (by network bit count): 1.2.3.4/24
+- IPv6 Subnet (by network bit count): fe80::1/48
+- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0
+- IPv4 Range: 1.2.3.4-1.2.3.7
+- IPv6 Range: fe80::1-fe80::9
+- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice.
+
+> [!TIP]
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+
+> [!NOTE]
+> Querying for rules with this parameter can only be performed using filter objects.
+> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]
@@ -1100,4 +1106,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Set-NetFirewallSetting](./Set-NetFirewallSetting.md)
 
 [Show-NetFirewallRule](./Show-NetFirewallRule.md)
-

--- a/docset/winserver2016-ps/netsecurity/Set-NetFirewallRule.md
+++ b/docset/winserver2016-ps/netsecurity/Set-NetFirewallRule.md
@@ -912,11 +912,11 @@ The acceptable formats for this parameter are:
 - Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice.
 
 > [!TIP]
-> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword `LocalSubnet4` means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
 > Querying for rules with this parameter can only be performed using filter objects.
-> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
+> See the [`Get-NetFirewallAddressFilter`](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2019-ps/netsecurity/New-NetFirewallRule.md
+++ b/docset/winserver2019-ps/netsecurity/New-NetFirewallRule.md
@@ -798,21 +798,25 @@ Accept wildcard characters: False
 ```
 
 ### -RemoteAddress
-Specifies that network packets with matching IP addresses match this rule. 
-This parameter value is an IPv4 or IPv6 address, subnet, range or keyword. 
-The acceptable formats for this parameter are: 
+Specifies that network packets with matching IP addresses match this rule.
+This parameter value is an IPv4 or IPv6 address, subnet, range or keyword.
+The acceptable formats for this parameter are:
 
-- Single IPv4 Address: 1.2.3.4 
-- Single IPv6 Address: fe80::1 
-- IPv4 Subnet (by network bit count):  1.2.3.4/24 
-- IPv6 Subnet (by network bit count):  fe80::1/48 
-- IPv4 Subnet (by network mask):  1.2.3.4/255.255.255.0 
-- IPv4 Range: 1.2.3.4-1.2.3.7 
-- IPv6 Range: fe80::1-fe80::9 
-- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice. NOTE: Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+- Single IPv4 Address: 1.2.3.4
+- Single IPv6 Address: fe80::1
+- IPv4 Subnet (by network bit count): 1.2.3.4/24
+- IPv6 Subnet (by network bit count): fe80::1/48
+- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0
+- IPv4 Range: 1.2.3.4-1.2.3.7
+- IPv6 Range: fe80::1-fe80::9
+- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal (Windows 10 only).
 
-Querying for rules with this parameter can only be performed using filter objects.
-See the Get-NetFirewallAddressFilter cmdlet for more information.
+> [!TIP]
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+
+> [!NOTE]
+> Querying for rules with this parameter can only be performed using filter objects.
+> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2019-ps/netsecurity/New-NetFirewallRule.md
+++ b/docset/winserver2019-ps/netsecurity/New-NetFirewallRule.md
@@ -812,11 +812,11 @@ The acceptable formats for this parameter are:
 - Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal (Windows 10 only).
 
 > [!TIP]
-> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword `LocalSubnet4` means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
 > Querying for rules with this parameter can only be performed using filter objects.
-> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
+> See the [`Get-NetFirewallAddressFilter`](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2019-ps/netsecurity/Set-NetFirewallAddressFilter.md
+++ b/docset/winserver2019-ps/netsecurity/Set-NetFirewallAddressFilter.md
@@ -260,11 +260,11 @@ The acceptable formats for this parameter are:
 - Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal (Windows 10 only).
 
 > [!TIP]
-> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword `LocalSubnet4` means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
 > Querying for rules with this parameter can only be performed using filter objects.
-> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
+> See the [`Get-NetFirewallAddressFilter`](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2019-ps/netsecurity/Set-NetFirewallAddressFilter.md
+++ b/docset/winserver2019-ps/netsecurity/Set-NetFirewallAddressFilter.md
@@ -246,20 +246,25 @@ Accept wildcard characters: False
 ```
 
 ### -RemoteAddress
-Specifies that network packets with matching IP addresses match this rule. 
-This parameter value is the second end point of an IPsec rule and specifies the computers that are subject to the requirements of this rule. 
-This parameter value is an IPv4 or IPv6 address, hostname, subnet, range, or the following keyword: Any. 
-The acceptable formats for this parameter are: 
-- Single IPv4 Address: 1.2.3.4 
-- Single IPv6 Address: fe80::1 
-- IPv4 Subnet (by network bit count): 1.2.3.4/24 
-- IPv6 Subnet (by network bit count): fe80::1/48 
-- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0 
-- IPv4 Range: 1.2.3.4 through 1.2.3.7 
-- IPv6 Range: fe80::1 through fe80::9 
+Specifies that network packets with matching IP addresses match this rule.
+This parameter value is an IPv4 or IPv6 address, subnet, range or keyword.
+The acceptable formats for this parameter are:
+
+- Single IPv4 Address: 1.2.3.4
+- Single IPv6 Address: fe80::1
+- IPv4 Subnet (by network bit count): 1.2.3.4/24
+- IPv6 Subnet (by network bit count): fe80::1/48
+- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0
+- IPv4 Range: 1.2.3.4-1.2.3.7
+- IPv6 Range: fe80::1-fe80::9
+- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal (Windows 10 only).
+
+> [!TIP]
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
-> Querying for rules with this parameter can only be performed using filter objects. See the **Get-NetFirewallAddressFilter** cmdlet for more information.
+> Querying for rules with this parameter can only be performed using filter objects.
+> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2019-ps/netsecurity/Set-NetFirewallRule.md
+++ b/docset/winserver2019-ps/netsecurity/Set-NetFirewallRule.md
@@ -912,11 +912,11 @@ The acceptable formats for this parameter are:
 - Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal (Windows 10 only).
 
 > [!TIP]
-> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword `LocalSubnet4` means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
 > Querying for rules with this parameter can only be performed using filter objects.
-> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
+> See the [`Get-NetFirewallAddressFilter`](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2019-ps/netsecurity/Set-NetFirewallRule.md
+++ b/docset/winserver2019-ps/netsecurity/Set-NetFirewallRule.md
@@ -898,19 +898,25 @@ Accept wildcard characters: False
 ```
 
 ### -RemoteAddress
-Specifies that network packets with matching IP addresses match this rule. 
-This parameter value is the second end point of an IPsec rule and specifies the computers that are subject to the requirements of this rule. 
-This parameter value is an IPv4 or IPv6 address, subnet, range, or the following keyword: Any. 
-The acceptable formats for this parameter are: 
-- Single IPv4 Address: 1.2.3.4 
-- Single IPv6 Address: fe80::1 
-- IPv4 Subnet (by network bit count): 1.2.3.4/24 
-- IPv6 Subnet (by network bit count): fe80::1/48 
-- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0 
-- IPv4 Range: 1.2.3.4 through 1.2.3.7 
-- IPv6 Range: fe80::1 through fe80::9 
-Querying for rules with this parameter can only be performed using filter objects.
-See the Get-NetFirewallAddressFilter cmdlet for more information.
+Specifies that network packets with matching IP addresses match this rule.
+This parameter value is an IPv4 or IPv6 address, subnet, range or keyword.
+The acceptable formats for this parameter are:
+
+- Single IPv4 Address: 1.2.3.4
+- Single IPv6 Address: fe80::1
+- IPv4 Subnet (by network bit count): 1.2.3.4/24
+- IPv6 Subnet (by network bit count): fe80::1/48
+- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0
+- IPv4 Range: 1.2.3.4-1.2.3.7
+- IPv6 Range: fe80::1-fe80::9
+- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal (Windows 10 only).
+
+> [!TIP]
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+
+> [!NOTE]
+> Querying for rules with this parameter can only be performed using filter objects.
+> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]
@@ -1100,4 +1106,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Set-NetFirewallSetting](./Set-NetFirewallSetting.md)
 
 [Show-NetFirewallRule](./Show-NetFirewallRule.md)
-

--- a/docset/winserver2022-ps/netsecurity/New-NetFirewallRule.md
+++ b/docset/winserver2022-ps/netsecurity/New-NetFirewallRule.md
@@ -798,21 +798,25 @@ Accept wildcard characters: False
 ```
 
 ### -RemoteAddress
-Specifies that network packets with matching IP addresses match this rule. 
-This parameter value is an IPv4 or IPv6 address, subnet, range or keyword. 
-The acceptable formats for this parameter are: 
+Specifies that network packets with matching IP addresses match this rule.
+This parameter value is an IPv4 or IPv6 address, subnet, range or keyword.
+The acceptable formats for this parameter are:
 
-- Single IPv4 Address: 1.2.3.4 
-- Single IPv6 Address: fe80::1 
-- IPv4 Subnet (by network bit count):  1.2.3.4/24 
-- IPv6 Subnet (by network bit count):  fe80::1/48 
-- IPv4 Subnet (by network mask):  1.2.3.4/255.255.255.0 
-- IPv4 Range: 1.2.3.4-1.2.3.7 
-- IPv6 Range: fe80::1-fe80::9 
-- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice. NOTE: Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+- Single IPv4 Address: 1.2.3.4
+- Single IPv6 Address: fe80::1
+- IPv4 Subnet (by network bit count): 1.2.3.4/24
+- IPv6 Subnet (by network bit count): fe80::1/48
+- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0
+- IPv4 Range: 1.2.3.4-1.2.3.7
+- IPv6 Range: fe80::1-fe80::9
+- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal.
 
-Querying for rules with this parameter can only be performed using filter objects.
-See the Get-NetFirewallAddressFilter cmdlet for more information.
+> [!TIP]
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+
+> [!NOTE]
+> Querying for rules with this parameter can only be performed using filter objects.
+> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2022-ps/netsecurity/New-NetFirewallRule.md
+++ b/docset/winserver2022-ps/netsecurity/New-NetFirewallRule.md
@@ -812,11 +812,11 @@ The acceptable formats for this parameter are:
 - Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal.
 
 > [!TIP]
-> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword `LocalSubnet4` means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
 > Querying for rules with this parameter can only be performed using filter objects.
-> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
+> See the [`Get-NetFirewallAddressFilter`](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2022-ps/netsecurity/Set-NetFirewallAddressFilter.md
+++ b/docset/winserver2022-ps/netsecurity/Set-NetFirewallAddressFilter.md
@@ -246,20 +246,25 @@ Accept wildcard characters: False
 ```
 
 ### -RemoteAddress
-Specifies that network packets with matching IP addresses match this rule. 
-This parameter value is the second end point of an IPsec rule and specifies the computers that are subject to the requirements of this rule. 
-This parameter value is an IPv4 or IPv6 address, hostname, subnet, range, or the following keyword: Any. 
-The acceptable formats for this parameter are: 
-- Single IPv4 Address: 1.2.3.4 
-- Single IPv6 Address: fe80::1 
-- IPv4 Subnet (by network bit count): 1.2.3.4/24 
-- IPv6 Subnet (by network bit count): fe80::1/48 
-- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0 
-- IPv4 Range: 1.2.3.4 through 1.2.3.7 
-- IPv6 Range: fe80::1 through fe80::9 
+Specifies that network packets with matching IP addresses match this rule.
+This parameter value is an IPv4 or IPv6 address, subnet, range or keyword.
+The acceptable formats for this parameter are:
+
+- Single IPv4 Address: 1.2.3.4
+- Single IPv6 Address: fe80::1
+- IPv4 Subnet (by network bit count): 1.2.3.4/24
+- IPv6 Subnet (by network bit count): fe80::1/48
+- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0
+- IPv4 Range: 1.2.3.4-1.2.3.7
+- IPv6 Range: fe80::1-fe80::9
+- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal.
+
+> [!TIP]
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
-> Querying for rules with this parameter can only be performed using filter objects. See the **Get-NetFirewallAddressFilter** cmdlet for more information.
+> Querying for rules with this parameter can only be performed using filter objects.
+> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2022-ps/netsecurity/Set-NetFirewallAddressFilter.md
+++ b/docset/winserver2022-ps/netsecurity/Set-NetFirewallAddressFilter.md
@@ -260,11 +260,11 @@ The acceptable formats for this parameter are:
 - Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal.
 
 > [!TIP]
-> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword `LocalSubnet4` means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
 > Querying for rules with this parameter can only be performed using filter objects.
-> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
+> See the [`Get-NetFirewallAddressFilter`](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2022-ps/netsecurity/Set-NetFirewallRule.md
+++ b/docset/winserver2022-ps/netsecurity/Set-NetFirewallRule.md
@@ -894,11 +894,11 @@ The acceptable formats for this parameter are:
 - Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal.
 
 > [!TIP]
-> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword `LocalSubnet4` means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
 > Querying for rules with this parameter can only be performed using filter objects.
-> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
+> See the [`Get-NetFirewallAddressFilter`](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2022-ps/netsecurity/Set-NetFirewallRule.md
+++ b/docset/winserver2022-ps/netsecurity/Set-NetFirewallRule.md
@@ -880,19 +880,25 @@ Accept wildcard characters: False
 ```
 
 ### -RemoteAddress
-Specifies that network packets with matching IP addresses match this rule. 
-This parameter value is the second end point of an IPsec rule and specifies the computers that are subject to the requirements of this rule. 
-This parameter value is an IPv4 or IPv6 address, subnet, range, or the following keyword: Any. 
-The acceptable formats for this parameter are: 
-- Single IPv4 Address: 1.2.3.4 
-- Single IPv6 Address: fe80::1 
-- IPv4 Subnet (by network bit count): 1.2.3.4/24 
-- IPv6 Subnet (by network bit count): fe80::1/48 
-- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0 
-- IPv4 Range: 1.2.3.4 through 1.2.3.7 
-- IPv6 Range: fe80::1 through fe80::9 
-Querying for rules with this parameter can only be performed using filter objects.
-See the Get-NetFirewallAddressFilter cmdlet for more information.
+Specifies that network packets with matching IP addresses match this rule.
+This parameter value is an IPv4 or IPv6 address, subnet, range or keyword.
+The acceptable formats for this parameter are:
+
+- Single IPv4 Address: 1.2.3.4
+- Single IPv6 Address: fe80::1
+- IPv4 Subnet (by network bit count): 1.2.3.4/24
+- IPv6 Subnet (by network bit count): fe80::1/48
+- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0
+- IPv4 Range: 1.2.3.4-1.2.3.7
+- IPv6 Range: fe80::1-fe80::9
+- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal.
+
+> [!TIP]
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+
+> [!NOTE]
+> Querying for rules with this parameter can only be performed using filter objects.
+> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]
@@ -1097,4 +1103,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Set-NetFirewallSetting](./Set-NetFirewallSetting.md)
 
 [Show-NetFirewallRule](./Show-NetFirewallRule.md)
-

--- a/docset/winserver2025-ps/netsecurity/New-NetFirewallRule.md
+++ b/docset/winserver2025-ps/netsecurity/New-NetFirewallRule.md
@@ -804,15 +804,19 @@ The acceptable formats for this parameter are:
 
 - Single IPv4 Address: 1.2.3.4
 - Single IPv6 Address: fe80::1
-- IPv4 Subnet (by network bit count):  1.2.3.4/24
-- IPv6 Subnet (by network bit count):  fe80::1/48
-- IPv4 Subnet (by network mask):  1.2.3.4/255.255.255.0
+- IPv4 Subnet (by network bit count): 1.2.3.4/24
+- IPv6 Subnet (by network bit count): fe80::1/48
+- IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0
 - IPv4 Range: 1.2.3.4-1.2.3.7
 - IPv6 Range: fe80::1-fe80::9
-- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice. NOTE: Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal.
 
-Querying for rules with this parameter can only be performed using filter objects.
-See the Get-NetFirewallAddressFilter cmdlet for more information.
+> [!TIP]
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+
+> [!NOTE]
+> Querying for rules with this parameter can only be performed using filter objects.
+> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2025-ps/netsecurity/New-NetFirewallRule.md
+++ b/docset/winserver2025-ps/netsecurity/New-NetFirewallRule.md
@@ -812,11 +812,11 @@ The acceptable formats for this parameter are:
 - Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal.
 
 > [!TIP]
-> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword `LocalSubnet4` means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
 > Querying for rules with this parameter can only be performed using filter objects.
-> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
+> See the [`Get-NetFirewallAddressFilter`](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2025-ps/netsecurity/Set-NetFirewallAddressFilter.md
+++ b/docset/winserver2025-ps/netsecurity/Set-NetFirewallAddressFilter.md
@@ -247,19 +247,24 @@ Accept wildcard characters: False
 
 ### -RemoteAddress
 Specifies that network packets with matching IP addresses match this rule.
-This parameter value is the second end point of an IPsec rule and specifies the computers that are subject to the requirements of this rule.
-This parameter value is an IPv4 or IPv6 address, hostname, subnet, range, or the following keyword: Any.
+This parameter value is an IPv4 or IPv6 address, subnet, range or keyword.
 The acceptable formats for this parameter are:
+
 - Single IPv4 Address: 1.2.3.4
 - Single IPv6 Address: fe80::1
 - IPv4 Subnet (by network bit count): 1.2.3.4/24
 - IPv6 Subnet (by network bit count): fe80::1/48
 - IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0
-- IPv4 Range: 1.2.3.4 through 1.2.3.7
-- IPv6 Range: fe80::1 through fe80::9
+- IPv4 Range: 1.2.3.4-1.2.3.7
+- IPv6 Range: fe80::1-fe80::9
+- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal.
+
+> [!TIP]
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
-> Querying for rules with this parameter can only be performed using filter objects. See the **Get-NetFirewallAddressFilter** cmdlet for more information.
+> Querying for rules with this parameter can only be performed using filter objects.
+> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2025-ps/netsecurity/Set-NetFirewallAddressFilter.md
+++ b/docset/winserver2025-ps/netsecurity/Set-NetFirewallAddressFilter.md
@@ -260,11 +260,11 @@ The acceptable formats for this parameter are:
 - Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal.
 
 > [!TIP]
-> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword `LocalSubnet4` means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
 > Querying for rules with this parameter can only be performed using filter objects.
-> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
+> See the [`Get-NetFirewallAddressFilter`](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2025-ps/netsecurity/Set-NetFirewallRule.md
+++ b/docset/winserver2025-ps/netsecurity/Set-NetFirewallRule.md
@@ -894,11 +894,11 @@ The acceptable formats for this parameter are:
 - Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal.
 
 > [!TIP]
-> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword `LocalSubnet4` means that all local IPv4 addresses are matching this rule).
 
 > [!NOTE]
 > Querying for rules with this parameter can only be performed using filter objects.
-> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
+> See the [`Get-NetFirewallAddressFilter`](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]

--- a/docset/winserver2025-ps/netsecurity/Set-NetFirewallRule.md
+++ b/docset/winserver2025-ps/netsecurity/Set-NetFirewallRule.md
@@ -881,18 +881,24 @@ Accept wildcard characters: False
 
 ### -RemoteAddress
 Specifies that network packets with matching IP addresses match this rule.
-This parameter value is the second end point of an IPsec rule and specifies the computers that are subject to the requirements of this rule.
-This parameter value is an IPv4 or IPv6 address, subnet, range, or the following keyword: Any.
+This parameter value is an IPv4 or IPv6 address, subnet, range or keyword.
 The acceptable formats for this parameter are:
+
 - Single IPv4 Address: 1.2.3.4
 - Single IPv6 Address: fe80::1
 - IPv4 Subnet (by network bit count): 1.2.3.4/24
 - IPv6 Subnet (by network bit count): fe80::1/48
 - IPv4 Subnet (by network mask): 1.2.3.4/255.255.255.0
-- IPv4 Range: 1.2.3.4 through 1.2.3.7
-- IPv6 Range: fe80::1 through fe80::9
-Querying for rules with this parameter can only be performed using filter objects.
-See the Get-NetFirewallAddressFilter cmdlet for more information.
+- IPv4 Range: 1.2.3.4-1.2.3.7
+- IPv6 Range: fe80::1-fe80::9
+- Keyword: Any, LocalSubnet, DNS, DHCP, WINS, DefaultGateway, Internet, Intranet, IntranetRemoteAccess, PlayToDevice, CaptivePortal.
+
+> [!TIP]
+> Keywords can be restricted to IPv4 or IPv6 by appending a 4 or 6 (for example, keyword "LocalSubnet4" means that all local IPv4 addresses are matching this rule).
+
+> [!NOTE]
+> Querying for rules with this parameter can only be performed using filter objects.
+> See the [Get-NetFirewallAddressFilter](./Get-NetFirewallAddressFilter.md) cmdlet for more information.
 
 ```yaml
 Type: String[]
@@ -1097,4 +1103,3 @@ The path after the pound sign (`#`) provides the namespace and class name for th
 [Set-NetFirewallSetting](./Set-NetFirewallSetting.md)
 
 [Show-NetFirewallRule](./Show-NetFirewallRule.md)
-


### PR DESCRIPTION
# PR Summary

Clearly specifies what possible inputs for this parameter are accepted on each operating system. 
Only for "\*-NetFirewall\*" cmdlets. Only for the currently supported OSes (WS 2016/2019/2022/2025, W10/11).

Previously some descriptions showed examples of IP address ranges in an incorrect format: "1.2.3.4 through 1.2.3.7"
I also added a new keyword "CaptivePortal" to those OS that support it (note, while W10 supports this keyword, WS2019 doesn't).

I also made sure that information about appending 4/6, using Get-NetFirewallAddressFilter appears in all these documents and is nicely formatted.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
