### PR TITLE
Add example to show creating clustered share.

### DIFF
--- a/docset/winserver2022-ps/smbshare/New-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbShare.md
@@ -82,6 +82,15 @@ groups `CONTOSO\Finance Users` and `CONTOSO\HR Users`. Full Access permissions t
 This example uses splatting to pass parameter values from the `$Parameters` variable to the command.
 Learn more about [Splatting](/powershell/module/microsoft.powershell.core/about/about_splatting).
 
+### Example 4: Create an SMB share in a Windows Server Failover Cluster.
+
+```powershell
+New-SmbShare -Name "Data" -ScopeName "Network Name resource" -Path "D:\Folder"
+```
+
+This command creates a clustered SMB share by using -ScopeName to specify the Network Name resource of a cluster group.
+
+
 ## PARAMETERS
 
 ### -AsJob


### PR DESCRIPTION
Added example 4 to show how to use -ScopeName switch to create an SMB share within a failover cluster. Usage of this switch is not extensively documented and it's not currently made clear that a Network Name cluster resource needs to be specified.

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
