### PR TITLE
Update VMHostAssignableDevice command set - WS25

### DIFF
--- a/docset/winserver2025-ps/hyper-v/Add-VMHostAssignableDevice.md
+++ b/docset/winserver2025-ps/hyper-v/Add-VMHostAssignableDevice.md
@@ -1,0 +1,227 @@
+---
+description: Assigns a device to a virtual machine host.
+external help file: Microsoft.HyperV.PowerShell.Cmdlets.dll-Help.xml
+Module Name: Hyper-V
+ms.date: 06/12/2024
+online version: https://learn.microsoft.com/powershell/module/hyper-v/add-vmhostassignabledevice?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Add-VMHostAssignableDevice
+---
+
+# Add-VMHostAssignableDevice
+
+## SYNOPSIS
+Adds an assignable device to a virtual machine (VM) host.
+
+## SYNTAX
+
+### Path (Default)
+
+```
+Add-VMHostAssignableDevice [-CimSession <CimSession[]>] [-ComputerName <String[]>]
+ [-Credential <PSCredential[]>] [-Force] [-InstancePath <String>] [-LocationPath <String>]
+ -ResourcePoolName <String[]> [<CommonParameters>]
+```
+
+### Object
+
+```
+Add-VMHostAssignableDevice [-Force] [-HostAssignableDevice] <VMHostAssignableDevice[]>
+ -ResourcePoolName <String[]> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Add-VMHostAssignableDevice` cmdlet assigns a hardware device to a virtual machine host. You
+can add devices to the VM host by providing either the instance or location path of the device, or
+by specifying an existing host-assignable device object.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+$params = @{
+ComputerName = "MyVM01"
+InstancePath = "PCI\VEN_8086&DEV_0F48&SUBSYS_72708086&REV_0B\3&11583659&0&D8"
+ResourcePoolName = "MyResourcePool"
+}
+Add-VMHostAssignableDevice $params
+```
+
+This example assigns a device identified by its instance path to VM host **MyVM01** within the
+resource pool **MyResourcePool**.
+
+### Example 2
+
+```powershell
+$gpu = Get-VMHostAssignableDevice
+Add-VMHostAssignableDevice -HostAssignableDevice $gpu -ResourcePoolName "GpuChildPool"
+```
+
+This example retrieves a list of GPUs or other assignable devices and adds these devices to a
+resource pool named **GpuChildPool**, making the devices available for use by virtual machines in
+that resource pool.
+
+## PARAMETERS
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ComputerName
+
+Specifies the name of the Hyper-V host to which the device is to be added. NetBIOS names, IP
+addresses, and fully qualified domain names are allowed. The default is the local computer. Use
+localhost or a dot (`.`) to specify the local computer explicitly.
+
+```yaml
+Type: String[]
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+Specifies one or more user accounts that have permission to perform this action. The default is the
+current user.
+
+```yaml
+Type: PSCredential[]
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+
+Forces the command to run without asking for user confirmation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HostAssignableDevice
+
+Specifies the device object to be assigned to the virtual machine.
+
+```yaml
+Type: VMHostAssignableDevice[]
+Parameter Sets: Object
+Aliases: VMHostAssignableDevice
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -InstancePath
+
+Represents the Device Instance path in the host machine.
+
+```yaml
+Type: String
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LocationPath
+
+Specifies the location path to the assignable device.
+
+```yaml
+Type: String
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResourcePoolName
+
+Specifies the name of the resource pool to which the device is assigned.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### Microsoft.HyperV.PowerShell.VMHostAssignableDevice[]
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-VMHostAssignableDevice](get-vmhostassignabledevice.md)
+
+[Dismount-VMHostAssignableDevice](dismount-vmhostassignabledevice.md)
+
+[Mount-VMHostAssignableDevice](mount-vmhostassignabledevice.md)
+
+[Remove-VMHostAssignableDevice](remove-vmhostassignabledevice.md)

