### PR TITLE
Converted SYNTAX blocks to one param per line and sorted

### DIFF
--- a/docset/winserver2022-ps/defender/Add-MpPreference.md
+++ b/docset/winserver2022-ps/defender/Add-MpPreference.md
@@ -16,14 +16,23 @@ Modifies settings for Windows Defender.
 ## SYNTAX
 
 ```
-Add-MpPreference [-ExclusionPath <String[]>] [-ExclusionExtension <String[]>]
-[-ExclusionProcess <String[]>] [-ExclusionIpAddress <String[]>]
-[-ThreatIDDefaultAction_Ids <Int64[]>] [-ThreatIDDefaultAction_Actions <ThreatAction[]>]
-[-AttackSurfaceReductionOnlyExclusions <String[]>]
-[-ControlledFolderAccessAllowedApplications <String[]>]
-[-ControlledFolderAccessProtectedFolders <String[]>] [-AttackSurfaceReductionRules_Ids <String[]>]
-[-AttackSurfaceReductionRules_Actions <ASRRuleActionType[]>] [-Force] [-CimSession <CimSession[]>]
-[-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
+Add-MpPreference
+ [-AsJob]
+ [-AttackSurfaceReductionOnlyExclusions <String[]>]
+ [-AttackSurfaceReductionRules_Actions <ASRRuleActionType[]>]
+ [-AttackSurfaceReductionRules_Ids <String[]>]
+ [-CimSession <CimSession[]>]
+ [-ControlledFolderAccessAllowedApplications <String[]>]
+ [-ControlledFolderAccessProtectedFolders <String[]>]
+ [-ExclusionExtension <String[]>]
+ [-ExclusionIpAddress <String[]>]
+ [-ExclusionPath <String[]>]
+ [-ExclusionProcess <String[]>]
+ [-Force]
+ [-ThreatIDDefaultAction_Actions <ThreatAction[]>]
+ [-ThreatIDDefaultAction_Ids <Int64[]>]
+ [-ThrottleLimit <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -69,7 +78,7 @@ For more information about Windows PowerShell background jobs, see
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -212,7 +221,7 @@ Specifies an array of IP addresses to exclude from scheduled and real-time scann
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -229,7 +238,7 @@ You can specify a folder to exclude all the files under the folder.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -248,7 +257,7 @@ themselves. To exclude a process, specify it by using the **ExclusionPath** para
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -264,7 +273,7 @@ Forces the command to run without asking for user confirmation.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -327,7 +336,7 @@ computer.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/docset/winserver2022-ps/defender/Get-MpComputerStatus.md
+++ b/docset/winserver2022-ps/defender/Get-MpComputerStatus.md
@@ -16,8 +16,11 @@ Gets the status of antimalware software on the computer.
 ## SYNTAX
 
 ```
