### PR TITLE
Update indents for VMHostPartitionableGpu 2025

### DIFF
--- a/docset/winserver2025-ps/hyper-v/Get-VMHostPartitionableGpu.md
+++ b/docset/winserver2025-ps/hyper-v/Get-VMHostPartitionableGpu.md
@@ -159,4 +159,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-- [Set-VMHostPartitionableGpu](set-vmhostpartitionablegpu.md)
+[Set-VMHostPartitionableGpu](set-vmhostpartitionablegpu.md)

--- a/docset/winserver2025-ps/hyper-v/Set-VMHostPartitionableGpu.md
+++ b/docset/winserver2025-ps/hyper-v/Set-VMHostPartitionableGpu.md
@@ -209,4 +209,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-- [Get-VMHostPartitionableGpu](get-vmhostpartitionablegpu.md)
+[Get-VMHostPartitionableGpu](get-vmhostpartitionablegpu.md)


### PR DESCRIPTION
Resolve cabgen error related to incorrect formatting of Related Links section. Related Links should not include `-` to define the list.

Related to:

- https://github.com/MicrosoftDocs/windows-powershell-docs/commit/46e9e7d1a51fa6bb84a6ec1331e04ac922c33543 (only addressed Get)
- https://github.com/MicrosoftDocs/windows-powershell-docs/commit/2c4d896678d1542c631430cb5548d784c764afe4 (addressed 2022)
- https://github.com/MicrosoftDocs/windows-powershell-docs/pull/3852 (addressed 2025)