### PR TITLE
Add more details for ThrottleRateActionBitsPerSecond parameter in New-NetQosPolicy

### DIFF
--- a/docset/winserver2022-ps/netqos/New-NetQosPolicy.md
+++ b/docset/winserver2022-ps/netqos/New-NetQosPolicy.md
@@ -715,6 +715,8 @@ Accept wildcard characters: False
 
 ### -ThrottleRateActionBitsPerSecond
 Specifies a throttle rate in bits per second to set the maximum bandwidth that can be consumed.
+If a value of `0` is entered for this parameter, there won't be any rate limit.
+Value entered will be rounded down to the nearest multiple of 8.
 
 ```yaml
 Type: UInt64


### PR DESCRIPTION

# PR Summary

Add more details for `ThrottleRateActionBitsPerSecond` parameter in New-NetQosPolicy for some extreme conditions.

We're using `New-NetQosPolicy` in production to choke some application by setting `ThrottleRateActionBitsPerSecond` as low as possible, but it turns out that:
 - `0` means no rate limiting, will be ignored
 - the value will be rounded down to nearest multiple of 8 (e.g. 500 -> 496)

Adding these details into documentation to avoid confusion for others.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