--- a/docset/winserver2025-ps/hyper-v/Dismount-VMHostAssignableDevice.md
+++ b/docset/winserver2025-ps/hyper-v/Dismount-VMHostAssignableDevice.md
@@ -1,0 +1,225 @@
+---
+description: Dismounts an assignable device from a virtual machine host.
+external help file: Microsoft.HyperV.PowerShell.Cmdlets.dll-Help.xml
+Module Name: Hyper-V
+ms.date: 06/12/2024
+online version: https://learn.microsoft.com/powershell/module/hyper-v/dismount-vmhostassignabledevice?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Dismount-VMHostAssignableDevice
+---
+
+# Dismount-VMHostAssignableDevice
+
+## SYNOPSIS
+Dismounts a device from a virtual machine (VM) host.
+
+## SYNTAX
+
+```
+Dismount-VMHostAssignableDevice [-InstancePath <String>] [-LocationPath <String>] [-Force]
+ [-Passthru] [-CimSession <CimSession[]>] [-ComputerName <String[]>] [-Credential <PSCredential[]>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Dismount-VMHostAssignableDevice` cmdlet is used to dismount an assignable device from the
+virtual machine host. Use this cmdlet when you need to reassign a device or resolve conflicts
+between devices and virtual machines.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Dismount-VMHostAssignableDevice -InstancePath "PCIROOT(0)#PCI(1D02)#PCI(0000)"
+```
+
+This example dismounts the device with the specified instance path from the host, making it
+available for assignment to a virtual machine.
+
+## PARAMETERS
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ComputerName
+
+Specifies one or more Hyper-V hosts from which the assignable devices are to be dismounted. NetBIOS
+names, IP addresses, and fully qualified domain names are allowed. The default is the local
+computer. Use localhost or a dot (`.`) to specify the local computer explicitly.
+
+```yaml
+Type: String[]
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+Specifies one or more user accounts that have permission to perform this action. The default is the
+current user.
+
+```yaml
+Type: PSCredential[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+
+Forces the command to run without asking for user confirmation.
+
+Using the **Force** parameter also overrides some security checks in the platform. To learn more,
+see [Dismount the device from the host partition
+](/windows-server/virtualization/hyper-v/deploy/deploying-graphics-devices-using-dda#dismount-the-device-from-the-host-partition).
+
+If no partitioning driver is provided, during dismount, you must use `-Force` to bypass the
+security warning. For more information about the security implications, see [Plan for deploying devices by using Discrete Device Assignment](/windows-server/virtualization/hyper-v/plan/plan-for-deploying-devices-using-discrete-device-assignment).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InstancePath
+
+Represents the Device Instance path in the host machine.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LocationPath
+
+Specifies the location path to the assignable device.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Passthru
+
+Returns an object for each process that the cmdlet started.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### Microsoft.HyperV.PowerShell.VMHostAssignableDevice
+
+## NOTES
+
+## RELATED LINKS
+
+[Add-VMHostAssignableDevice](add-vmhostassignabledevice.md)
+
+[Get-VMHostAssignableDevice](get-vmhostassignabledevice.md)
+
+[Mount-VMHostAssignableDevice](mount-vmhostassignabledevice.md)
+
+[Remove-VMHostAssignableDevice](remove-vmhostassignabledevice.md)

--- a/docset/winserver2025-ps/hyper-v/Get-VMHostAssignableDevice.md
+++ b/docset/winserver2025-ps/hyper-v/Get-VMHostAssignableDevice.md
@@ -1,0 +1,178 @@
+---
+description: Retrieves information about an assignable device to a virtual machine host.
+external help file: Microsoft.HyperV.PowerShell.Cmdlets.dll-Help.xml
+Module Name: Hyper-V
+ms.date: 06/12/2024
+online version: https://learn.microsoft.com/powershell/module/hyper-v/get-vmhostassignabledevice?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Get-VMHostAssignableDevice
+---
+
+# Get-VMHostAssignableDevice
+
+## SYNOPSIS
+Retrieves device information assigned to a virtual machine (VM) host.
+
+## SYNTAX
+
+```
+Get-VMHostAssignableDevice [-InstancePath <String>] [-LocationPath <String>]
+ [-ResourcePoolName <String[]>] [-CimSession <CimSession[]>] [-ComputerName <String[]>]
+ [-Credential <PSCredential[]>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Get-VMHostAssignableDevice` cmdlet retrieves information about devices that can be assigned to
+a virtual machine host. This can include devices such as GPUs, network adapters, or storage
+controllers that are physically present on the host system. The cmdlet can filter devices by their
+instance path or location path.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Get-VMHostAssignableDevice
+```
+
+This example retrieves all assignable devices on the host computer.
+
+### Example 2
+
+```powershell
+Get-VMHostAssignableDevice -ComputerName "MyHost"
+```
+
+In this example, the cmdlet retrieves all assignable devices from the computer named **MyHost**.
+
+## PARAMETERS
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ComputerName
+
+Specifies one or more Hyper-V hosts from which the assignable devices are to be retrieved. NetBIOS
+names, IP addresses, and fully qualified domain names are allowed. The default is the local
+computer. Use localhost or a dot (`.`) to specify the local computer explicitly.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+Specifies one or more user accounts that have permission to perform this action. The default is the
+current user.
+
+```yaml
+Type: PSCredential[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InstancePath
+
+Represents the Device Instance path in the host machine.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LocationPath
+
+Specifies the location path to the assignable device.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResourcePoolName
+
+Retrieves the name of the resource pool to which the device is assigned.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### Microsoft.HyperV.PowerShell.VMHostAssignableDevice
+
+## NOTES
+
+## RELATED LINKS
+
+[Add-VMHostAssignableDevice](add-vmhostassignabledevice.md)
+
+[Dismount-VMHostAssignableDevice](dismount-vmhostassignabledevice.md)
+
+[Mount-VMHostAssignableDevice](mount-vmhostassignabledevice.md)
+
+[Remove-VMHostAssignableDevice](remove-vmhostassignabledevice.md)

--- a/docset/winserver2025-ps/hyper-v/Mount-VMHostAssignableDevice.md
+++ b/docset/winserver2025-ps/hyper-v/Mount-VMHostAssignableDevice.md
@@ -1,0 +1,232 @@
+---
+description: Mounts an assignable device to a virtual machine host.
+external help file: Microsoft.HyperV.PowerShell.Cmdlets.dll-Help.xml
+Module Name: Hyper-V
+ms.date: 06/12/2024
+online version: https://learn.microsoft.com/powershell/module/hyper-v/mount-vmhostassignabledevice?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Mount-VMHostAssignableDevice
+---
+
+# Mount-VMHostAssignableDevice
+
+## SYNOPSIS
+Mounts a device to a virtual machine (VM) host.
+
+## SYNTAX
+
+### Path (Default)
+
+```
+Mount-VMHostAssignableDevice [-CimSession <CimSession[]>] [-ComputerName <String[]>]
+ [-Credential <PSCredential[]>] [-InstancePath <String>] [-LocationPath <String>] [-Passthru]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Object
+
+```
+Mount-VMHostAssignableDevice [-HostAssignableDevice] <VMHostAssignableDevice[]> [-Passthru]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Mount-VMHostAssignableDevice` cmdlet mounts a device such as GPUs, network adapters, or storage
+controllers that are physically present on the virtual machine host.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+$device = Get-VMHostAssignableDevice -InstancePath "PCIROOT(0)#PCI(0300)#PCI(0000)"
+$params = @{
+HostAssignableDevice = $device
+VMName = "MyVM"
+}
+Mount-VMHostAssignableDevice @params
+```
+
+In this example, the `Get-VMHostAssignableDevice` cmdlet retrieves the device with the specified
+instance path and stores it in the `$device` variable. The `Mount-VMHostAssignableDevice` cmdlet
+then assigns this device to the virtual machine named **MyVM**.
+
+## PARAMETERS
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ComputerName
+
+Specifies one or more Hyper-V hosts from which the assignable devices are to be mounted. NetBIOS
+names, IP addresses, and fully qualified domain names are allowed. The default is the local
+computer. Use localhost or a dot (`.`) to specify the local computer explicitly.
+
+```yaml
+Type: String[]
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+Specifies one or more user accounts that have permission to perform this action. The default is the
+current user.
+
+```yaml
+Type: PSCredential[]
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HostAssignableDevice
+
+Specifies the assignable device to be mounted on the virtual machine host.
+
+```yaml
+Type: VMHostAssignableDevice[]
+Parameter Sets: Object
+Aliases: VMHostAssignableDevice
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -InstancePath
+
+Represents the Device Instance path in the host machine.
+
+```yaml
+Type: String
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LocationPath
+
+Specifies the location path to the assignable device.
+
+```yaml
+Type: String
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Passthru
+
+Returns an object for each process that the cmdlet started.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### Microsoft.HyperV.PowerShell.VMHostAssignableDevice[]
+
+## OUTPUTS
+
+### Microsoft.HyperV.PowerShell.VMHostAssignableDevice
+
+## NOTES
+
+## RELATED LINKS
+
+[Add-VMHostAssignableDevice](add-vmhostassignabledevice.md)
+
+[Get-VMHostAssignableDevice](get-vmhostassignabledevice.md)
+
+[Dismount-VMHostAssignableDevice](dismount-vmhostassignabledevice.md)
+
+[Remove-VMHostAssignableDevice](remove-vmhostassignabledevice.md)

--- a/docset/winserver2025-ps/hyper-v/Remove-VMHostAssignableDevice.md
+++ b/docset/winserver2025-ps/hyper-v/Remove-VMHostAssignableDevice.md
@@ -1,0 +1,248 @@
+---
+description: Removes an assignable device from a virtual machine host.
+external help file: Microsoft.HyperV.PowerShell.Cmdlets.dll-Help.xml
+Module Name: Hyper-V
+ms.date: 06/12/2024
+online version: https://learn.microsoft.com/powershell/module/hyper-v/remove-vmhostassignabledevice?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Remove-VMHostAssignableDevice
+---
+
+# Remove-VMHostAssignableDevice
+
+## SYNOPSIS
+Removes a device assigned to a virtual machine (VM) host.
+
+## SYNTAX
+
+### Path (Default)
+
+```
+Remove-VMHostAssignableDevice [-CimSession <CimSession[]>] [-ComputerName <String[]>]
+ [-Credential <PSCredential[]>] [-InstancePath <String>] [-LocationPath <String>]
+ -ResourcePoolName <String[]> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Object
+
+```
+Remove-VMHostAssignableDevice [-HostAssignableDevice] <VMHostAssignableDevice[]>
+ -ResourcePoolName <String[]> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Remove-VMHostAssignableDevice` cmdlet removes a device that is assigned to a virtual machine
+host. Depending on the parameters specified, you can remove devices by providing either the
+instance or location path of the device.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+$params = @{
+InstancePath = "PCIROOT(0)#PCI(0300)#PCI(0000)"
+ResourcePoolName = "MyResourcePool"
+}
+Remove-VMHostAssignableDevice $params
+```
+
+This example removes the device with the specified instance path from the resource pool named
+**MyResourcePool**.
+
+## PARAMETERS
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ComputerName
+
+Specifies one or more Hyper-V hosts from which the assignable devices are to be removed. NetBIOS
+names, IP addresses, and fully qualified domain names are allowed. The default is the local
+computer. Use localhost or a dot (`.`) to specify the local computer explicitly.
+
+```yaml
+Type: String[]
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+Specifies one or more user accounts that have permission to perform this action. The default is the
+current user.
+
+```yaml
+Type: PSCredential[]
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+
+Forces the command to run without asking for user confirmation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HostAssignableDevice
+
+Specifies the device object to be removed. You can get this object using
+`Get-VMHostAssignableDevice`.
+
+```yaml
+Type: VMHostAssignableDevice[]
+Parameter Sets: Object
+Aliases: VMHostAssignableDevice
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -InstancePath
+
+Specifies the Device Instance path in the host machine.
+
+```yaml
+Type: String
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LocationPath
+
+Specifies the location path to the assignable device.
+
+```yaml
+Type: String
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResourcePoolName
+
+Specifies the name of the resource pool from which to remove an assignable device.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### Microsoft.HyperV.PowerShell.VMHostAssignableDevice[]
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+
+[Add-VMHostAssignableDevice](add-vmhostassignabledevice.md)
+
+[Get-VMHostAssignableDevice](get-vmhostassignabledevice.md)
+
+[Dismount-VMHostAssignableDevice](dismount-vmhostassignabledevice.md)
+
+[Mount-VMHostAssignableDevice](mount-vmhostassignabledevice.md)


### PR DESCRIPTION
# PR Summary

Updated the VMHostAssignableDevice command set for Windows Server 2025.
Added new example for `Add`.

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
