### PR TITLE
Update VMHostPartitionableGpu command set - WS25

### DIFF
--- a/docset/winserver2025-ps/hyper-v/Get-VMHostPartitionableGpu.md
+++ b/docset/winserver2025-ps/hyper-v/Get-VMHostPartitionableGpu.md
@@ -2,7 +2,7 @@
 description: Gets the host machine’s partitionable GPU.
 external help file: Microsoft.HyperV.PowerShell.Cmdlets.dll-Help.xml
 Module Name: Hyper-V
-ms.date: 09/22/2022
+ms.date: 06/12/2024
 online version: https://learn.microsoft.com/powershell/module/hyper-v/get-vmhostpartitionablegpu?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-VMHostPartitionableGpu
@@ -16,49 +16,66 @@ Gets the host machine’s partitionable GPU.
 ## SYNTAX
 
 ### ComputerName (Default)
+
 ```
-Get-VMHostPartitionableGpu [[-ComputerName] <String[]>] [[-Credential] <PSCredential[]>] [-Name <String>]
- [<CommonParameters>]
+Get-VMHostPartitionableGpu [[-ComputerName] <String[]>] [[-Credential] <PSCredential[]>]
+ [-Name <String>] [<CommonParameters>]
 ```
 
 ### CimSession
+
 ```
 Get-VMHostPartitionableGpu [-CimSession] <CimSession[]> [-Name <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The 'Get-VMHostPartitionableGpu' cmdlet gets the host machine’s partitionable graphic processing unit.
-This displays the information of the GPU as provided by the manufacturer's driver.
+
+The `Get-VMHostPartitionableGpu` cmdlet gets the host machine’s partitionable graphic processing
+unit. This displays the information of the GPU as provided by the manufacturer's driver.
 
 ## EXAMPLES
 
 ### Example 1
-```
+
+```powershell
 Get-VMHostPartitionableGpu
 ```
 
 This example gets the details of the local partitionable graphic processing unit on the host.
 
 ### Example 2
+
 ```powershell
-Get-VMHostPartitionableGpu -ComputerName "SampleHost"
+Get-VMHostPartitionableGpu -ComputerName "MyHost"
 ```
 
-This example gets a partitionable GPU by using the host name. This command will display all the GPU devices available for partitioning in the host.
+This example gets a partitionable GPU by using the host name. This command will display all the GPU
+devices available for partitioning in the host.
 
 ### Example 3
+
 ```powershell
-Get-VMHostPartitionableGpu -name "SampleGPUDeviceIDName"
+Get-VMHostPartitionableGpu -Name "GPUDeviceIDName"
 ```
 
-Displays a partitionable GPU by using the specific GPU device name. The result will show the details of the specific GPU listed.
+### Example 4
+
+```powershell
+Get-VMHostPartitionableGpu | FL Name, ValidPartitionCounts
+```
+
+This example retrieves information about the partitionable GPUs available on a virtual machine host
+and formats the output as a list, displaying the name of each GPU and the number of valid
+partitions that can be created on each GPU.
 
 ## PARAMETERS
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
-The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -73,10 +90,10 @@ Accept wildcard characters: False
 ```
 
 ### -ComputerName
-Specifies one or more Hyper-V hosts that run this cmdlet.
-NetBIOS names, IP addresses, and fully qualified domain names are allowed.
-The default is the local computer.
-Use localhost or a dot ('.') to specify the local computer explicitly.
+
+Specifies one or more Hyper-V hosts that run this cmdlet. NetBIOS names, IP addresses, and fully
+qualified domain names are allowed. The default is the local computer. Use localhost or a dot (`.`)
+to specify the local computer explicitly.
 
 ```yaml
 Type: String[]
@@ -91,7 +108,9 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies one or more user accounts that have permission to perform this action. The default is the current user.
+
+Specifies one or more user accounts that have permission to perform this action. The default is the
+current user.
 
 ```yaml
 Type: PSCredential[]
@@ -106,6 +125,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies the name of the graphic processing unit to be retrieved.
 
 ```yaml
@@ -121,7 +141,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -134,3 +158,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+- [Set-VMHostPartitionableGpu](set-vmhostpartitionablegpu.md)

--- a/docset/winserver2025-ps/hyper-v/Set-VMHostPartitionableGpu.md
+++ b/docset/winserver2025-ps/hyper-v/Set-VMHostPartitionableGpu.md
@@ -2,7 +2,7 @@
 description: Configures the host partitionable GPU to the number of partitions supported by the manufacturer.
 external help file: Microsoft.HyperV.PowerShell.Cmdlets.dll-Help.xml
 Module Name: Hyper-V
