### PR TITLE
Fixed example numbering

### DIFF
--- a/docset/winserver2022-ps/grouppolicy/Set-GPRegistryValue.md
+++ b/docset/winserver2022-ps/grouppolicy/Set-GPRegistryValue.md
@@ -101,7 +101,7 @@ This command configures a registry-based policy setting for the registry value
 data type of `DWord`. This policy setting sets the Screen Saver timeout to 900 seconds (15 minutes)
 when Group Policy is applied on the client.
 
-### Example 1: Configure a registry-based policy settings for multiple registry values
+### Example 2: Configure a registry-based policy settings for multiple registry values
 
 ```powershell
 $params = @{


### PR DESCRIPTION
# PR Summary
Encountered a small mistake in the numbering of the examples, it went like this: example 1, example 1, example 3. Changed it to the intended 1, 2, 3.

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
