### PR TITLE
Update New-VMSwitch.md

### DIFF
--- a/docset/winserver2025-ps/hyper-v/New-VMSwitch.md
+++ b/docset/winserver2025-ps/hyper-v/New-VMSwitch.md
@@ -187,7 +187,7 @@ Allowed values are **Absolute**, **Default**, **None**, or **Weight**.
 If **Absolute** is specified, minimum bandwidth is bits per second.
 If **Weight** is specified, minimum bandwidth is a value ranging from 1 to 100.
 If **None** is specified, minimum bandwidth is disabled on the switch - that is, users cannot configure it on any network adapter connected to the switch.
-If **Default** is specified, the system will set the mode to **Weight**, if the switch is not IOV-enabled, or **None** if the switch is IOV-enabled.
+If **Default** is specified, the system will set the mode to **Absolute**, if the switch is not IOV-enabled, or **None** if the switch is IOV-enabled.
 
 ```yaml
 Type: VMSwitchBandwidthMode


### PR DESCRIPTION
Changed the description of -MinimumBandwidthMode to indicate that it defaults to "Absolute", not "Weight". The documentation has been incorrect on that for years. The default has always been "Absolute".

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [ ] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [ ] **Summary:** This PR's summary describes the scope and intent of the change.
- [ ] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [ ] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