-ms.date: 10/21/2022
+ms.date: 06/12/2024
 online version: https://learn.microsoft.com/powershell/module/hyper-v/set-vmhostpartitionablegpu?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-VMHostPartitionableGpu
@@ -16,44 +16,53 @@ Configures the host partitionable GPU to the number of partitions supported by t
 ## SYNTAX
 
 ### ComputerName (Default)
+
 ```
 Set-VMHostPartitionableGpu [[-ComputerName] <String[]>] [[-Credential] <PSCredential[]>] [-Passthru]
  [-PartitionCount <UInt16>] [<CommonParameters>]
 ```
 
 ### CimSession
+
 ```
 Set-VMHostPartitionableGpu [-CimSession] <CimSession[]> [-Passthru] [-PartitionCount <UInt16>]
  [<CommonParameters>]
 ```
 
 ### Object
+
 ```
 Set-VMHostPartitionableGpu [-HostPartitionableGpu] <VMHostPartitionableGpu[]> [-Passthru]
  [-PartitionCount <UInt16>] [<CommonParameters>]
 ```
 
 ### Name
+
 ```
-Set-VMHostPartitionableGpu [-Passthru] [-Name <String>] [-PartitionCount <UInt16>] [<CommonParameters>]
+Set-VMHostPartitionableGpu [-Passthru] [-Name <String>] [-PartitionCount <UInt16>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The `Set-VMHostPartitionableGpu` cmdlet configures the host partitionable GPU to the number of partitions supported by the manufacturer.
+
+The `Set-VMHostPartitionableGpu` cmdlet configures the host partitionable GPU to the number of
+partitions supported by the manufacturer.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
-Set-VMHostPartitionableGpu -ComputerName SampleHost -partitioncount 8
+Set-VMHostPartitionableGpu -ComputerName "MyHost" -PartitionCount 8
 ```
 
 This example partitions a GPU in a specific host into eight partitions.
 
 ### Example 2
+
 ```powershell
-$GPU = Get-VMHostPartitionableGpu -name "SampleGPUDeviceIDName"
-Set-VMHostPartitionableGpu -Name $GPU -partitionCount 4
+$GPU = Get-VMHostPartitionableGpu -Name "GPUDeviceIDName"
+Set-VMHostPartitionableGpu -Name $GPU -PartitionCount 4
 ```
 
 This example partitions a GPU in a host into four partitions by using the GPU device ID name.
@@ -61,8 +70,11 @@ This example partitions a GPU in a host into four partitions by using the GPU de
 ## PARAMETERS
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
-The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -77,9 +89,10 @@ Accept wildcard characters: False
 ```
 
 ### -ComputerName
-Specifies one or more Hyper-V hosts on the virtual network adapters are to be retrieved. NetBIOS names, IP addresses, and fully qualified domain names are allowed.
-The default is the local computer.
-Use localhost or a dot ('.') to specify the local computer explicitly.
+
+Specifies one or more Hyper-V hosts on the virtual network adapters are to be retrieved. NetBIOS
+names, IP addresses, and fully qualified domain names are allowed. The default is the local
+computer. Use localhost or a dot (`.`) to specify the local computer explicitly.
 
 ```yaml
 Type: String[]
@@ -94,8 +107,9 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies one or more user accounts that have permission to perform this action.
-The default is the current user.
+
+Specifies one or more user accounts that have permission to perform this action. The default is the
+current user.
 
 ```yaml
 Type: PSCredential[]
@@ -110,7 +124,8 @@ Accept wildcard characters: False
 ```
 
 ### -HostPartitionableGpu
-Full GPU object, obtained by executing 'Get-VMHostPartitionableGpu'.
+
+Full GPU object, obtained by executing `Get-VMHostPartitionableGpu`.
 
 ```yaml
 Type: VMHostPartitionableGpu[]
@@ -125,6 +140,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies the name of the GPU.
 
 ```yaml
@@ -140,7 +156,9 @@ Accept wildcard characters: False
 ```
 
 ### -PartitionCount
-Specifies the number of partitions that the GPU will assign. The number of partitions is defined by the manufacturer.
+
+Specifies the number of partitions that the GPU will assign. The number of partitions is defined by
+the manufacturer.
 
 ```yaml
 Type: UInt16
@@ -155,6 +173,7 @@ Accept wildcard characters: False
 ```
 
 ### -Passthru
+
 Returns an object for each process that the cmdlet started.
 
 ```yaml
@@ -170,7 +189,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -185,3 +208,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+- [Get-VMHostPartitionableGpu](get-vmhostpartitionablegpu.md)


### PR DESCRIPTION
# PR Summary

Updated the VMHostPartitionableGpu command set for Windows Server 2025.
Added new example for `Get`.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