-Get-MpComputerStatus [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
-[<CommonParameters>]
+Get-MpComputerStatus
+ [-AsJob]
+ [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,7 +32,7 @@ computer.
 
 ### Example 1: Get the computer status
 
-```
+```powershell
 PS C:\> Get-MpComputerStatus
 AMEngineVersion                  : 1.1.24050.5
 AMProductVersion                 : 4.18.24050.7
@@ -45,18 +48,18 @@ AntivirusSignatureAge            : 1
 AntivirusSignatureLastUpdated    : 6/4/2024 8:06:27 AM
 AntivirusSignatureVersion        : 1.413.102.0
 BehaviorMonitorEnabled           : True
-ComputerID                       : 
+ComputerID                       :
 ComputerState                    : 0
 DefenderSignaturesOutOfDate      : False
-DeviceControlDefaultEnforcement  : 
+DeviceControlDefaultEnforcement  :
 DeviceControlPoliciesLastUpdated : 12/31/1600 4:00:00 PM
 DeviceControlState               : Disabled
 FullScanAge                      : 4294967295
-FullScanEndTime                  : 
+FullScanEndTime                  :
 FullScanOverdue                  : False
 FullScanRequired                 : False
-FullScanSignatureVersion         : 
-FullScanStartTime                : 
+FullScanSignatureVersion         :
+FullScanStartTime                :
 InitializationProgress           : ServiceStartedSuccessfully
 IoavProtectionEnabled            : True
 IsTamperProtected                : False
@@ -71,14 +74,14 @@ NISSignatureVersion              : 1.413.102.0
 OnAccessProtectionEnabled        : True
 ProductStatus                    : 524288
 QuickScanAge                     : 4294967295
-QuickScanEndTime                 : 
+QuickScanEndTime                 :
 QuickScanOverdue                 : False
-QuickScanSignatureVersion        : 
-QuickScanStartTime               : 
+QuickScanSignatureVersion        :
+QuickScanStartTime               :
 RealTimeProtectionEnabled        : True
 RealTimeScanDirection            : 0
 RebootRequired                   : False
-SmartAppControlExpiration        : 
+SmartAppControlExpiration        :
 SmartAppControlState             : Off
 TamperProtectionSource           : E5 transition
 TDTCapable                       : N/A
@@ -95,7 +98,6 @@ TroubleShootingModeSource        : ATP
 TroubleShootingQuotaResetTime    : 6/5/2024 4:47:42 PM
 TroubleShootingStartTime         : N/A
 PSComputerName                   :
-
 ```
 
 This command gets the status of antimalware protection software installed on the computer.
@@ -118,7 +120,7 @@ For more information about Windows PowerShell background jobs, see
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -157,7 +159,7 @@ computer.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/docset/winserver2022-ps/defender/Get-MpPreference.md
+++ b/docset/winserver2022-ps/defender/Get-MpPreference.md
@@ -16,8 +16,11 @@ Gets preferences for the Windows Defender scans and updates.
 ## SYNTAX
 
 ```
-Get-MpPreference [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
-[<CommonParameters>]
+Get-MpPreference
+ [-AsJob]
+ [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,7 +33,7 @@ information about the preferences that this cmdlet retrieves, see
 
 ### Example 1: View the scheduled scan day
 
-```
+```powershell
 PS C:\> $Preferences = Get-MpPreference
 PS C:\> $Preferences.ScanScheduleDay
 ```
@@ -58,7 +61,7 @@ For more information about Windows PowerShell background jobs, see
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -97,7 +100,7 @@ computer.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/docset/winserver2022-ps/defender/Get-MpThreat.md
+++ b/docset/winserver2022-ps/defender/Get-MpThreat.md
@@ -24,8 +24,12 @@ Get-MpThreat [<CommonParameters>]
 ### ById
 
 ```
-Get-MpThreat [-ThreatID <Int64[]>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
-[<CommonParameters>]
+Get-MpThreat
+ [-AsJob]
+ [-CimSession <CimSession[]>]
+ [-ThreatID <Int64[]>]
+ [-ThrottleLimit <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -37,7 +41,7 @@ computer.
 
 ### Example 1: Get the history of a detected threat
 
-```
+```powershell
 PS C:\> Get-MpThreat -ThreatID 1994
 ```
 
@@ -61,7 +65,7 @@ For more information about Windows PowerShell background jobs, see
 ```yaml
 Type: SwitchParameter
 Parameter Sets: ById
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -117,7 +121,7 @@ computer.
 ```yaml
 Type: Int32
 Parameter Sets: ById
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -146,4 +150,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Get-MpThreatCatalog](./Get-MpThreatCatalog.md)
 
 [Get-MpThreatDetection](./Get-MpThreatDetection.md)
-

--- a/docset/winserver2022-ps/defender/Get-MpThreatCatalog.md
+++ b/docset/winserver2022-ps/defender/Get-MpThreatCatalog.md
@@ -24,7 +24,11 @@ Get-MpThreatCatalog [<CommonParameters>]
 ### ById
 
 ```
-Get-MpThreatCatalog [-ThreatID <Int64[]>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+Get-MpThreatCatalog
+ [-AsJob]
+ [-CimSession <CimSession[]>]
+ [-ThreatID <Int64[]>]
+ [-ThrottleLimit <Int32>]
  [<CommonParameters>]
 ```
 
@@ -37,7 +41,7 @@ The definitions catalog contains references to all known threats that Windows De
 
 ### Example 1: Get a known threat from the definitions catalog
 
-```
+```powershell
 PS C:\> Get-MpThreatCatalog -ThreatID 1994
 ```
 
@@ -61,7 +65,7 @@ For more information about Windows PowerShell background jobs, see
 ```yaml
 Type: SwitchParameter
 Parameter Sets: ById
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -117,7 +121,7 @@ computer.
 ```yaml
 Type: Int32
 Parameter Sets: ById
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/docset/winserver2022-ps/defender/Get-MpThreatDetection.md
+++ b/docset/winserver2022-ps/defender/Get-MpThreatDetection.md
@@ -22,7 +22,11 @@ Get-MpThreatDetection [<CommonParameters>]
 
 ### ById
 ```
-Get-MpThreatDetection [-ThreatID <Int64[]>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+Get-MpThreatDetection
+ [-AsJob]
+ [-CimSession <CimSession[]>]
+ [-ThreatID <Int64[]>]
+ [-ThrottleLimit <Int32>]
  [<CommonParameters>]
 ```
 
@@ -33,7 +37,7 @@ If Windows Defender has detected the threat that you specify, this cmdlet return
 ## EXAMPLES
 
 ### Example 1: Get threats that Windows Defender detected
-```
+```powershell
 PS C:\> Get-MpThreatDetection
 ```
 
@@ -41,7 +45,7 @@ This command returns the list of past malware detections for the local computer.
 
 **Error codes**
 
-The following table lists the hexadecimal and decimal error codes for this cmdlet. Each hexadecimal error code has a 0x8050 prefix. Therefore, an ERROR_MP_BAD_SCANID error corresponds to error code 0x80508012. Additionally, an ERR_MP_REMOVE_FAILED error corresponds to error code 0x80508017. 
+The following table lists the hexadecimal and decimal error codes for this cmdlet. Each hexadecimal error code has a 0x8050 prefix. Therefore, an ERROR_MP_BAD_SCANID error corresponds to error code 0x80508012. Additionally, an ERR_MP_REMOVE_FAILED error corresponds to error code 0x80508017.
 
 For a list of error codes, along with possible reasons and resolutions, see [Windows Defender Antivirus client error codes](/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus#windows-defender-antivirus-client-error-codes) in the topic [Review event logs and error codes to troubleshoot issues with Windows Defender Antivirus](/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus#windows-defender-antivirus-client-error-codes).
 
@@ -87,19 +91,19 @@ For a list of error codes, along with possible reasons and resolutions, see [Win
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete. 
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
 
-The cmdlet immediately returns an object that represents the job and then displays the command prompt. 
-You can continue to work in the session while the job completes. 
-To manage the job, use the `*-Job` cmdlets. 
-To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+The cmdlet immediately returns an object that represents the job and then displays the command prompt.
+You can continue to work in the session while the job completes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet.
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: ById
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -109,8 +113,8 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. 
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. 
+Runs the cmdlet in a remote session or on a remote computer.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -149,7 +153,7 @@ The throttle limit applies only to the current cmdlet, not to the session or to 
 ```yaml
 Type: Int32
 Parameter Sets: ById
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/docset/winserver2022-ps/defender/Remove-MpPreference.md
+++ b/docset/winserver2022-ps/defender/Remove-MpPreference.md
@@ -16,36 +16,105 @@ Removes exclusions or default actions.
 ## SYNTAX
 
 ```
-Remove-MpPreference [-ExclusionPath <String[]>] [-ExclusionExtension <String[]>] [-ExclusionProcess <String[]>]
- [-ExclusionIpAddress <String[]>] [-RealTimeScanDirection] [-QuarantinePurgeItemsAfterDelay]
- [-RemediationScheduleDay] [-RemediationScheduleTime] [-ReportingAdditionalActionTimeOut]
- [-ReportingCriticalFailureTimeOut] [-ReportingNonCriticalTimeOut] [-ScanAvgCPULoadFactor]
- [-CheckForSignaturesBeforeRunningScan] [-ScanPurgeItemsAfterDelay] [-ScanOnlyIfIdleEnabled] [-ScanParameters]
- [-ScanScheduleDay] [-ScanScheduleQuickScanTime] [-ScanScheduleTime] [-SignatureFirstAuGracePeriod]
- [-SignatureAuGracePeriod] [-SignatureDefinitionUpdateFileSharesSources]
- [-SignatureDisableUpdateOnStartupWithoutEngine] [-SignatureFallbackOrder] [-SharedSignaturesPath]
- [-SignatureScheduleDay] [-SignatureScheduleTime] [-SignatureUpdateCatchupInterval] [-SignatureUpdateInterval]
- [-SignatureBlobUpdateInterval] [-SignatureBlobFileSharesSources] [-MeteredConnectionUpdates]
- [-AllowNetworkProtectionOnWinServer] [-DisableDatagramProcessing] [-DisableCpuThrottleOnIdleScans]
- [-MAPSReporting] [-SubmitSamplesConsent] [-DisableAutoExclusions] [-DisablePrivacyMode]
- [-RandomizeScheduleTaskTimes] [-SchedulerRandomizationTime] [-DisableBehaviorMonitoring]
- [-DisableIntrusionPreventionSystem] [-DisableIOAVProtection] [-DisableRealtimeMonitoring]
- [-DisableScriptScanning] [-DisableArchiveScanning] [-DisableCatchupFullScan] [-DisableCatchupQuickScan]
- [-DisableEmailScanning] [-DisableRemovableDriveScanning] [-DisableRestorePoint]
- [-DisableScanningMappedNetworkDrivesForFullScan] [-DisableScanningNetworkFiles] [-UILockdown]
- [-ThreatIDDefaultAction_Ids <Int64[]>] [-ThreatIDDefaultAction_Actions <ThreatAction[]>]
- [-UnknownThreatDefaultAction] [-LowThreatDefaultAction] [-ModerateThreatDefaultAction]
- [-HighThreatDefaultAction] [-SevereThreatDefaultAction] [-DisableBlockAtFirstSeen] [-PUAProtection]
- [-CloudBlockLevel] [-CloudExtendedTimeout] [-EnableNetworkProtection] [-EnableControlledFolderAccess]
- [-AttackSurfaceReductionOnlyExclusions <String[]>] [-ControlledFolderAccessAllowedApplications <String[]>]
- [-ControlledFolderAccessProtectedFolders <String[]>] [-AttackSurfaceReductionRules_Ids <String[]>]
- [-AttackSurfaceReductionRules_Actions <ASRRuleActionType[]>] [-EnableLowCpuPriority]
- [-EnableFileHashComputation] [-EnableFullScanOnBatteryPower] [-ProxyPacUrl] [-ProxyServer] [-ProxyBypass]
- [-ForceUseProxyOnly] [-DisableTlsParsing] [-DisableHttpParsing] [-DisableDnsParsing]
- [-DisableDnsOverTcpParsing] [-DisableSshParsing] [-PlatformUpdatesChannel] [-EngineUpdatesChannel]
- [-SignaturesUpdatesChannel] [-DisableGradualRelease] [-AllowNetworkProtectionDownLevel]
- [-AllowDatagramProcessingOnWinServer] [-EnableDnsSinkhole] [-DisableInboundConnectionFiltering]
- [-DisableRdpParsing] [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+Remove-MpPreference
+ [-AllowDatagramProcessingOnWinServer]
+ [-AllowNetworkProtectionDownLevel]
+ [-AllowNetworkProtectionOnWinServer]
+ [-AsJob]
+ [-AttackSurfaceReductionOnlyExclusions <String[]>]
+ [-AttackSurfaceReductionRules_Actions <ASRRuleActionType[]>]
+ [-AttackSurfaceReductionRules_Ids <String[]>]
+ [-CheckForSignaturesBeforeRunningScan]
+ [-CimSession <CimSession[]>]
+ [-CloudBlockLevel]
+ [-CloudExtendedTimeout]
+ [-ControlledFolderAccessAllowedApplications <String[]>]
+ [-ControlledFolderAccessProtectedFolders <String[]>]
+ [-DisableArchiveScanning]
+ [-DisableAutoExclusions]
+ [-DisableBehaviorMonitoring]
+ [-DisableBlockAtFirstSeen]
+ [-DisableCatchupFullScan]
+ [-DisableCatchupQuickScan]
+ [-DisableCpuThrottleOnIdleScans]
+ [-DisableDatagramProcessing]
+ [-DisableDnsOverTcpParsing]
+ [-DisableDnsParsing]
+ [-DisableEmailScanning]
+ [-DisableGradualRelease]
+ [-DisableHttpParsing]
+ [-DisableIOAVProtection]
+ [-DisableInboundConnectionFiltering]
+ [-DisableIntrusionPreventionSystem]
+ [-DisablePrivacyMode]
+ [-DisableRdpParsing]
+ [-DisableRealtimeMonitoring]
+ [-DisableRemovableDriveScanning]
+ [-DisableRestorePoint]
+ [-DisableScanningMappedNetworkDrivesForFullScan]
+ [-DisableScanningNetworkFiles]
+ [-DisableScriptScanning]
+ [-DisableSshParsing]
+ [-DisableTlsParsing]
+ [-EnableControlledFolderAccess]
+ [-EnableDnsSinkhole]
+ [-EnableFileHashComputation]
+ [-EnableFullScanOnBatteryPower]
+ [-EnableLowCpuPriority]
+ [-EnableNetworkProtection]
+ [-EngineUpdatesChannel]
+ [-ExclusionExtension <String[]>]
+ [-ExclusionIpAddress <String[]>]
+ [-ExclusionPath <String[]>]
+ [-ExclusionProcess <String[]>]
+ [-ForceUseProxyOnly]
+ [-Force]
+ [-HighThreatDefaultAction]
+ [-LowThreatDefaultAction]
+ [-MAPSReporting]
+ [-MeteredConnectionUpdates]
+ [-ModerateThreatDefaultAction]
+ [-PUAProtection]
+ [-PlatformUpdatesChannel]
+ [-ProxyBypass]
+ [-ProxyPacUrl]
+ [-ProxyServer]
+ [-QuarantinePurgeItemsAfterDelay]
+ [-RandomizeScheduleTaskTimes]
+ [-RealTimeScanDirection]
+ [-RemediationScheduleDay]
+ [-RemediationScheduleTime]
+ [-ReportingAdditionalActionTimeOut]
+ [-ReportingCriticalFailureTimeOut]
+ [-ReportingNonCriticalTimeOut]
+ [-ScanAvgCPULoadFactor]
+ [-ScanOnlyIfIdleEnabled]
+ [-ScanParameters]
+ [-ScanPurgeItemsAfterDelay]
+ [-ScanScheduleDay]
+ [-ScanScheduleQuickScanTime]
+ [-ScanScheduleTime]
+ [-SchedulerRandomizationTime]
+ [-SevereThreatDefaultAction]
+ [-SharedSignaturesPath]
+ [-SignatureAuGracePeriod]
+ [-SignatureBlobFileSharesSources]
+ [-SignatureBlobUpdateInterval]
+ [-SignatureDefinitionUpdateFileSharesSources]
+ [-SignatureDisableUpdateOnStartupWithoutEngine]
+ [-SignatureFallbackOrder]
+ [-SignatureFirstAuGracePeriod]
+ [-SignatureScheduleDay]
+ [-SignatureScheduleTime]
+ [-SignatureUpdateCatchupInterval]
+ [-SignatureUpdateInterval]
+ [-SignaturesUpdatesChannel]
+ [-SubmitSamplesConsent]
+ [-ThreatIDDefaultAction_Actions <ThreatAction[]>]
+ [-ThreatIDDefaultAction_Ids <Int64[]>]
+ [-ThrottleLimit <Int32>]
+ [-UILockdown]
+ [-UnknownThreatDefaultAction]
  [<CommonParameters>]
 ```
 
@@ -56,14 +125,14 @@ If you attempt to remove an exclusion that is not in the list, this cmdlet repor
 ## EXAMPLES
 
 ### Example 1: Remove a folder from the exclusion list
-```
+```powershell
 Remove-MpPreference -ExclusionPath "C:\Temp"
 ```
 
 This command removes the folder C:\Temp from the exclusion list.
 
 ### Example 2: Exclude a specific file
-```
+```powershell
 Remove-MpPreference -AttackSurfaceReductionOnlyExclusions "C:\Windows\App.exe"
 ```
 
@@ -117,19 +186,19 @@ Accept wildcard characters: False
 ```
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete. 
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
 
-The cmdlet immediately returns an object that represents the job and then displays the command prompt. 
-You can continue to work in the session while the job completes. 
-To manage the job, use the `*-Job` cmdlets. 
-To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+The cmdlet immediately returns an object that represents the job and then displays the command prompt.
+You can continue to work in the session while the job completes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet.
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -137,7 +206,6 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-
 
 ### -AttackSurfaceReductionOnlyExclusions
 Specifies the files and paths to exclude from Attack Surface Reduction (ASR) rules. Specify the folders or files and resources that should be excluded from ASR rules. Enter a folder path or a fully qualified resource name. For example, ""C:\Windows"" will exclude all files in that directory. ""C:\Windows\App.exe"" will exclude only that specific file in that specific folder.
@@ -205,7 +273,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. 
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -448,15 +516,15 @@ Accept wildcard characters: False
 ```
 
 ### -DisableGradualRelease
-Indicates that the cmdlet removes whether to disable gradual rollout of monthly and daily Windows Defender updates. 
+Indicates that the cmdlet removes whether to disable gradual rollout of monthly and daily Windows Defender updates.
 If you enable this option, devices are offered all updates after the gradual release cycle finishes.
-Consider this option for datacenter computers that only receive limited updates. 
+Consider this option for datacenter computers that only receive limited updates.
 
 This setting applies to both monthly and daily updates.
-It overrides any previously configured channel selections for platform and engine updates. 
+It overrides any previously configured channel selections for platform and engine updates.
 
 If you disable or do not configure this policy, the device remains in Current Channel (Default) unless specified otherwise in specific channels for platform and engine updates.
-The device stays up to date automatically during the gradual release cycle, which is suitable for most devices. 
+The device stays up to date automatically during the gradual release cycle, which is suitable for most devices.
 
 This policy is available starting with platform version 4.18.2106.5 and later.
 
@@ -704,7 +772,7 @@ Accept wildcard characters: False
 ```
 
 ### -EnableDnsSinkhole
-Indicates that the cmdlet removes whether to examine DNS traffic to detect and sinkhole DNS exfiltration attempts and other DNS based malicious attacks. 
+Indicates that the cmdlet removes whether to examine DNS traffic to detect and sinkhole DNS exfiltration attempts and other DNS based malicious attacks.
 
 ```yaml
 Type: SwitchParameter
@@ -825,7 +893,7 @@ Specifies an array of IP addresses to exclude from scheduled and real-time scann
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -841,7 +909,7 @@ This cmdlet removes the exclusions that you specify.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -857,7 +925,7 @@ This cmdlet removes exclusions of files opened by the processes that you specify
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -872,7 +940,7 @@ Forces the command to run without asking for user confirmation.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -1533,12 +1601,12 @@ Accept wildcard characters: False
 Specifies an array of the actions to take for the IDs specified by using the **ThreatIDDefaultAction_Ids** parameter.
 The acceptable values for this parameter are:
 
-- 1: Clean 
-- 2: Quarantine 
-- 3: Remove 
-- 6: Allow 
-- 8: UserDefined 
-- 9: NoAction 
+- 1: Clean
+- 2: Quarantine
+- 3: Remove
+- 6: Allow
+- 8: UserDefined
+- 9: NoAction
 - 10: Block
 
 >[!NOTE]
@@ -1580,7 +1648,7 @@ The throttle limit applies only to the current cmdlet, not to the session or to 
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/docset/winserver2022-ps/defender/Remove-MpThreat.md
+++ b/docset/winserver2022-ps/defender/Remove-MpThreat.md
@@ -16,7 +16,11 @@ Removes active threats from a computer.
 ## SYNTAX
 
 ```
-Remove-MpThreat [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
+Remove-MpThreat
+ [-AsJob]
+ [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -25,7 +29,7 @@ The **Remove-MpThreat** cmdlet removes all active threats that Windows Defender 
 ## EXAMPLES
 
 ### Example 1: Remove active threats from a computer
-```
+```powershell
 PS C:\> Remove-MpThreat
 ```
 
@@ -34,19 +38,19 @@ This command removes all active threats from the local computer.
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete. 
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
 
-The cmdlet immediately returns an object that represents the job and then displays the command prompt. 
-You can continue to work in the session while the job completes. 
-To manage the job, use the `*-Job` cmdlets. 
-To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+The cmdlet immediately returns an object that represents the job and then displays the command prompt.
+You can continue to work in the session while the job completes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet.
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -56,8 +60,8 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. 
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. 
+Runs the cmdlet in a remote session or on a remote computer.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -80,7 +84,7 @@ The throttle limit applies only to the current cmdlet, not to the session or to 
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/docset/winserver2022-ps/defender/Set-MpPreference.md
+++ b/docset/winserver2022-ps/defender/Set-MpPreference.md
@@ -15,57 +15,116 @@ Configures preferences for Windows Defender scans and updates.
 
 ## SYNTAX
 
-
 ```powershell
-Set-MpPreference [-ExclusionPath <String[]>] [-ExclusionExtension <String[]>] [-ExclusionProcess <String[]>]
- [-ExclusionIpAddress <String[]>] [-RealTimeScanDirection <ScanDirection>]
- [-IntelTDTEnabled <UInt32>]
- [-QuarantinePurgeItemsAfterDelay <UInt32>] [-RemediationScheduleDay <Day>]
- [-RemediationScheduleTime <DateTime>] [-ReportingAdditionalActionTimeOut <UInt32>]
- [-ReportingCriticalFailureTimeOut <UInt32>] [-ReportingNonCriticalTimeOut <UInt32>]
- [-ScanAvgCPULoadFactor <Byte>] [-CheckForSignaturesBeforeRunningScan <Boolean>]
- [-ScanPurgeItemsAfterDelay <UInt32>] [-ScanOnlyIfIdleEnabled <Boolean>] [-ScanParameters <ScanType>]
- [-ScanScheduleDay <Day>] [-ScanScheduleQuickScanTime <DateTime>] [-ScanScheduleOffset <UInt32>]
- [-ScanScheduleTime <HH:MM:SS>]
- [-SignatureFirstAuGracePeriod <UInt32>] [-SignatureAuGracePeriod <UInt32>]
- [-SignatureDefinitionUpdateFileSharesSources <String>]
- [-SignatureDisableUpdateOnStartupWithoutEngine <Boolean>] [-SignatureFallbackOrder <String>]
- [-SharedSignaturesPath <String>] [-SignatureScheduleDay <Day>] [-SignatureScheduleTime <DateTime>]
- [-SignatureUpdateCatchupInterval <UInt32>] [-SignatureUpdateInterval <UInt32>]
- [-SignatureBlobUpdateInterval <UInt32>] [-SignatureBlobFileSharesSources <String>]
- [-MeteredConnectionUpdates <Boolean>] [-AllowNetworkProtectionOnWinServer <Boolean>]
- [-DisableDatagramProcessing <Boolean>] [-DisableCpuThrottleOnIdleScans <Boolean>]
- [-MAPSReporting <MAPSReportingType>] [-SubmitSamplesConsent <SubmitSamplesConsentType>]
- [-DisableAutoExclusions <Boolean>] [-DisablePrivacyMode <Boolean>] [-RandomizeScheduleTaskTimes <Boolean>]
- [-SchedulerRandomizationTime <UInt32>] [-DisableBehaviorMonitoring <Boolean>]
- [-DisableRealtimeMonitoring <Boolean>] [-DisableScriptScanning <Boolean>] [-DisableArchiveScanning <Boolean>] [-DisableCacheMaintenance <UInt32>]
- [-DisableCatchupFullScan <Boolean>] [-DisableCatchupQuickScan <Boolean>] [-DisableEmailScanning <Boolean>]
- [-DisableRemovableDriveScanning <Boolean>] [-DisableRestorePoint <Boolean>]
- [-DisableScanningMappedNetworkDrivesForFullScan <Boolean>] [-DisableScanningNetworkFiles <Boolean>]
- [-DisableIOAVProtection <Boolean>] [-AllowSwitchToAsyncInspection <Boolean>]
- [-UILockdown <Boolean>] [-ThreatIDDefaultAction_Ids <Int64[]>]
- [-ThreatIDDefaultAction_Actions <ThreatAction[]>] [-UnknownThreatDefaultAction <ThreatAction>]
- [-LowThreatDefaultAction <ThreatAction>] [-ModerateThreatDefaultAction <ThreatAction>]
- [-HighThreatDefaultAction <ThreatAction>] [-SevereThreatDefaultAction <ThreatAction>] [-Force]
- [-DisableBlockAtFirstSeen <Boolean>] [-PUAProtection <PUAProtectionType>]
- [-ThrottleLimit <Int32>] [-AsJob]  [<CommonParameters>] [-DisableGradualRelease <Boolean>] [-DefinitionUpdatesChannel <UpdatesChannelType>] [-EngineUpdatesChannel <UpdatesChannelType>] [-PlatformUpdatesChannel <UpdatesChannelType>][-CloudBlockLevel <CloudBlockLevelType>][-ServiceHealthReportInterval <UInt32>]
- [-CloudBlockLevel <CloudBlockLevelType>] [-CloudExtendedTimeout <UInt32>]
- [-EnableNetworkProtection <ASRRuleActionType>] [-EnableControlledFolderAccess <ControlledFolderAccessType>]
- [-AttackSurfaceReductionOnlyExclusions <String[]>] [-ControlledFolderAccessAllowedApplications <String[]>]
- [-ControlledFolderAccessProtectedFolders <String[]>] [-AttackSurfaceReductionRules_Ids <String[]>]
- [-AttackSurfaceReductionRules_Actions <ASRRuleActionType[]>] [-EnableLowCpuPriority <Boolean>]
- [-EnableFileHashComputation <Boolean>] [-EnableFullScanOnBatteryPower <Boolean>] [-ProxyPacUrl <String>]
- [-ProxyServer <String>] [-ProxyBypass <String[]>] [-ForceUseProxyOnly <Boolean>]
- [-OobeEnableRtpAndSigUpdate <Boolean>]
- [-DisableTlsParsing <Boolean>] [-DisableHttpParsing <Boolean>] [-DisableDnsParsing <Boolean>]
- [-DisableFtpParsing <Boolean>] [-DisableSmtpParsing <Boolean>]
- [-DisableDnsOverTcpParsing <Boolean>] [-DisableSshParsing <Boolean>]
+Set-MpPreference
+ [-AllowDatagramProcessingOnWinServer <Boolean>]
+ [-AllowNetworkProtectionDownLevel <Boolean>]
+ [-AllowNetworkProtectionOnWinServer <Boolean>]
+ [-AllowSwitchToAsyncInspection <Boolean>]
+ [-AsJob]
+ [-AttackSurfaceReductionOnlyExclusions <String[]>]
+ [-AttackSurfaceReductionRules_Actions <ASRRuleActionType[]>]
+ [-AttackSurfaceReductionRules_Ids <String[]>]
+ [-CheckForSignaturesBeforeRunningScan <Boolean>]
+ [-CimSession <CimSession[]>]
+ [-CloudBlockLevel <CloudBlockLevelType>]
+ [-CloudExtendedTimeout <UInt32>]
+ [-ControlledFolderAccessAllowedApplications <String[]>]
+ [-ControlledFolderAccessProtectedFolders <String[]>]
+ [-DefinitionUpdatesChannel <UpdatesChannelType>]
+ [-DisableArchiveScanning <Boolean>]
+ [-DisableAutoExclusions <Boolean>]
+ [-DisableBehaviorMonitoring <Boolean>]
+ [-DisableBlockAtFirstSeen <Boolean>]
+ [-DisableCacheMaintenance <UInt32>]
+ [-DisableCatchupFullScan <Boolean>]
+ [-DisableCatchupQuickScan <Boolean>]
+ [-DisableCpuThrottleOnIdleScans <Boolean>]
+ [-DisableDatagramProcessing <Boolean>]
+ [-DisableDnsOverTcpParsing <Boolean>]
+ [-DisableDnsParsing <Boolean>]
+ [-DisableEmailScanning <Boolean>]
+ [-DisableFtpParsing <Boolean>]
+ [-DisableGradualRelease <Boolean>]
+ [-DisableHttpParsing <Boolean>]
+ [-DisableIOAVProtection <Boolean>]
+ [-DisableInboundConnectionFiltering <Boolean>]
  [-DisableNetworkProtectionPerfTelemetry <Boolean>]
- [-PlatformUpdatesChannel <UpdatesChannelType>] [-EngineUpdatesChannel <UpdatesChannelType>]
- [-SignaturesUpdatesChannel <UpdatesChannelType>] [-DisableGradualRelease <Boolean>]
- [-AllowNetworkProtectionDownLevel <Boolean>] [-AllowDatagramProcessingOnWinServer <Boolean>]
- [-EnableDnsSinkhole <Boolean>] [-DisableInboundConnectionFiltering <Boolean>] [-DisableRdpParsing <Boolean>]
- [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
+ [-DisablePrivacyMode <Boolean>]
+ [-DisableRdpParsing <Boolean>]
+ [-DisableRealtimeMonitoring <Boolean>]
+ [-DisableRemovableDriveScanning <Boolean>]
+ [-DisableRestorePoint <Boolean>]
+ [-DisableScanningMappedNetworkDrivesForFullScan <Boolean>]
+ [-DisableScanningNetworkFiles <Boolean>]
+ [-DisableScriptScanning <Boolean>]
+ [-DisableSmtpParsing <Boolean>]
+ [-DisableSshParsing <Boolean>]
+ [-DisableTlsParsing <Boolean>]
+ [-EnableControlledFolderAccess <ControlledFolderAccessType>]
+ [-EnableDnsSinkhole <Boolean>]
+ [-EnableFileHashComputation <Boolean>]
+ [-EnableFullScanOnBatteryPower <Boolean>]
+ [-EnableLowCpuPriority <Boolean>]
+ [-EnableNetworkProtection <ASRRuleActionType>]
+ [-EngineUpdatesChannel <UpdatesChannelType>]
+ [-ExclusionExtension <String[]>]
+ [-ExclusionIpAddress <String[]>]
+ [-ExclusionPath <String[]>]
+ [-ExclusionProcess <String[]>]
+ [-ForceUseProxyOnly <Boolean>]
+ [-Force]
+ [-HighThreatDefaultAction <ThreatAction>]
+ [-IntelTDTEnabled <UInt32>]
+ [-LowThreatDefaultAction <ThreatAction>]
+ [-MAPSReporting <MAPSReportingType>]
+ [-MeteredConnectionUpdates <Boolean>]
+ [-ModerateThreatDefaultAction <ThreatAction>]
+ [-OobeEnableRtpAndSigUpdate <Boolean>]
+ [-PUAProtection <PUAProtectionType>]
+ [-PlatformUpdatesChannel <UpdatesChannelType>]
+ [-ProxyBypass <String[]>]
+ [-ProxyPacUrl <String>]
+ [-ProxyServer <String>]
+ [-QuarantinePurgeItemsAfterDelay <UInt32>]
+ [-RandomizeScheduleTaskTimes <Boolean>]
+ [-RealTimeScanDirection <ScanDirection>]
+ [-RemediationScheduleDay <Day>]
+ [-RemediationScheduleTime <DateTime>]
+ [-ReportingAdditionalActionTimeOut <UInt32>]
+ [-ReportingCriticalFailureTimeOut <UInt32>]
+ [-ReportingNonCriticalTimeOut <UInt32>]
+ [-ScanAvgCPULoadFactor <Byte>]
+ [-ScanOnlyIfIdleEnabled <Boolean>]
+ [-ScanParameters <ScanType>]
+ [-ScanPurgeItemsAfterDelay <UInt32>]
+ [-ScanScheduleDay <Day>]
+ [-ScanScheduleOffset <UInt32>]
+ [-ScanScheduleQuickScanTime <DateTime>]
+ [-ScanScheduleTime <HH:MM:SS>]
+ [-SchedulerRandomizationTime <UInt32>]
+ [-ServiceHealthReportInterval <UInt32>]
+ [-SevereThreatDefaultAction <ThreatAction>]
+ [-SharedSignaturesPath <String>]
+ [-SignatureAuGracePeriod <UInt32>]
+ [-SignatureBlobFileSharesSources <String>]
+ [-SignatureBlobUpdateInterval <UInt32>]
+ [-SignatureDefinitionUpdateFileSharesSources <String>]
+ [-SignatureDisableUpdateOnStartupWithoutEngine <Boolean>]
+ [-SignatureFallbackOrder <String>]
+ [-SignatureFirstAuGracePeriod <UInt32>]
+ [-SignatureScheduleDay <Day>]
+ [-SignatureScheduleTime <DateTime>]
+ [-SignatureUpdateCatchupInterval <UInt32>]
+ [-SignatureUpdateInterval <UInt32>]
+ [-SignaturesUpdatesChannel <UpdatesChannelType>]
+ [-SubmitSamplesConsent <SubmitSamplesConsentType>]
+ [-ThreatIDDefaultAction_Actions <ThreatAction[]>]
+ [-ThreatIDDefaultAction_Ids <Int64[]>]
+ [-ThrottleLimit <Int32>]
+ [-UILockdown <Boolean>]
+ [-UnknownThreatDefaultAction <ThreatAction>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -91,7 +150,7 @@ The following table provides remediation action values for detected threats at l
 
 ### Example 1: Schedule to check for definition updates everyday
 
-```sql
+```powershell
 PS C:\> Set-MpPreference -SignatureScheduleDay Everyday
 ```
 
@@ -99,7 +158,7 @@ This command configures preferences to check for definition updates every day.
 
 ### Example 2: Schedule a time of day to check for definition updates
 
-```sql
+```powershell
 PS C:\> Set-MpPreference -SignatureScheduleTime 02:00:00
 ```
 
@@ -152,7 +211,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-
 ### -AllowSwitchToAsyncInspection
 
 Specifies whether to enable a performance optimization that allows synchronously inspected network flows to switch to async inspection once they have been checked and validated.
@@ -160,7 +218,7 @@ Specifies whether to enable a performance optimization that allows synchronously
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -169,14 +227,13 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete. 
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
 
-The cmdlet immediately returns an object that represents the job and then displays the command prompt. 
-You can continue to work in the session while the job completes. 
-To manage the job, use the `*-Job` cmdlets. 
-To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+The cmdlet immediately returns an object that represents the job and then displays the command prompt.
+You can continue to work in the session while the job completes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet.
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
@@ -232,7 +289,7 @@ If you add multiple rules as a comma-separated list, specify their states separa
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -260,8 +317,8 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. 
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. 
+Runs the cmdlet in a remote session or on a remote computer.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -411,7 +468,7 @@ Aliases: dcm
 
 Required: False
 Position: Named
-Default value: 0 
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -428,7 +485,7 @@ Aliases: dcfsc
 
 Required: False
 Position: Named
-Default value: 0 
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -543,15 +600,15 @@ Accept wildcard characters: False
 ```
 
 ### -DisableGradualRelease
-Specifies whether to disable gradual rollout of monthly and daily Windows Defender updates. 
+Specifies whether to disable gradual rollout of monthly and daily Windows Defender updates.
 If you enable this option, devices are offered all updates after the gradual release cycle finishes.
-Consider this option for datacenter computers that only receive limited updates. 
+Consider this option for datacenter computers that only receive limited updates.
 
 This setting applies to both monthly and daily updates.
-It overrides configured channel selections for platform and engine updates. 
+It overrides configured channel selections for platform and engine updates.
 
 If you disable or do not configure this policy, the device remains in Current Channel (Default) unless specified otherwise in specific channels.
-The device stays up to date automatically during the gradual release cycle, which is suitable for most devices. 
+The device stays up to date automatically during the gradual release cycle, which is suitable for most devices.
 
 This policy is available starting with platform version 4.18.2106.5 and later.
 
@@ -615,9 +672,10 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DisableNetworkProtectionPerfTelemetry 
-This setting disables the gathering and sending of performance telemetry from network protection. 
+### -DisableNetworkProtectionPerfTelemetry
+This setting disables the gathering and sending of performance telemetry from network protection.
 The accepted values are 0 and 1.
+
 - 1- Network protection telemetry is disabled.
 - 0 (Default) - Network protection telemetry is enabled.
 
@@ -728,7 +786,7 @@ Accept wildcard characters: False
 ```
 
 ### -DisableScanningNetworkFiles
-Indicates whether to scan for network files. If you specify a value of $False or do not specify a value, Windows Defender scans network files. If you specify a value of $True, Windows Defender does not scan network files. 
+Indicates whether to scan for network files. If you specify a value of $False or do not specify a value, Windows Defender scans network files. If you specify a value of $True, Windows Defender does not scan network files.
 
 ```yaml
 Type: Boolean
@@ -774,9 +832,10 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DisableSmtpParsing 
+### -DisableSmtpParsing
 This setting disables SMTP parsing for network protection.
 The accepted values are 0 and 1.
+
 - 1 - SMTP parsing is disabled.
 - 0 (Default) - SMTP parsing is enabled.
 
@@ -916,7 +975,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### Enable UdpReceiveOffload: 
+### Enable UdpReceiveOffload:
 Specifies whether UDP receive offload support in Network Protection is enabled, resulting in potentially higher UDP bandwidth in the inbound direction. Starting with platform version `4.18.24030`, Microsoft will gradually move this support default from disabled to enabled. This setting can be manually controlled by setting it to `1` to enable and `0` to disable.
 
 ```yaml
@@ -931,7 +990,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### Enable UdpSegmentationOffload: 
+### Enable UdpSegmentationOffload:
 Specifies whether UDP segmentation offload support in Network Protection is enabled, resulting in potentially higher UDP bandwidth in the outbound direction. Starting with platform version `4.18.24030`, Microsoft will gradually move this support default from disabled to enabled. This setting can be manually controlled by setting it to `1` to enable and `0` to disable.
 
 ```yaml
@@ -990,7 +1049,7 @@ Specifies an array of IP addresses to exclude from scheduled and real-time scann
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -1006,7 +1065,7 @@ You can specify a folder to exclude all the files under the folder.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -1025,7 +1084,7 @@ To exclude a process, specify it by using the **ExclusionPath** parameter.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -1068,8 +1127,8 @@ Accept wildcard characters: False
 Specifies which automatic remediation action to take for a high level threat.
 The acceptable values for this parameter are:
 
-- Quarantine 
-- Remove 
+- Quarantine
+- Remove
 - Ignore
 
 ```yaml
@@ -1088,6 +1147,7 @@ Accept wildcard characters: False
 ### -IntelTDTEnabled
 This policy setting configures the Intel TDT integration level for Intel TDT-capable devices.
 The acceptable values for this parameter are:
+
 - 0 (Default) - If you don't configure this setting, the default value will be applied. The default value is controlled by Microsoft security intelligence updates. Microsoft will enable Intel TDT if there is a known threat.
 - 1 - If you configure this setting to enabled, Intel TDT integration will turn on.
 - 2 - If you configure this setting to disabled, Intel TDT integration will turn off.
@@ -1136,7 +1196,7 @@ The acceptable values for this parameter are:
 Send no information to Microsoft.
 This is the default value.
 - 1: Basic membership.
-Send basic information to Microsoft about detected software, including where the software came from, the actions that you apply or that apply automatically, and whether the actions succeeded. 
+Send basic information to Microsoft about detected software, including where the software came from, the actions that you apply or that apply automatically, and whether the actions succeeded.
 - 2: Advanced membership.
 In addition to basic information, send more information to Microsoft about malicious software, spyware, and potentially unwanted software, including the location of the software, file names, how the software operates, and how it affects your computer.
 
@@ -1148,7 +1208,7 @@ However, Microsoft will not use this information to identify you or contact you.
 ```yaml
 Type: MAPSReportingType
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: Disabled, Basic, Advanced
 
 Required: False
@@ -1178,8 +1238,8 @@ Accept wildcard characters: False
 Specifies which automatic remediation action to take for a moderate level threat.
 The acceptable values for this parameter are:
 
-- Quarantine 
-- Remove 
+- Quarantine
+- Remove
 - Ignore
 
 ```yaml
@@ -1200,13 +1260,14 @@ Accept wildcard characters: False
 This setting allows you to configure whether real-time protection and Security Intelligence Updates are enabled during Out of Box experience (OOBE).
 
 Valid values are:
+
 - True - If you enable this setting, real-time protection and Security Intelligence Updates are enabled during OOBE.
 - False (Default) - If you either disable or don't configure this setting, real-time protection and Security Intelligence Updates during OOBE aren't enabled.
 
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -1290,7 +1351,7 @@ When potentially unwanted software is downloaded or attempts to install itself o
 ```yaml
 Type: PUAProtectionType
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: Disabled, Enabled, AuditMode
 
 Required: False
@@ -1339,9 +1400,9 @@ Specifies scanning configuration for incoming and outgoing files on NTFS volumes
 The acceptable values for this parameter are:
 
 - 0: Scan both incoming and outgoing files.
-This is the default. 
-- 1: Scan incoming files only. 
-- 2: Scan outgoing files only. 
+This is the default.
+- 1: Scan incoming files only.
+- 2: Scan outgoing files only.
 
 Specify a value for this parameter to enhance performance on servers which have a large number of file transfers, but need scanning for either incoming or outgoing files.
 Evaluate this configuration based on the server role.
@@ -1368,12 +1429,12 @@ The acceptable values for this parameter are:
 - 0: Everyday
 - 1: Sunday
 - 2: Monday
-- 3: Tuesday 
+- 3: Tuesday
 - 4: Wednesday
-- 5: Thursday 
+- 5: Thursday
 - 6: Friday
 - 7: Saturday
-- 8: Never 
+- 8: Never
 
 The default value is 8, never.
 If you specify a value of 8 or do not specify a value, Windows Defender performs a scheduled full scan to complete remediation by using a default frequency.
@@ -1494,14 +1555,14 @@ Specifies the scan type to use during a scheduled scan.
 The acceptable values for this parameter are:
 
 - 1: Quick scan
-- 2: Full scan 
+- 2: Full scan
 
 If you do not specify this parameter, Windows Defender uses the default value of quick scan.
 
 ```yaml
 Type: ScanType
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: QuickScan, FullScan
 
 Required: False
@@ -1534,14 +1595,14 @@ Specifies the day of the week on which to perform a scheduled scan.
 Alternatively, specify everyday for a scheduled scan or never.
 The acceptable values for this parameter are:
 
-- 0: Everyday 
-- 1: Sunday 
-- 2: Monday 
-- 3: Tuesday 
-- 4: Wednesday 
-- 5: Thursday 
-- 6: Friday 
-- 7: Saturday 
+- 0: Everyday
+- 1: Sunday
+- 2: Monday
+- 3: Tuesday
+- 4: Wednesday
+- 5: Thursday
+- 6: Friday
+- 7: Saturday
 - 8: Never
 
 The default value is 8, never.
@@ -1620,7 +1681,7 @@ Accept wildcard characters: False
 ### -ServiceHealthReportInterval
 This policy setting configures the time interval (in minutes) for the service health reports to be sent from endpoints. These are for Microsoft Defender Antivirus events 1150 and 1151. For more information, see [Microsoft Defender Antivirus event IDs](/microsoft-365/security/defender-endpoint/troubleshoot-microsoft-defender-antivirus#microsoft-defender-antivirus-event-ids).
 
-If you do not configure this setting, the default value will be applied. The default value is set at 60 minutes (one hour). 
+If you do not configure this setting, the default value will be applied. The default value is set at 60 minutes (one hour).
 If you configure this setting to 0, no service health reports will be sent.
 The maximum value allowed to be set is 14400 minutes (ten days).
 
@@ -1638,8 +1699,8 @@ Accept wildcard characters: False
 Specifies which automatic remediation action to take for a severe level threat.
 The acceptable values for this parameter are:
 
-- Quarantine 
-- Remove 
+- Quarantine
+- Remove
 - Ignore
 
 ```yaml
@@ -1802,15 +1863,15 @@ Specifies the day of the week on which to check for definition updates.
 Alternatively, specify everyday for a scheduled scan or never.
 The acceptable values for this parameter are:
 
-- 0: Everyday 
-- 1: Sunday 
-- 2: Monday 
-- 3: Tuesday 
-- 4: Wednesday 
-- 5: Thursday 
-- 6: Friday 
-- 7: Saturday 
-- 8: Never 
+- 0: Everyday
+- 1: Sunday
+- 2: Monday
+- 3: Tuesday
+- 4: Wednesday
+- 5: Thursday
+- 6: Friday
+- 7: Saturday
+- 8: Never
 
 The default value is 8, never.
 If you specify a value of 8 or do not specify a value, Windows Defender checks for definition updates by using a default frequency.
@@ -1909,14 +1970,14 @@ Otherwise, if the **MAPSReporting** parameter does not have a value of Disabled,
 The acceptable values for this parameter are:
 
 - 0: Always prompt
-- 1: Send safe samples automatically 
+- 1: Send safe samples automatically
 - 2: Never send
 - 3: Send all samples automatically
 
 ```yaml
 Type: SubmitSamplesConsentType
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: AlwaysPrompt, SendSafeSamples, NeverSend, SendAllSamples
 
 Required: False
@@ -1930,16 +1991,16 @@ Accept wildcard characters: False
 Specifies an array of the actions to take for the IDs specified by using the **ThreatIDDefaultAction_Ids** parameter.
 The acceptable values for this parameter are:
 
-- 1: Clean 
-- 2: Quarantine 
-- 3: Remove 
-- 6: Allow 
-- 8: UserDefined 
-- 9: NoAction 
+- 1: Clean
+- 2: Quarantine
+- 3: Remove
+- 6: Allow
+- 8: UserDefined
+- 9: NoAction
 - 10: Block
 
->[!NOTE]
->A value of 0 (NULL) applies an action based on the Security Intelligence Update (SIU). This is the default value.
+> [!NOTE]
+> A value of 0 (NULL) applies an action based on the Security Intelligence Update (SIU). This is the default value.
 
 ```yaml
 Type: ThreatAction[]
@@ -1978,7 +2039,7 @@ The throttle limit applies only to the current cmdlet, not to the session or to 
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -1990,13 +2051,14 @@ Accept wildcard characters: False
 ### -ThrottleForScheduledScanOnly
 A CPU usage limit can be applied to scheduled scans only, or to scheduled and custom scans. The default value applies a CPU usage limit to scheduled scans only.
 The acceptable values for this parameter are:
+
 - 1 (Default) - If you enable this setting, CPU throttling will apply only to scheduled scans.
 - 0 - If you disable this setting, CPU throttling will apply to scheduled and custom scans.
 
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -2004,7 +2066,6 @@ Default value: 1
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-
 
 ### -UILockdown
 Indicates whether to disable UI lockdown mode.
@@ -2014,7 +2075,7 @@ If you specify $False or do not specify a value, UI lockdown mode is enabled.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -2027,8 +2088,8 @@ Accept wildcard characters: False
 Specifies which automatic remediation action to take for an unknown level threat.
 The acceptable values for this parameter are:
 
-- Quarantine 
-- Remove 
+- Quarantine
+- Remove
 - Ignore
 
 ```yaml

--- a/docset/winserver2022-ps/defender/Start-MpScan.md
+++ b/docset/winserver2022-ps/defender/Start-MpScan.md
@@ -16,8 +16,13 @@ Starts a scan on a computer.
 ## SYNTAX
 
 ```
-Start-MpScan [-ScanPath <String>] [-ScanType <ScanType>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
- [-AsJob] [<CommonParameters>]
+Start-MpScan
+ [-AsJob]
+ [-CimSession <CimSession[]>]
+ [-ScanPath <String>]
+ [-ScanType <ScanType>]
+ [-ThrottleLimit <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -27,7 +32,7 @@ The cmdlet performs scans for the path you specify.
 ## EXAMPLES
 
 ### Example 1: Start a scan
-```
+```powershell
 PS C:\> Start-MpScan
 ```
 
@@ -36,19 +41,19 @@ This command starts a scan on the computer on which you run the cmdlet.
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete. 
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
 
-The cmdlet immediately returns an object that represents the job and then displays the command prompt. 
-You can continue to work in the session while the job completes. 
-To manage the job, use the `*-Job` cmdlets. 
-To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+The cmdlet immediately returns an object that represents the job and then displays the command prompt.
+You can continue to work in the session while the job completes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet.
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -58,8 +63,8 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. 
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. 
+Runs the cmdlet in a remote session or on a remote computer.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -81,7 +86,7 @@ Specify a file name, a folder name, such as C:\, or a UNC path.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -101,7 +106,7 @@ The acceptable values for this parameter are:
 ```yaml
 Type: ScanType
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: FullScan, QuickScan, CustomScan
 
 Required: False
@@ -119,7 +124,7 @@ The throttle limit applies only to the current cmdlet, not to the session or to 
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -138,4 +143,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/docset/winserver2022-ps/defender/Start-MpWDOScan.md
+++ b/docset/winserver2022-ps/defender/Start-MpWDOScan.md
@@ -16,7 +16,11 @@ Starts a Windows Defender offline scan.
 ## SYNTAX
 
 ```
-Start-MpWDOScan [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
+Start-MpWDOScan
+ [-AsJob]
+ [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -25,7 +29,7 @@ The **Start-MpWDOScan** cmdlet starts a Windows Defender offline scan on a compu
 ## EXAMPLES
 
 ### Example 1: Start an offline scan
-```
+```powershell
 PS C:\>Start-MpWDOScan
 ```
 
@@ -35,19 +39,19 @@ This command causes the computer to start in Windows Defender offline and begin 
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete. 
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
 
-The cmdlet immediately returns an object that represents the job and then displays the command prompt. 
-You can continue to work in the session while the job completes. 
-To manage the job, use the `*-Job` cmdlets. 
-To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+The cmdlet immediately returns an object that represents the job and then displays the command prompt.
+You can continue to work in the session while the job completes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet.
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -57,8 +61,8 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. 
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. 
+Runs the cmdlet in a remote session or on a remote computer.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -81,7 +85,7 @@ The throttle limit applies only to the current cmdlet, not to the session or to 
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -100,4 +104,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/docset/winserver2022-ps/defender/Update-MpSignature.md
+++ b/docset/winserver2022-ps/defender/Update-MpSignature.md
@@ -16,8 +16,12 @@ Updates the antimalware definitions on a computer.
 ## SYNTAX
 
 ```
-Update-MpSignature [-UpdateSource <UpdateSource>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
- [-AsJob] [<CommonParameters>]
+Update-MpSignature
+ [-AsJob]
+ [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>]
+ [-UpdateSource <UpdateSource>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -26,7 +30,7 @@ The **Update-MpSignature** cmdlet updates the antimalware definitions with the l
 ## EXAMPLES
 
 ### Example 1: Update signatures
-```
+```powershell
 PS C:\> Update-MpSignature
 ```
 
@@ -34,7 +38,7 @@ This command updates the antimalware definitions.
 By default, the cmdlet uses the sources configured through [SignatureFallbackOrder](Set-MpPreference.yml#-signaturefallbackorder). If no signature fallback order is configured, the cmdlet uses the default update source.
 
 ### Example 2: Update signatures from a specific source
-```
+```powershell
 PS C:\> Update-MpSignature -UpdateSource MicrosoftUpdateServer
 ```
 
@@ -43,19 +47,19 @@ This command updates the antimalware definitions from the Microsoft Update Serve
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete. 
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
 
-The cmdlet immediately returns an object that represents the job and then displays the command prompt. 
-You can continue to work in the session while the job completes. 
-To manage the job, use the `*-Job` cmdlets. 
-To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet. 
+The cmdlet immediately returns an object that represents the job and then displays the command prompt.
+You can continue to work in the session while the job completes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the [Receive-Job](https://go.microsoft.com/fwlink/?LinkID=113372) cmdlet.
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](https://go.microsoft.com/fwlink/?LinkID=113251).
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -65,8 +69,8 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. 
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. 
+Runs the cmdlet in a remote session or on a remote computer.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -89,7 +93,7 @@ The throttle limit applies only to the current cmdlet, not to the session or to 
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -106,7 +110,7 @@ The acceptable values for this parameter are:
 
 - InternalDefinitionUpdateServer
 - MicrosoftUpdateServer
-- MMPC 
+- MMPC
 - FileShares
 
 If you specify the InternalDefinitionUpdateServer setting, the service checks for updates on the Windows Software Update Services (WSUS) server.
@@ -114,7 +118,7 @@ If you specify the InternalDefinitionUpdateServer setting, the service checks fo
 ```yaml
 Type: UpdateSource
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: InternalDefinitionUpdateServer, MicrosoftUpdateServer, MMPC, FileShares
 
 Required: False
@@ -134,5 +138,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-
-


### PR DESCRIPTION
And other minor lint fixes:

- Eliminated trailing spaces and >2 consecutive carriage returns
- Added powershell fence to EXAMPLE code blocks where missing