### PR TITLE
Update Set-NetFirewallProfile.md to clarify AllowLocalFirewallRules and AllowLocalIPsecRules can only be set in a GPO

### DIFF
--- a/docset/winserver2022-ps/netsecurity/Set-NetFirewallProfile.md
+++ b/docset/winserver2022-ps/netsecurity/Set-NetFirewallProfile.md
@@ -161,6 +161,7 @@ This parameter removes the setting from the GPO, which results in the policy not
 
 The default setting when managing a computer is True.
 When managing a GPO, the default setting is NotConfigured.
+Note that this will only take effect if a GPO is targeted with -PolicyStore. If this is set locally it is not applied.
 
 ```yaml
 Type: GpoBoolean
@@ -186,6 +187,7 @@ This parameter removes the setting from the GPO, which results in the policy not
 
 The default setting when managing a computer is True.
 When managing a GPO, the default setting is NotConfigured.
+Note that this will only take effect if a GPO is targeted with -PolicyStore. If this is set locally it is not applied.
 
 ```yaml
 Type: GpoBoolean


### PR DESCRIPTION
2 properties (AllowLocalFirewallRules and AllowLocalIPsecRules) are only configurable via a Group Policy object. The Powershell command does not fail the call when someone sets it locally, but it is not applied from a local setting. These are GP only properties.

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [ ] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [ ] **Summary:** This PR's summary describes the scope and intent of the change.
- [ ] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [ ] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
