### PR TITLE
Update SMB cmdlets and parameters for WS22

### DIFF
--- a/docset/winserver2022-ps/smbshare/Block-SmbClientAccessToServer.md
+++ b/docset/winserver2022-ps/smbshare/Block-SmbClientAccessToServer.md
@@ -1,0 +1,289 @@
+---
+description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
+external help file: SmbClientAccessToServer.cdxml-help.xml
+Module Name: SmbShare
+ms.date: 02/22/2024
+online version: https://learn.microsoft.com/powershell/module/smbshare/block-smbclientaccesstoserver?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Block-SmbClientAccessToServer
+---
+
+# Block-SmbClientAccessToServer
+
+## SYNOPSIS
+Blocks SMB client access to a specified server.
+
+## SYNTAX
+
+### Query
+
+```
+Block-SmbClientAccessToServer [-Name] <String[]> -IdentifierType <IdentifierType>
+ -Identifier <String> [-Description <String>] [-Force] [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### InputObject
+
+```
+Block-SmbClientAccessToServer -InputObject <CimInstance[]> -IdentifierType <IdentifierType>
+ -Identifier <String> [-Description <String>] [-Force] [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Block-SmbClientAccessToServer` cmdlet is used to prevent SMB clients from accessing a
+specified server when using SMB over QUIC client access control. When you run this cmdlet, all SMB
+client connections to the specified server will be terminated, and no new connections will be
+allowed until the block is lifted. To unblock access to the server, use the
+`Unblock-SmbClientAccessToServer` cmdlet.
+
+## EXAMPLES
+
+### Example 1: Block SMB client access to a server
+
+```powershell
+$params = @{
+    Name = "Server01"
+    IdentifierType = "ISSUER"
+    Identifier = "CN=MyCertificateIssuer"
+    Force = $true
+}
+Block-SmbClientAccessToServer @params
+```
+
+This command blocks SMB client access to a server named `Server01` for the based on the client's
+certificate. This command runs without prompting for confirmation as the **Force** parameter is set
+to `$true`.
+
+## PARAMETERS
+
+### -AsJob
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or
+[Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: (All)
+Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+
+Used to provide a description of the rule being added to the server's firewall when you use the
+`Block-SmbClientAccessToServer` cmdlet. This can be useful if you need to keep track of why SMB
+client access to a server has been blocked, or if you need to provide additional information about
+the block for documentation purposes.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+
+Forces the command to run without asking for user confirmation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identifier
+
+Specifies the identity of the client that is being granted access to the SMB server. This parameter
+takes a string value that represents the identity of the client. The format of the string value
+will depend on the **IdentifierType** parameter that you're using.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IdentifierType
+
+Specifies the type of identifier that you're using to identify a client. The valid values for the
+**IdentifierType** parameter are:
+
+- SHA256
+- ISSUER
+
+If you're using the `SHA256` identifier type, you're specifying a hash value that uniquely
+identifies the client. If you're using the `ISSUER` identifier type, you're specifying the issuer
+of the client's certificate.
+
+```yaml
+Type: IdentifierType
+Parameter Sets: (All)
+Aliases:
+Accepted values: SHA256, ISSUER
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+
+Specifies the input object that's used in a pipeline command.
+
+```yaml
+Type: CimInstance[]
+Parameter Sets: InputObject
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Name
+
+Specifies a fully-qualified DNS name or NetBIOS name that must match the certificate's subject name
+or an entry in the certificate's subject alternative names.
+
+```yaml
+Type: String[]
+Parameter Sets: Query
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ThrottleLimit
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer.
+
+The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### System.String[]
+
+### Microsoft.Management.Infrastructure.CimInstance[]
+
+## OUTPUTS
+
+### Microsoft.Management.Infrastructure.CimInstance[]
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-SmbClientAccessToServer](Get-SmbClientAccessToServer.md)
+
+[Grant-SmbClientAccessToServer](Grant-SmbClientAccessToServer.md)
+
+[Revoke-SmbClientAccessToServer](Revoke-SmbClientAccessToServer.md)
+
+[Unblock-SmbClientAccessToServer](Unblock-SmbClientAccessToServer.md)

--- a/docset/winserver2022-ps/smbshare/Get-SmbClientAccessToServer.md
+++ b/docset/winserver2022-ps/smbshare/Get-SmbClientAccessToServer.md
@@ -1,0 +1,199 @@
+---
+description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
+external help file: SmbClientAccessToServer.cdxml-help.xml
+Module Name: SmbShare
+ms.date: 02/22/2024
+online version: https://learn.microsoft.com/powershell/module/smbshare/get-smbclientaccesstoserver?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Get-SmbClientAccessToServer
+---
+
+# Get-SmbClientAccessToServer
+
+## SYNOPSIS
+Gets information about SMB client access to a specified server.
+
+## SYNTAX
+
+### Query
+
+```
+Get-SmbClientAccessToServer [-Name] <String[]> [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
+ [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### InputObject
+
+```
+Get-SmbClientAccessToServer -InputObject <CimInstance[]> [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Get-SmbClientAccessToServer` cmdlet is used to retrieve information about SMB client access to
+a specified server. When you run this cmdlet, it'll return a list of allowed and blocked
+connections for SMB over QUIC client access control.
+
+## EXAMPLES
+
+### Example 1: Retrieve client access information
+
+```powershell
+Get-SmbClientAccessToServer -Name "Server01"
+```
+
+This command retrieves the SMB client access information for a device named `Server01`.
+
+## PARAMETERS
+
+### -AsJob
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or
+[Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: (All)
+Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+
+Specifies the input object that's used in a pipeline command.
+
+```yaml
+Type: CimInstance[]
+Parameter Sets: InputObject
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Name
+
+Specifies a fully-qualified DNS name or NetBIOS name that must match the certificate's subject name
+or an entry in the certificate's subject alternative names.
+
+```yaml
+Type: String[]
+Parameter Sets: Query
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ThrottleLimit
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer.
+
+The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### System.String[]
+
+### Microsoft.Management.Infrastructure.CimInstance[]
+
+## OUTPUTS
+
+### Microsoft.Management.Infrastructure.CimInstance[]
+
+## NOTES
+
+## RELATED LINKS
+
+[Block-SmbClientAccessToServer](Block-SmbClientAccessToServer.md)
+
+[Grant-SmbClientAccessToServer](Grant-SmbClientAccessToServer.md)
+
+[Revoke-SmbClientAccessToServer](Revoke-SmbClientAccessToServer.md)
+
+[Unblock-SmbClientAccessToServer](Unblock-SmbClientAccessToServer.md)

--- a/docset/winserver2022-ps/smbshare/Get-SmbClientCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/Get-SmbClientCertificateMapping.md
@@ -1,0 +1,291 @@
+---
+description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
+external help file: SmbClientCertificateMapping.cdxml-help.xml
+Module Name: SmbShare
+ms.date: 02/22/2024
+online version: https://learn.microsoft.com/powershell/module/smbshare/get-smbclientcertificatemapping?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Get-SmbClientCertificateMapping
+---
+
+# Get-SmbClientCertificateMapping
+
+## SYNOPSIS
+Retrieves the client certificate mappings for the Server Message Block (SMB) protocol.
+
+## SYNTAX
+
+```
+Get-SmbClientCertificateMapping [[-Namespace] <String[]>] [[-Subject] <String[]>]
+ [-IssuerName <String[]>] [-Thumbprint <String[]>] [-DisplayName <String[]>] [-StoreName <String[]>]
+ [-Type <Type[]>] [-Flags <Flags[]>] [-IncludeHidden] [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Get-SmbClientCertificateMapping` cmdlet retrieves the client certificate mappings for the SMB
+protocol, such as when using SMB over QUIC. These mappings are used to authenticate clients that
+connect to SMB servers using certificates.
+
+## EXAMPLES
+
+### Example 1: Retrieve all certificate mappings for a specific store
+
+```powershell
+Get-SmbClientCertificateMapping -StoreName "My"
+```
+
+This retrieves all certificate mappings that have been stored in a specific certificate store.
+
+### Example 2: Retrieve a specific certificate mapping by display name
+
+```powershell
+Get-SmbClientCertificateMapping -DisplayName "MyCertificateMapping"
+```
+
+This retrieves a specific certificate mapping by its display name.
+
+## PARAMETERS
+
+### -AsJob
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: (All)
+Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisplayName
+
+Specifies the friendly name of the certificate.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Flags
+
+Specifies if `NamedPipes` are enabled for SMB over QUIC. The acceptable values for this parameter
+are:
+
+- `None`: Remove all flags
+- `AllowNamedPipe`: Enable use of named pipes in SMB over QUIC connections for this mapping (off by
+  default, overrides value of the **RestrictNamedPipeAccessOverQuic** parameter)
+- `DefaultCert`: Not used
+
+```yaml
+Type: Flags[]
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, AllowNamedPipe, DefaultCert
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -IncludeHidden
+
+Not used.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IssuerName
+
+Filters the certificate mappings based on the issuer name of the certificate.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Namespace
+
+Specifies the namespace in which the certificate mappings are located. By default, the cmdlet
+searches in the `root\cimv2\Security\MicrosoftTlsCertificateMappingProvider` namespace.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -StoreName
+
+Specifies the path to the certificate store for the certificate.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Subject
+
+Specifies the subject name of the certificate.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ThrottleLimit
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Thumbprint
+
+Specifies the thumbprint value of the certificate.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Type
+
+Specifies the type of certificate mapping. The acceptable value for this parameter is:
+
+`QUIC`: Certificate mapping is for SMB over QUIC.
+
+```yaml
+Type: Type[]
+Parameter Sets: (All)
+Aliases:
+Accepted values: QUIC
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### System.String[]
+
+### Microsoft.PowerShell.Cmdletization.GeneratedTypes.SmbClientCertificateMapping.Type[]
+
+### Microsoft.PowerShell.Cmdletization.GeneratedTypes.SmbClientCertificateMapping.Flags[]
+
+## OUTPUTS
+
+### Microsoft.Management.Infrastructure.CimInstance
+
+### Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/SMB/MSFT_SmbClientCertificateMapping
+
+## NOTES
+
+## RELATED LINKS
+
+[New-SmbClientCertificateMapping](New-SmbClientCertificateMapping.md)
+
+[Remove-SmbClientCertificateMapping](Remove-SmbClientCertificateMapping.md)
+
+[Set-SmbClientCertificateMapping](Set-SmbClientCertificateMapping.md)

--- a/docset/winserver2022-ps/smbshare/Get-SmbServerCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/Get-SmbServerCertificateMapping.md
@@ -31,7 +31,7 @@ server for SMB over QUIC. For more information, see [SMB over QUIC](https://aka.
 > [!NOTE]
 >
 > - The **RequireClientAuthentication** and **SkipClientCertificateAccessCheck** parameters are only
-> supported in Windows Server Datacenter: Azure Edition.
+> supported in Windows Server 2022 Datacenter: Azure Edition.
 >
 > - If the **RequireClientAuthentication** parameter is set to `$true` and
 > **SkipClientCertificateAccessCheck** is set to `$false`, the server will perform both client

--- a/docset/winserver2022-ps/smbshare/Get-SmbServerCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/Get-SmbServerCertificateMapping.md
@@ -190,13 +190,15 @@ Accept wildcard characters: False
 ### -SkipClientCertificateAccessCheck
 
 Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not perform the access control
-checks based on the client certificates. This can be useful in scenarios where the server is acting
-as a gateway or proxy, and does not need to perform full certificate validation.
+connects. This parameter only applies when the server certificate mapping
+**RequireClientAuthentication** value is `$true`. When this parameter is set to `$true`, the server
+will not perform the access control checks based on the client certificates. This can be useful in
+scenarios where the server is acting as a gateway or proxy and client certificate validation is
+sufficient.
 
 However, it can also increase the risk of security breaches. When this parameter is set to
-`$false`, the server will check whether the client has access to the certificate it presents before
-allowing the client to connect.
+`$false`, the server will perform the access control checks based on the client certificates in
+addition to the client certificate validation before allowing the client to connect.
 
 ```yaml
 Type: Boolean[]

--- a/docset/winserver2022-ps/smbshare/Get-SmbServerCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/Get-SmbServerCertificateMapping.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbServerCertificateMapping.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 08/31/2021
+ms.date: 02/22/2024
 online version: https://learn.microsoft.com/powershell/module/smbshare/get-smbservercertificatemapping?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-SmbServerCertificateMapping
@@ -16,34 +16,55 @@ Retrieves a certificate associated with the SMB server for SMB over QUIC.
 ## SYNTAX
 
 ```
-Get-SmbServerCertificateMapping [[-Name] <String[]>] [[-Subject] <String[]>] [-Thumbprint <String[]>]
- [-DisplayName <String[]>] [-StoreName <String[]>] [-Type <Type[]>] [-Flags <Flags[]>] [-IncludeHidden]
- [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
+Get-SmbServerCertificateMapping [[-Name] <String[]>] [[-Subject] <String[]>]
+ [-Thumbprint <String[]>] [-DisplayName <String[]>] [-StoreName <String[]>] [-Type <Type[]>]
+ [-Flags <Flags[]>] [-RequireClientAuthentication <Boolean[]>]
+ [-SkipClientCertificateAccessCheck <Boolean[]>] [-IncludeHidden] [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>] [-AsJob] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-SmbServerCertificateMapping** cmdlet retrieves the certificates associated with the SMB server for SMB over QUIC on ‘Windows Server 2022 Datacenter: Azure Edition’. This cmdlet is not used for Windows or other Windows Server editions. For more information, review [SMB over QUIC](https://aka.ms/smboverquic).
+
+The `Get-SmbServerCertificateMapping` cmdlet retrieves the certificates associated with the SMB
+server for SMB over QUIC. For more information, see [SMB over QUIC](https://aka.ms/smboverquic).
+
+> [!NOTE]
+>
+> - The **RequireClientAuthentication** and **SkipClientCertificateAccessCheck** parameters are only
+> supported in Windows Server Datacenter: Azure Edition.
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is set to `$false`, the server will perform both client
+> certificate validation and access control checks.
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is also set to `$true`, the server will perform client
+> certificate validation but no access control checks.
 
 ## EXAMPLES
 
 ### Example 1 - Retrieve the certificate mapped to two SMB over QUIC server names
 
-This command retrieves the certificate mapped to two SMB over QUIC server names that clients can connect to, `fs2.contoso.com` and `2022-ae-02.corp.contoso.com`.
+This command retrieves the certificate mapped to two SMB over QUIC server names that clients can
+connect to, `fs2.contoso.com` and `2022-ae-02.corp.contoso.com`.
 
 ```powershell
-PS C:\> Get-SmbServerCertificateMapping
+Get-SmbServerCertificateMapping
 ```
+
 ```output
-Name                        Subject       Thumbprint                               DisplayName StoreName Type Flags 
-----                        -------       ----------                               ----------- --------- ---- ----- 
-2022-ae-02.corp.contoso.com CN=2022-ae-02 88032B3551FAF7DE26EFFFF814AA086E3DBD2A4F 2022-ae-02  My        QUIC None 
+Name                        Subject       Thumbprint                               DisplayName StoreName Type Flags
+----                        -------       ----------                               ----------- --------- ---- -----
+2022-ae-02.corp.contoso.com CN=2022-ae-02 88032B3551FAF7DE26EFFFF814AA086E3DBD2A4F 2022-ae-02  My        QUIC None
 fs2.contoso.com             CN=2022-ae-02 88032B3551FAF7DE26EFFFF814AA086E3DBD2A4F 2022-ae-02  My        QUIC None
 ```
 
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
 
 ```yaml
 Type: SwitchParameter
@@ -58,7 +79,11 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session object, such as the output of a [`New-CimSession`](/powershell/module/cimcmdlets/new-cimsession) or [`Get-CimSession`](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [`New-CimSession`](/powershell/module/cimcmdlets/new-cimsession) or
+[`Get-CimSession`](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -73,6 +98,7 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayName
+
 Specifies a friendly name to display for the mapping.
 
 ```yaml
@@ -88,12 +114,14 @@ Accept wildcard characters: False
 ```
 
 ### -Flags
-Specifies if `NamedPipes` are enabled for SMB over QUIC. The acceptable values for this parameter are: 
 
+Specifies if `NamedPipes` are enabled for SMB over QUIC. The acceptable values for this parameter
+are:
 
-- `None:` Remove all flags 
-- `AllowNamedPipe:` Enable use of named pipes in SMB over QUIC connections for this mapping (off by default, overrides value of RestrictNamedPipeAccessOverQuic) 
-- `DefaultCert:` Not used
+- `None`: Remove all flags
+- `AllowNamedPipe`: Enable use of named pipes in SMB over QUIC connections for this mapping (off by
+  default, overrides value of the **RestrictNamedpipeAccessOverQuic** parameter)
+- `DefaultCert`: Not used
 
 ```yaml
 Type: Flags[]
@@ -109,6 +137,7 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeHidden
+
 Not used.
 
 ```yaml
@@ -124,7 +153,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies a fully-qualified DNS name or NetBIOS name that must match the certificate’s subject name or an entry in the certificate’s subject alternative names.
+
+Specifies a fully-qualified DNS name or NetBIOS name that must match the certificate's subject name
+or an entry in the certificate's subject alternative names.
 
 ```yaml
 Type: String[]
@@ -138,7 +169,49 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -RequireClientAuthentication
+
+Specifies whether client authentication is required for connections to the server. When this
+parameter is set to `$true`, clients must present a valid certificate to connect to the server.
+When it is set to `$false`, clients can connect without presenting a certificate.
+
+```yaml
+Type: Boolean[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SkipClientCertificateAccessCheck
+
+Specifies whether the server should skip the check for client certificate access when a client
+connects. When this parameter is set to `$true`, the server will not perform the access control
+checks based on the client certificates. This can be useful in scenarios where the server is acting
+as a gateway or proxy, and does not need to perform full certificate validation.
+
+However, it can also increase the risk of security breaches. When this parameter is set to
+`$false`, the server will check whether the client has access to the certificate it presents before
+allowing the client to connect.
+
+```yaml
+Type: Boolean[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -StoreName
+
 Specifies the path to the certificate store for the certificate.
 
 ```yaml
@@ -154,6 +227,7 @@ Accept wildcard characters: False
 ```
 
 ### -Subject
+
 Specifies the subject name of the certificate.
 
 ```yaml
@@ -169,7 +243,12 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If this parameter is omitted or a value of 0 is entered, then Windows PowerShell calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer. The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
 
 ```yaml
 Type: Int32
@@ -184,6 +263,7 @@ Accept wildcard characters: False
 ```
 
 ### -Thumbprint
+
 Specifies the thumbprint value of the certificate.
 
 ```yaml
@@ -199,9 +279,10 @@ Accept wildcard characters: False
 ```
 
 ### -Type
-Specifies the type of certificate mapping. The acceptable value for this parameter is:  
 
-`QUIC:` Certificate mapping is for SMB over QUIC.
+Specifies the type of certificate mapping. The acceptable value for this parameter is:
+
+- `QUIC`: Certificate mapping is for SMB over QUIC.
 
 ```yaml
 Type: Type[]
@@ -217,7 +298,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -226,6 +311,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### Microsoft.PowerShell.Cmdletization.GeneratedTypes.SmbServerCertificateMapping.Type[]
 
 ### Microsoft.PowerShell.Cmdletization.GeneratedTypes.SmbServerCertificateMapping.Flags[]
+
+### System.Boolean[]
 
 ## OUTPUTS
 
@@ -236,3 +323,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[New-SmbServerCertificateMapping](New-SmbServerCertificateMapping.md)
+
+[Remove-SmbServerCertificateMapping](Remove-SmbServerCertificateMapping.md)
+
+[Set-SmbServerCertificateMapping](Set-SmbServerCertificateMapping.md)

--- a/docset/winserver2022-ps/smbshare/Get-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Get-SmbServerConfiguration.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbServerConfiguration.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 06/23/2022
+ms.date: 02/22/2024
 online version: https://learn.microsoft.com/powershell/module/smbshare/get-smbserverconfiguration?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-SmbServerConfiguration
@@ -22,7 +22,8 @@ Get-SmbServerConfiguration [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
 
 ## DESCRIPTION
 
-The `Get-SmbServerConfiguration` cmdlet retrieves the Server Message Block (SMB) server configuration.
+The `Get-SmbServerConfiguration` cmdlet retrieves the Server Message Block (SMB) server
+configuration.
 
 ## EXAMPLES
 
@@ -32,7 +33,7 @@ The `Get-SmbServerConfiguration` cmdlet retrieves the Server Message Block (SMB)
 Get-SmbServerConfiguration
 ```
 
-```Output
+```output
 AnnounceComment                        :
 AnnounceServer                         : False
 AsynchronousCredits                    : 512
@@ -83,12 +84,6 @@ EncryptionCiphers                      : AES_128_GCM, AES_128_CCM, AES_256_GCM, 
 
 This command retrieves the SMB server configuration.
 
-> [!NOTE]
-> The **EncryptionCiphers** parameter is available beginning with 2022-06 Cumulative Update for
-> Microsoft server operating system version 21H2 for x64-based Systems
-> ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
-> version 22H2 ([KB5014668](https://support.microsoft.com/help/5014668)).
-
 ## PARAMETERS
 
 ### -AsJob
@@ -111,8 +106,8 @@ Accept wildcard characters: False
 ### -CimSession
 
 Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
-object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967)
-or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
 current session on the local computer.
 
 ```yaml
@@ -158,15 +153,14 @@ Aliases: cf
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -185,7 +179,7 @@ Accept wildcard characters: False
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -201,4 +195,6 @@ The **MSFT_SmbServerConfiguration** object represents the configuration of the S
 
 ## RELATED LINKS
 
-[Set-SmbServerConfiguration](./Set-SmbServerConfiguration.md)
+[Reset-SmbServerConfiguration](Reset-SmbServerConfiguration.md)
+
+[Set-SmbServerConfiguration](Set-SmbServerConfiguration.md)

--- a/docset/winserver2022-ps/smbshare/Get-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/Get-SmbShare.md
@@ -26,116 +26,127 @@ Get-SmbShare [[-Name] <String[]>] [[-ScopeName] <String[]>] [-Scoped <Boolean[]>
 ```
 
 ## DESCRIPTION
-The **Get-SmbShare** cmdlet retrieves objects that represent the Server Message Block (SMB) shares being displayed by the computer.
+
+The `Get-SmbShare` cmdlet retrieves objects that represent the Server Message Block (SMB) shares
+being displayed by the computer.
 
 ## EXAMPLES
 
 ### Example 1: Get SMB shares on a local computer
-```
-PS C:\>Get-SMBShare
-Name                          ScopeName                     Path                          Description 
-----                          ---------                     ----                          ----------- 
-ADMIN$                        *                             C:\Windows                    Remote Admin 
-C$                            *                             C:\                           Default share 
-D$                            *                             D:\                           Default share 
-F$                            *                             F:\                           Default share 
-IPC$                          *                                                           Remote IPC 
+
+```powershell
+Get-SMBShare
+Name                          ScopeName                     Path                          Description
+----                          ---------                     ----                          -----------
+ADMIN$                        *                             C:\\Windows                   Remote Admin
+C$                            *                             C:\\                          Default share
+D$                            *                             D:\\                          Default share
+F$                            *                             F:\                           Default share
+IPC$                          *                                                           Remote IPC
 VMS1                          *                             I:\VMS
 ```
 
 This command retrieves the SMB shares on the computer.
 
 ### Example 2: Get a specific SMB share on the local computer
-```
-PS C:\>Get-SmbShare -Name "VMS1"
-Name                          ScopeName                     Path                          Description 
-----                          ---------                     ----                          ----------- 
+
+```powershell
+Get-SmbShare -Name "VMS1"
+Name                          ScopeName                     Path                          Description
+----                          ---------                     ----                          -----------
 VMS1                          *                             I:\VMS
 ```
 
-This command retrieves information about the SMB share named 'VMS1' on the local computer.
+This command retrieves information about the SMB share named `VMS1` on the local computer.
 
 ### Example 3: Display information about the SMB shares on a remote computer
-```
-PS C:\>get-smbshare -CimSession "NEDFS1"
+
+```powershell
+Get-SmbShare -CimSession "NEDFS1"
 
 Name        ScopeName Path                Description   PSComputerName
 ----        --------- ----                -----------   --------------
-ADMIN$      *         C:\Windows          Remote Admin  ae-dfsr-sr-01
-C$          *         C:\                 Default share ae-dfsr-sr-01
-D$          *         D:\                 Default share ae-dfsr-sr-01
-E$          *         E:\                 Default share ae-dfsr-sr-01
-IPC$        *                             Remote IPC    ae-dfsr-sr-01
-IT dept     *         D:\data\IT dept                   ae-dfsr-sr-01
-procedures  *         D:\hr\procedures                  ae-dfsr-sr-01
-VHD and ISO *         D:\data\VHD and ISO               ae-dfsr-sr-01
-
+ADMIN$      *         C:\\Windows          Remote Admin  ae-dfsr-sr-01
+C$          *         C:\\                 Default share ae-dfsr-sr-01
+D$          *         D:\\                 Default share ae-dfsr-sr-01
+E$          *         E:\\                 Default share ae-dfsr-sr-01
+IPC$        *                              Remote IPC    ae-dfsr-sr-01
+IT dept     *         D:\\data\IT dept                   ae-dfsr-sr-01
+procedures  *         D:\\hr\procedures                  ae-dfsr-sr-01
+VHD and ISO *         D:\\data\VHD and ISO               ae-dfsr-sr-01
 ```
 
-This command displays the information about the SMB shares on the remote computer NEDFS1.
+This command displays the information about the SMB shares on the remote computer `NEDFS1`.
 
 ### Example 4: Display all properties about a specific SMB share on the local computer in a list
-```
-PS C:\>Get-SmbShare -Name "VMS1" | Format-List -Property *
-PresetPathAcl         : System.Security.AccessControl.DirectorySecurity 
-ShareState            : Online 
-AvailabilityType      : Clustered 
-ShareType             : FileSystemDirectory 
-FolderEnumerationMode : Unrestricted 
-CachingMode           : Manual 
-CATimeout             : 0 
-ConcurrentUserLimit   : 0 
-ContinuouslyAvailable : True 
-CurrentUsers          : 3 
-Description           : 
-EncryptData           : False 
-Name                  : VMS1 
-Path                  : I:\VMS 
-Scoped                : True 
+
+```powershell
+Get-SmbShare -Name "VMS1" | Format-List -Property *
+PresetPathAcl         : System.Security.AccessControl.DirectorySecurity
+ShareState            : Online
+AvailabilityType      : Clustered
+ShareType             : FileSystemDirectory
+FolderEnumerationMode : Unrestricted
+CachingMode           : Manual
+CATimeout             : 0
+ConcurrentUserLimit   : 0
+ContinuouslyAvailable : True
+CurrentUsers          : 3
+Description           :
+EncryptData           : False
+Name                  : VMS1
+Path                  : I:\VMS
+Scoped                : True
 ScopeName             : *
-SecurityDescriptor    : O:BAG:DUD:(A;;FA;;;S-1-5-21-219828122-4198910963-4161819395-500)(A;;FA;;;S-1-5-21-219828122-419 
-                        8910963-4161819395-1106)(A;;FA;;;S-1-5-21-219828122-4198910963-4161819395-1109) 
-ShadowCopy            : False 
-Special               : False 
-Temporary             : False 
-Volume                : \\?\Volume{b02c4ba7-e6f1-11e1-93eb-0008a1c0ef0d}\ 
-PSComputerName        : 
-CimClass              : ROOT/Microsoft/Windows/SMB:MSFT_SmbShare 
-CimInstanceProperties : {AvailabilityType, CachingMode, CATimeout, ConcurrentUserLimit...} 
+SecurityDescriptor    : O:BAG:DUD:(A;;FA;;;S-1-5-21-219828122-4198910963-4161819395-500)(A;;FA;;;S-1-5-21-219828122-419
+                        8910963-4161819395-1106)(A;;FA;;;S-1-5-21-219828122-4198910963-4161819395-1109)
+ShadowCopy            : False
+Special               : False
+Temporary             : False
+Volume                : \\?\Volume{b02c4ba7-e6f1-11e1-93eb-0008a1c0ef0d}\
+PSComputerName        :
+CimClass              : ROOT/Microsoft/Windows/SMB:MSFT_SmbShare
+CimInstanceProperties : {AvailabilityType, CachingMode, CATimeout, ConcurrentUserLimit...}
 CimSystemProperties   : Microsoft.Management.Infrastructure.CimSystemProperties
 ```
 
-This command displays all of the information about the SMB share named 'VMS1' on the local computer as a formatted list.
+This command displays all of the information about the SMB share named `VMS1` on the local computer
+as a formatted list.
 
 ### Example 5: Get shares on the local failover cluster computer that have scale out availability
-```
-PS C:\>Get-SmbShare | Where-Object -Property AvailabilityType -Eq ScaleOut
-Name                          ScopeName                     Path                          Description 
-----                          ---------                     ----                          ----------- 
-ClusterStorage$               Contoso-SO                    C:\ClusterStorage             Cluster Shared Volumes Def... 
-VMS3                          Contoso-SO                    C:\ClusterStorage\Volume1\VMS 
-VMS4                          Contoso-SO                    C:\ClusterStorage\Volume2\VMS
+
+```powershell
+Get-SmbShare | Where-Object -Property AvailabilityType -Eq ScaleOut
+Name                          ScopeName                     Path                          Description
+----                          ---------                     ----                          -----------
+ClusterStorage$               Contoso-SO                    C:\\ClusterStorage             Cluster Shared Volumes Def...
+VMS3                          Contoso-SO                    C:\\ClusterStorage\Volume1\VMS
+VMS4                          Contoso-SO                    C:\\ClusterStorage\Volume2\VMS
 ```
 
 This command retrieves the SMB shares on the computer that have scaled out availability.
 
 ### Example 6: Get shares that are connected to a local failover cluster file server resource named "Contoso-FS"
-```
-PS C:\>Get-SmbShare -ScopeName "Contoso-FS"
-Name                          ScopeName                     Path                          Description 
-----                          ---------                     ----                          ----------- 
-I$                            Contoso-FS                    I:\                           Cluster Default Share 
-J$                            Contoso-FS                    J:\                           Cluster Default Share 
-VMS1                          Contoso-FS                    I:\VMS 
+
+```powershell
+Get-SmbShare -ScopeName "Contoso-FS"
+Name                          ScopeName                     Path                          Description
+----                          ---------                     ----                          -----------
+I$                            Contoso-FS                    I:\                           Cluster Default Share
+J$                            Contoso-FS                    J:\                           Cluster Default Share
+VMS1                          Contoso-FS                    I:\VMS
 VMS2                          Contoso-FS                    J:\VMS
 ```
 
-This command retrieves the SMB shares on the Windows Server failover cluster that are connected to the clustered file server resource named Contoso-FS.
+This command retrieves the SMB shares on the Windows Server failover cluster that are connected to
+the clustered file server resource named `Contoso-FS`.
 
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
 
 ```yaml
 Type: SwitchParameter
@@ -150,6 +161,7 @@ Accept wildcard characters: False
 ```
 
 ### -AvailabilityType
+
 Specifies the cluster type of the shares being enumerated.
 
 ```yaml
@@ -166,6 +178,7 @@ Accept wildcard characters: False
 ```
 
 ### -CaTimeout
+
 Specifies the continuous availability time-out of the shares being enumerated.
 
 ```yaml
@@ -181,6 +194,7 @@ Accept wildcard characters: False
 ```
 
 ### -CachingMode
+
 Specifies the caching mode of the shares being enumerated.
 
 ```yaml
@@ -197,9 +211,11 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
-The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -214,6 +230,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompressData
+
 Indicates that the shares being enumerated should request compression from clients.
 
 ```yaml
@@ -229,6 +246,7 @@ Accept wildcard characters: False
 ```
 
 ### -ConcurrentUserLimit
+
 Specifies the concurrent user limit of the shares being enumerated.
 
 ```yaml
@@ -244,6 +262,7 @@ Accept wildcard characters: False
 ```
 
 ### -ContinuouslyAvailable
+
 Indicates that the shares being enumerated should be continuously available.
 
 ```yaml
@@ -259,6 +278,7 @@ Accept wildcard characters: False
 ```
 
 ### -EncryptData
+
 Indicates that the shares being enumerated should be encrypted.
 
 ```yaml
@@ -274,6 +294,7 @@ Accept wildcard characters: False
 ```
 
 ### -FolderEnumerationMode
+
 Specifies the folder enumeration mode of the shares being enumerated.
 
 ```yaml
@@ -290,6 +311,7 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeHidden
+
 Indicates that shares that are created and used internally are also enumerated.
 
 ```yaml
@@ -305,6 +327,7 @@ Accept wildcard characters: False
 ```
 
 ### -LeasingMode
+
 Specifies SMB leasing and oplock behaviors.
 
 ```yaml
@@ -320,6 +343,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies one or more SMB shares by share name.
 
 ```yaml
@@ -335,7 +359,9 @@ Accept wildcard characters: False
 ```
 
 ### -ScopeName
-Specifies the scope of the share by name. For use with Windows Server failover cluster file server resources.
+
+Specifies the scope of the share by name. For use with Windows Server failover cluster file server
+resources.
 
 ```yaml
 Type: String[]
@@ -350,6 +376,7 @@ Accept wildcard characters: False
 ```
 
 ### -Scoped
+
 Indicates that the shares to be numerated should be scoped.
 
 ```yaml
@@ -365,6 +392,7 @@ Accept wildcard characters: False
 ```
 
 ### -ShareState
+
 Specifies the state of the shares being enumerated.
 
 ```yaml
@@ -381,8 +409,9 @@ Accept wildcard characters: False
 ```
 
 ### -SmbInstance
-Specifies the input to this cmdlet.
-You can use this parameter, or you can pipe the input to this cmdlet.
+
+Specifies the input to this cmdlet. You can use this parameter, or you can pipe the input to this
+cmdlet.
 
 ```yaml
 Type: SmbInstance
@@ -398,8 +427,9 @@ Accept wildcard characters: False
 ```
 
 ### -Special
-Indicates that the shares to be numerated should be special.
-Admin share, default shares, IPC$ share are examples of special shares.
+
+Indicates that the shares to be numerated should be special. Admin share, default shares, IPC$
+share are examples of special shares.
 
 ```yaml
 Type: Boolean[]
@@ -414,9 +444,12 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-If this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
-The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
 
 ```yaml
 Type: Int32
@@ -431,7 +464,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -440,16 +477,18 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/SMB/MSFT_SmbShare
-The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays Windows Management Instrumentation (WMI) objects.
-The path after the pound sign (`#`) provides the namespace and class name for the underlying WMI object.
-The **MSFT_SmbShare** object represents the SMB shares on the computer.
+
+The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays
+Windows Management Instrumentation (WMI) objects. The path after the pound sign (`#`) provides the
+namespace and class name for the underlying WMI object. The **MSFT_SmbShare** object represents the
+SMB shares on the computer.
 
 ## NOTES
 
 ## RELATED LINKS
 
-[New-SmbShare](./New-SmbShare.md)
+[New-SmbShare](New-SmbShare.md)
 
-[Remove-SmbShare](./Remove-SmbShare.md)
+[Remove-SmbShare](Remove-SmbShare.md)
 
-[Set-SmbShare](./Set-SmbShare.md)
+[Set-SmbShare](Set-SmbShare.md)

--- a/docset/winserver2022-ps/smbshare/Grant-SmbClientAccessToServer.md
+++ b/docset/winserver2022-ps/smbshare/Grant-SmbClientAccessToServer.md
@@ -1,0 +1,290 @@
+---
+description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
+external help file: SmbServerConfiguration.cdxml-help.xml
+Module Name: SmbClientAccessToServer
+ms.date: 02/22/2024
+online version: https://learn.microsoft.com/powershell/module/smbshare/grant-smbclientaccesstoserver?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Grant-SmbClientAccessToServer
+---
+
+# Grant-SmbClientAccessToServer
+
+## SYNOPSIS
+Allow access to a computer or set of computers for SMB over QUIC's client access control feature on
+an SMB Server.
+
+## SYNTAX
+
+### Query
+
+```
+Grant-SmbClientAccessToServer [-Name] <String[]> -IdentifierType <IdentifierType>
+ -Identifier <String> [-Description <String>] [-Force] [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### InputObject
+
+```
+Grant-SmbClientAccessToServer -InputObject <CimInstance[]> -IdentifierType <IdentifierType>
+ -Identifier <String> [-Description <String>] [-Force] [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Grant-SmbClientAccessToServer` cmdlet is used to allow SMB clients to access a specified
+server. When you run this cmdlet, it'll add a new rule to the server's firewall to allow incoming
+SMB traffic from the specified client IP address. If you need to revoke access to the server in the
+future, you can use the `Revoke-SmbClientAccessToServer` cmdlet.
+
+## EXAMPLES
+
+### Example 1: Grant SMB client access to a server
+
+```powershell
+$params = @{
+    Name = "Server01"
+    IdentifierType = "ISSUER"
+    Identifier = "CN=MyCertificateIssuer"
+    Description = "Allow access from client for LabSvr"
+    Force = $true
+}
+Grant-SmbClientAccessToServer @params
+```
+
+This example grants SMB client access to a server named `Server01` based on the client's
+certificate. The **Description** parameter is used to provide a description of the rule being added
+to the server's firewall. This command runs without prompting for confirmation.
+
+## PARAMETERS
+
+### -AsJob
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or
+[Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: (All)
+Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+
+Used to provide a description of the rule being added to the server's firewall when you use the
+`Grant-SmbClientAccessToServer` cmdlet. This can be useful if you need to keep track of which
+clients have been granted access to a server, or if you need to provide additional information
+about the rule for documentation purposes.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+
+Forces the command to run without asking for user confirmation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identifier
+
+Specifies the identity of the client that is being granted access to the SMB server. This parameter
+takes a string value that represents the identity of the client. The format of the string value
+will depend on the **IdentifierType** parameter that you're using.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IdentifierType
+
+Specifies the type of identifier that you're using to identify a client. The valid values for the
+**IdentifierType** parameter are:
+
+- SHA256
+- ISSUER
+
+If you're using the `SHA256` identifier type, you're specifying a hash value that uniquely
+identifies the client. If you're using the `ISSUER` identifier type, you're specifying the issuer
+of the client's certificate.
+
+```yaml
+Type: IdentifierType
+Parameter Sets: (All)
+Aliases:
+Accepted values: SHA256, ISSUER
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+
+Specifies the input object that's used in a pipeline command.
+
+```yaml
+Type: CimInstance[]
+Parameter Sets: InputObject
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Name
+
+Specifies a fully-qualified DNS name or NetBIOS name that must match the certificate's subject name
+or an entry in the certificate's subject alternative names.
+
+```yaml
+Type: String
+Parameter Sets: Query
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ThrottleLimit
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer.
+
+The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### System.String[]
+
+### Microsoft.Management.Infrastructure.CimInstance[]
+
+## OUTPUTS
+
+### Microsoft.Management.Infrastructure.CimInstance[]
+
+## NOTES
+
+## RELATED LINKS
+
+[Block-SmbClientAccessToServer](Block-SmbClientAccessToServer.md)
+
+[Get-SmbClientAccessToServer](Get-SmbClientAccessToServer.md)
+
+[Revoke-SmbClientAccessToServer](Revoke-SmbClientAccessToServer.md)
+
+[Unblock-SmbClientAccessToServer](Unblock-SmbClientAccessToServer.md)

--- a/docset/winserver2022-ps/smbshare/New-SmbClientCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbClientCertificateMapping.md
@@ -1,0 +1,322 @@
+---
+description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
+external help file: SmbClientCertificateMapping.cdxml-help.xml
+Module Name: SmbShare
+ms.date: 02/22/2024
+online version: https://learn.microsoft.com/powershell/module/smbshare/new-smbclientcertificatemapping?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: New-SmbClientCertificateMapping
+---
+
+# New-SmbClientCertificateMapping
+
+## SYNOPSIS
+Creates a new client certificate mapping for the Server Message Block (SMB) protocol.
+
+## SYNTAX
+
+```
+New-SmbClientCertificateMapping [-Namespace] <String> [-Thumbprint <String>] [-StoreName <String>]
+ [-IssuerName <String>] [-Subject <String>] [-DisplayName <String>] [-Type <Type>] [-Flags <Flags>]
+ [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `New-SmbClientCertificateMapping` cmdlet creates a new client certificate mapping for the SMB
+protocol. These mappings are used to authenticate clients that connect to SMB servers using
+certificates. You can use this cmdlet to create a new mapping between a client certificate and an
+SMB client name.
+
+## EXAMPLES
+
+### Example 1: Create a new certificate mapping for an SMB client
+
+```powershell
+$params = @{
+    Thumbprint = "a1b2c3d4e5f6g7h8"
+    StoreName = "My"
+    IssuerName = "CN=MyCertificateAuthority"
+    Subject = "CN=MyClientCertificate"
+    DisplayName = "MyClientCertificateMapping"
+}
+New-SmbClientCertificateMapping @params
+```
+
+This creates a new certificate mapping for an SMB client where a specific thumbprint, store name,
+issuer name, subject, and display name are specified for the certificate mapping.
+
+For example, if you have an SMB client named `MySMBClient` that needs to connect to a server using
+a specific certificate, you could use this cmdlet to create a certificate mapping that associates
+the client with the certificate.
+
+## PARAMETERS
+
+### -AsJob
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: (All)
+Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisplayName
+
+Specifies the friendly name of the certificate.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Flags
+
+Specifies if `NamedPipes` are enabled for SMB over QUIC. The acceptable values for this parameter
+are:
+
+- `None`: Remove all flags
+- `AllowNamedPipe`: Enable use of named pipes in SMB over QUIC connections for this mapping (off by
+  default, overrides value of the **RestrictNamedPipeAccessOverQuic** parameter)
+- `DefaultCert`: Not used
+
+```yaml
+Type: Flags[]
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, AllowNamedPipe, DefaultCert
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Force
+
+Forces the command to run without asking for user confirmation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IssuerName
+
+Filters the certificate mappings based on the issuer name of the certificate.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Namespace
+
+Specifies the namespace of the QUIC server. For example, `server1.contoso.com`. By default, the
+cmdlet searches in the `root\cimv2\Security\MicrosoftTlsCertificateMappingProvider` namespace.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -StoreName
+
+Specifies the path to the certificate store for the certificate.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Subject
+
+Specifies the subject name of the certificate.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ThrottleLimit
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Thumbprint
+
+Specifies the thumbprint value of the certificate.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Type
+
+Specifies the type of certificate mapping. The acceptable value for this parameter is:
+
+`QUIC`: Certificate mapping is for SMB over QUIC.
+
+```yaml
+Type: Type[]
+Parameter Sets: (All)
+Aliases:
+Accepted values: QUIC
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### Microsoft.Management.Infrastructure.CimInstance
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-SmbClientCertificateMapping](Get-SmbClientCertificateMapping.md)
+
+[Remove-SmbClientCertificateMapping](Remove-SmbClientCertificateMapping.md)
+
+[Set-SmbClientCertificateMapping](Set-SmbClientCertificateMapping.md)

--- a/docset/winserver2022-ps/smbshare/New-SmbServerCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbServerCertificateMapping.md
@@ -195,13 +195,15 @@ Accept wildcard characters: False
 ### -SkipClientCertificateAccessCheck
 
 Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not perform the access control
-checks based on the client certificates. This can be useful in scenarios where the server is acting
-as a gateway or proxy, and does not need to perform full certificate validation.
+connects. This parameter only applies when the server certificate mapping
+**RequireClientAuthentication** value is `$true`. When this parameter is set to `$true`, the server
+will not perform the access control checks based on the client certificates. This can be useful in
+scenarios where the server is acting as a gateway or proxy and client certificate validation is
+sufficient.
 
 However, it can also increase the risk of security breaches. When this parameter is set to
-`$false`, the server will check whether the client has access to the certificate it presents before
-allowing the client to connect.
+`$false`, the server will perform the access control checks based on the client certificates in
+addition to the client certificate validation before allowing the client to connect.
 
 ```yaml
 Type: Boolean

--- a/docset/winserver2022-ps/smbshare/New-SmbServerCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbServerCertificateMapping.md
@@ -31,7 +31,7 @@ over QUIC. For more information, see [SMB over QUIC](https://aka.ms/smboverquic)
 > [!NOTE]
 >
 > - The **RequireClientAuthentication** and **SkipClientCertificateAccessCheck** parameters are only
-> supported in Windows Server Datacenter: Azure Edition.
+> supported in Windows Server 2022 Datacenter: Azure Edition.
 >
 > - If the **RequireClientAuthentication** parameter is set to `$true` and
 > **SkipClientCertificateAccessCheck** is set to `$false`, the server will perform both client

--- a/docset/winserver2022-ps/smbshare/New-SmbServerCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbServerCertificateMapping.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbServerCertificateMapping.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 08/31/2021
+ms.date: 02/22/2024
 online version: https://learn.microsoft.com/powershell/module/smbshare/new-smbservercertificatemapping?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-SmbServerCertificateMapping
@@ -17,32 +17,59 @@ Creates a certificate association with the SMB server for SMB over QUIC.
 
 ```
 New-SmbServerCertificateMapping [-Name] <String> [-Thumbprint] <String> [-StoreName] <String>
- [-Subject <String>] [-DisplayName <String>] [-Type <Type>] [-Flags <Flags>] [-Force]
- [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Subject <String>] [-DisplayName <String>] [-Type <Type>] [-Flags <Flags>]
+ [-RequireClientAuthentication <Boolean>] [-SkipClientCertificateAccessCheck <Boolean>] [-Force]
+ [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **New-SmbServerCertificateMapping** cmdlet associates a certificate to the SMB server for SMB over QUIC on Windows Server 2022 Datacenter: Azure Edition. This cmdlet is not used for Windows or other Windows Server editions. For more information, review [SMB over QUIC](https://aka.ms/smboverquic).
+
+The `New-SmbServerCertificateMapping` cmdlet associates a certificate to the SMB server for SMB
+over QUIC. For more information, see [SMB over QUIC](https://aka.ms/smboverquic).
+
+> [!NOTE]
+>
+> - The **RequireClientAuthentication** and **SkipClientCertificateAccessCheck** parameters are only
+> supported in Windows Server Datacenter: Azure Edition.
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is set to `$false`, the server will perform both client
+> certificate validation and access control checks.
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is also set to `$true`, the server will perform client
+> certificate validation but no access control checks.
 
 ## EXAMPLES
 
 ### Example 1 - Map a certificate located in the local machine's personal store
 
-This command maps a certificate located in the local machine’s personal store for SMB server edge endpoint “fs2.contoso.com” using the certificate’s thumbprint.
+This command maps a certificate located in the local machine's personal store for SMB server edge
+endpoint `fs2.contoso.com` using the certificate's thumbprint.
 
 ```powershell
-New-SmbServerCertificateMapping -Name fs2.contoso.com -Thumbprint 88032B3551FAF7DE26EFFFF814AA086E3DBD2A4F -StoreName my -Subject CN=2022-ae-02
+$params = @{
+    Name = "fs2.contoso.com"
+    Thumbprint = "88032B3551FAF7DE26EFFFF814AA086E3DBD2A4F"
+    StoreName = "My"
+    Subject = "CN=2022-ae-02"
+}
+New-SmbServerCertificateMapping @params
 ```
+
 ```output
-Name            Subject       Thumbprint                               DisplayName StoreName Type Flags 
-----            -------       ----------                               ----------- --------- ---- ----- 
+Name            Subject       Thumbprint                               DisplayName StoreName Type Flags
+----            -------       ----------                               ----------- --------- ---- -----
 fs2.contoso.com CN=2022-ae-02 88032B3551FAF7DE26EFFFF814AA086E3DBD2A4F 2022-ae-02  my        QUIC None
 ```
 
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
 
 ```yaml
 Type: SwitchParameter
@@ -57,7 +84,11 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or
+[Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -72,6 +103,7 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayName
+
 Specifies a friendly name to display for the mapping.
 
 ```yaml
@@ -87,11 +119,14 @@ Accept wildcard characters: False
 ```
 
 ### -Flags
-Specifies if Named Pipes are enabled for SMB over QUIC. The acceptable values for this parameter are: 
 
-- `None:` Remove all flags.
-- `AllowNamedPipe:` Enable use of named pipes in SMB over QUIC connections for this mapping (off by default, overrides the value of RestrictNamedPipeAccessOverQuic).
-- `DefaultCert:` Not used. 
+Specifies if Named Pipes are enabled for SMB over QUIC. The acceptable values for this parameter
+are:
+
+- `None`: Remove all flags.
+- `AllowNamedPipe`: Enable use of named pipes in SMB over QUIC connections for this mapping (off by
+  default, overrides the value of the **RestrictNamedpipeAccessOverQuic** parameter).
+- `DefaultCert`: Not used.
 
 ```yaml
 Type: Flags
@@ -107,6 +142,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Forces the command to run without asking for user confirmation.
 
 ```yaml
@@ -122,7 +158,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies a fully-qualified DNS name or NetBIOS name that must match the certificate’s subject name or an entry in the certificate’s subject alternative names.
+
+Specifies a fully-qualified DNS name or NetBIOS name that must match the certificate's subject name
+or an entry in the certificate's subject alternative names.
 
 ```yaml
 Type: String
@@ -136,8 +174,51 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -RequireClientAuthentication
+
+Specifies whether client authentication is required for connections to the server. When this
+parameter is set to `$true`, clients must present a valid certificate to connect to the server.
+When it is set to `$false`, clients can connect without presenting a certificate.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipClientCertificateAccessCheck
+
+Specifies whether the server should skip the check for client certificate access when a client
+connects. When this parameter is set to `$true`, the server will not perform the access control
+checks based on the client certificates. This can be useful in scenarios where the server is acting
+as a gateway or proxy, and does not need to perform full certificate validation.
+
+However, it can also increase the risk of security breaches. When this parameter is set to
+`$false`, the server will check whether the client has access to the certificate it presents before
+allowing the client to connect.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -StoreName
-Specifies the path to the certificate store for the certificate. The recommended value is “My” for the local machine personal store.
+
+Specifies the path to the certificate store for the certificate. The recommended value is "My" for
+the local machine personal store.
 
 ```yaml
 Type: String
@@ -152,6 +233,7 @@ Accept wildcard characters: False
 ```
 
 ### -Subject
+
 Specifies the subject name of the certificate.
 
 ```yaml
@@ -167,7 +249,12 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If this parameter is omitted or a value of 0 is entered, then Windows PowerShell calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer. The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
 
 ```yaml
 Type: Int32
@@ -182,6 +269,7 @@ Accept wildcard characters: False
 ```
 
 ### -Thumbprint
+
 Specifies the thumbprint value of the certificate.
 
 ```yaml
@@ -197,9 +285,10 @@ Accept wildcard characters: False
 ```
 
 ### -Type
-Specifies the type of certificate mapping. The acceptable value for this parameter is:  
 
-`QUIC` Certificate mapping is for SMB over QUIC. 
+Specifies the type of certificate mapping. The acceptable value for this parameter is:
+
+- `QUIC`: Certificate mapping is for SMB over QUIC.
 
 ```yaml
 Type: Type
@@ -215,6 +304,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -230,8 +320,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -246,7 +336,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -259,3 +353,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[Get-SmbServerCertificateMapping](Get-SmbServerCertificateMapping.md)
+
+[Remove-SmbServerCertificateMapping](Remove-SmbServerCertificateMapping.md)
+
+[Set-SmbServerCertificateMapping](Set-SmbServerCertificateMapping.md)

--- a/docset/winserver2022-ps/smbshare/New-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/New-SmbShare.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbShare.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 10/20/2022
+ms.date: 02/22/2024
 online version: https://learn.microsoft.com/powershell/module/smbshare/new-smbshare?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-SmbShare
@@ -42,7 +42,7 @@ To delete a share that was created by this cmdlet, use the `Remove-SmbShare` cmd
 
 ```powershell
 $Parameters = @{
-    Name = 'Public'
+    Name = 'VMSFiles'
     Path = 'D:\Public'
     FullAccess = 'Contoso\Administrator', 'Contoso\Contoso-HV1$'
 }
@@ -101,36 +101,15 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -CATimeout
-
-Specifies the continuous availability time-out for the share.
-
-```yaml
-Type: UInt32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -CachingMode
 
 Specifies the caching mode of the offline files for the SMB share. There are five caching modes:
 
-- None.
-Prevents users from storing documents and programs offline.
-- Manual.
-Allows users to identify the documents and programs they want to store offline.
-- Programs.
-Automatically stores documents and programs offline.
-- Documents.
-Automatically stores documents offline.
-- BranchCache.
-Enables BranchCache and manual caching of documents on the shared folder.
+- BranchCache - Enables BranchCache and manual caching of documents on the shared folder.
+- Documents - Automatically stores documents offline.
+- Manual - Allows users to identify the documents and programs that they want to store offline.
+- Programs - Automatically stores documents and programs offline.
+- None - Prevents users from storing documents and programs offline.
 
 ```yaml
 Type: CachingMode
@@ -182,8 +161,8 @@ Accept wildcard characters: False
 ### -CimSession
 
 Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
-object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967)
-or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
 current session on the local computer.
 
 ```yaml
@@ -335,9 +314,9 @@ Accept wildcard characters: False
 Specifies SMB leasing and oplock behaviors for application compatibility. The acceptable values for
 this parameter are:
 
-- `Full:` Use default lease and oplock behaviors from SMB3.
-- `Shared:` Grant read-caching lease but not write or handle-caching.
-- `None:` No oplocks or leases, behave like SMB1 (not recommended).
+- `Full`: Use default lease and oplock behaviors from SMB3.
+- `Shared`: Grant read-caching lease but not write or handle-caching.
+- `None`: No oplocks or leases, behave like SMB1 (not recommended).
 
 ```yaml
 Type: LeasingMode
@@ -425,7 +404,8 @@ Accept wildcard characters: False
 
 ### -ScopeName
 
-Specifies the scope name of the share. For use with Windows Server failover cluster file server resources.
+Specifies the scope name of the share. For use with Windows Server failover cluster file server
+resources.
 
 ```yaml
 Type: String
@@ -510,8 +490,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet isn't run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 > [!NOTE]
 > The **WhatIf** switch doesn't work with this cmdlet.
@@ -533,7 +512,7 @@ Accept wildcard characters: False
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -552,8 +531,8 @@ object that represents the SMB share.
 
 ## RELATED LINKS
 
-[Get-SmbShare](./Get-SmbShare.md)
+[Get-SmbShare](Get-SmbShare.md)
 
-[Remove-SmbShare](./Remove-SmbShare.md)
+[Remove-SmbShare](Remove-SmbShare.md)
 
-[Set-SmbShare](./Set-SmbShare.md)
+[Set-SmbShare](Set-SmbShare.md)

--- a/docset/winserver2022-ps/smbshare/Remove-SmbClientCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/Remove-SmbClientCertificateMapping.md
@@ -1,27 +1,26 @@
 ---
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
-external help file: SmbServerCertificateMapping.cdxml-help.xml
+external help file: SmbClientCertificateMapping.cdxml-help.xml
 Module Name: SmbShare
 ms.date: 02/22/2024
-online version: https://learn.microsoft.com/powershell/module/smbshare/remove-smbservercertificatemapping?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
+online version: https://learn.microsoft.com/powershell/module/smbshare/remove-smbclientcertificatemapping?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
-title: Remove-SmbServerCertificateMapping
+title: Remove-SmbClientCertificateMapping
 ---
 
-# Remove-SmbServerCertificateMapping
+# Remove-SmbClientCertificateMapping
 
 ## SYNOPSIS
-Removes a certificate mapping from the SMB server for SMB over QUIC.
+Removes an existing client certificate mapping for the Server Message Block (SMB) protocol.
 
 ## SYNTAX
 
 ### Query
 
 ```
-Remove-SmbServerCertificateMapping [-Name] <String[]> [[-Subject] <String[]>]
- [[-Thumbprint] <String[]>] [[-DisplayName] <String[]>] [[-StoreName] <String[]>] [[-Type] <Type[]>]
- [[-Flags]<Flags[]>] [[-RequireClientAuthentication] <Boolean[]>]
- [[-SkipClientCertificateAccessCheck] <Boolean[]>] [-IncludeHidden] [-Force]
+Remove-SmbClientCertificateMapping [-Namespace] <String[]> [[-Subject] <String[]>]
+ [[-Thumbprint] <String[]>] [[-DisplayName] <String[]>] [[-StoreName] <String[]>]
+ [[-IssuerName] <String[]>] [[-Type] <Type[]>] [[-Flags] <Flags[]>] [-IncludeHidden] [-Force]
  [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-PassThru] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
@@ -29,51 +28,35 @@ Remove-SmbServerCertificateMapping [-Name] <String[]> [[-Subject] <String[]>]
 ### InputObject
 
 ```
-Remove-SmbServerCertificateMapping -InputObject <CimInstance[]> [-Force]
+Remove-SmbClientCertificateMapping -InputObject <CimInstance[]> [-Force]
  [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-PassThru] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Remove-SmbServerCertificateMapping` cmdlet removes the certificates associated with the SMB
-server for SMB over QUIC. For more information, review
-[SMB over QUIC](/windows-server/storage/file-server/smb-over-quic).
-
-> [!NOTE]
->
-> - The **RequireClientAuthentication** and **SkipClientCertificateAccessCheck** parameters are only
-> supported in Windows Server Datacenter: Azure Edition.
->
-> - If the **RequireClientAuthentication** parameter is set to `$true` and
-> **SkipClientCertificateAccessCheck** is set to `$false`, the server will perform both client
-> certificate validation and access control checks.
->
-> - If the **RequireClientAuthentication** parameter is set to `$true` and
-> **SkipClientCertificateAccessCheck** is also set to `$true`, the server will perform client
-> certificate validation but no access control checks.
+The `Remove-SmbClientCertificateMapping` cmdlet removes an existing client certificate mapping for
+the SMB protocol. These mappings are used to authenticate clients that connect to SMB servers using
+certificates. You can use this cmdlet to remove a mapping between a client certificate and an SMB
+client name.
 
 ## EXAMPLES
 
-### Example 1 - Remove a certificate mapping for SMB server edge endpoint
+### Example 1: Remove all certificate mappings from a specific store
 
 ```powershell
-$params = @{
-    Name = "fs2.contoso.com"
-    Thumbprint = "88032B3551FAF7DE26EFFFF814AA086E3DBD2A4F"
-}
-Remove-SmbServerCertificateMapping @params
+Remove-SmbClientCertificateMapping -StoreName "My" -Force
 ```
 
-```output
-Confirm
-Are you sure you want to perform this action?
-Performing operation 'Delete' on Target 'SMB Server Certificate Mapping.'.
-[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"): y
+This force removes all certificate mappings that have been stored in a specific certificate store.
+
+### Example 2: Remove a certificate mapping by thumbprint
+
+```powershell
+Remove-SmbClientCertificateMapping -Thumbprint "MyThumbprint" -Force
 ```
 
-This command removes a certificate mapping for SMB server edge endpoint `fs2.contoso.com` with a
-specific certificate thumbprint.
+This force removes a certificate mapping with a specific thumbprint.
 
 ## PARAMETERS
 
@@ -97,8 +80,8 @@ Accept wildcard characters: False
 ### -CimSession
 
 Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
-object, such as the output of a [`New-CimSession`](/powershell/module/cimcmdlets/new-cimsession) or
-[`Get-CimSession`](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
 current session on the local computer.
 
 ```yaml
@@ -115,7 +98,7 @@ Accept wildcard characters: False
 
 ### -DisplayName
 
-Specifies a friendly name to display for the mapping.
+Specifies the friendly name of the certificate.
 
 ```yaml
 Type: String[]
@@ -136,7 +119,7 @@ are:
 
 - `None`: Remove all flags.
 - `AllowNamedPipe`: Enable use of named pipes in SMB over QUIC connections for this mapping (off by
-  default, overrides the value of the **RestrictNamedpipeAccessOverQuic** parameter).
+  default, overrides the value of the **RestrictNamedPipeAccessOverQuic** parameter).
 - `DefaultCert`: Not used.
 
 ```yaml
@@ -200,10 +183,26 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Name
+### -IssuerName
 
-Specifies a fully-qualified DNS name or NetBIOS name that must match the certificate's subject name
-or an entry in the certificate's subject alternative names.
+Filters the certificate mappings based on the issuer name of the certificate.
+
+```yaml
+Type: String[]
+Parameter Sets: Query
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Namespace
+
+Specifies the namespace of the QUIC server. For example, `server1.contoso.com`. By default, the
+cmdlet searches in the `root\cimv2\Security\MicrosoftTlsCertificateMappingProvider` namespace.
 
 ```yaml
 Type: String[]
@@ -231,47 +230,6 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RequireClientAuthentication
-
-Specifies whether client authentication is required for connections to the server. When this
-parameter is set to `$true`, clients must present a valid certificate to connect to the server.
-When it is set to `$false`, clients can connect without presenting a certificate.
-
-```yaml
-Type: Boolean[]
-Parameter Sets: Query
-Aliases:
-
-Required: False
-Position: 8
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -SkipClientCertificateAccessCheck
-
-Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not perform the access control
-checks based on the client certificates. This can be useful in scenarios where the server is acting
-as a gateway or proxy, and does not need to perform full certificate validation.
-
-However, it can also increase the risk of security breaches. When this parameter is set to
-`$false`, the server will check whether the client has access to the certificate it presents before
-allowing the client to connect.
-
-```yaml
-Type: Boolean[]
-Parameter Sets: Query
-Aliases:
-
-Required: False
-Position: 9
-Default value: None
-Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -346,9 +304,7 @@ Accept wildcard characters: False
 
 ### -Type
 
-Specifies the type of certificate mapping. The acceptable value for this parameter is:
-
-- `QUIC`: Certificate mapping is for SMB over QUIC.
+`QUIC`: Certificate mapping is for SMB over QUIC.
 
 ```yaml
 Type: Type[]
@@ -374,7 +330,7 @@ Aliases: cf
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -390,7 +346,7 @@ Aliases: wi
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -406,11 +362,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String[]
 
-### Microsoft.PowerShell.Cmdletization.GeneratedTypes.SmbServerCertificateMapping.Type[]
+### Microsoft.PowerShell.Cmdletization.GeneratedTypes.SmbClientCertificateMapping.Type[]
 
-### Microsoft.PowerShell.Cmdletization.GeneratedTypes.SmbServerCertificateMapping.Flags[]
-
-### System.Boolean[]
+### Microsoft.PowerShell.Cmdletization.GeneratedTypes.SmbClientCertificateMapping.Flags[]
 
 ### Microsoft.Management.Infrastructure.CimInstance[]
 
@@ -418,14 +372,14 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.Management.Infrastructure.CimInstance
 
-### Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/SMB/MSFT_SmbServerCertificateMapping
+### Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/SMB/MSFT_SmbClientCertificateMapping
 
 ## NOTES
 
 ## RELATED LINKS
 
-[Get-SmbServerCertificateMapping](Get-SmbServerCertificateMapping.md)
+[Get-SmbClientCertificateMapping](Get-SmbClientCertificateMapping.md)
 
-[New-SmbServerCertificateMapping](New-SmbServerCertificateMapping.md)
+[New-SmbClientCertificateMapping](New-SmbClientCertificateMapping.md)
 
-[Set-SmbServerCertificateMapping](Set-SmbServerCertificateMapping.md)
+[Set-SmbClientCertificateMapping](Set-SmbClientCertificateMapping.md)

--- a/docset/winserver2022-ps/smbshare/Remove-SmbServerCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/Remove-SmbServerCertificateMapping.md
@@ -255,13 +255,15 @@ Accept wildcard characters: False
 ### -SkipClientCertificateAccessCheck
 
 Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not perform the access control
-checks based on the client certificates. This can be useful in scenarios where the server is acting
-as a gateway or proxy, and does not need to perform full certificate validation.
+connects. This parameter only applies when the server certificate mapping
+**RequireClientAuthentication** value is `$true`. When this parameter is set to `$true`, the server
+will not perform the access control checks based on the client certificates. This can be useful in
+scenarios where the server is acting as a gateway or proxy and client certificate validation is
+sufficient.
 
 However, it can also increase the risk of security breaches. When this parameter is set to
-`$false`, the server will check whether the client has access to the certificate it presents before
-allowing the client to connect.
+`$false`, the server will perform the access control checks based on the client certificates in
+addition to the client certificate validation before allowing the client to connect.
 
 ```yaml
 Type: Boolean[]

--- a/docset/winserver2022-ps/smbshare/Remove-SmbServerCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/Remove-SmbServerCertificateMapping.md
@@ -43,7 +43,7 @@ server for SMB over QUIC. For more information, review
 > [!NOTE]
 >
 > - The **RequireClientAuthentication** and **SkipClientCertificateAccessCheck** parameters are only
-> supported in Windows Server Datacenter: Azure Edition.
+> supported in Windows Server 2022 Datacenter: Azure Edition.
 >
 > - If the **RequireClientAuthentication** parameter is set to `$true` and
 > **SkipClientCertificateAccessCheck** is set to `$false`, the server will perform both client

--- a/docset/winserver2022-ps/smbshare/Remove-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/Remove-SmbShare.md
@@ -2,8 +2,8 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbShare.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 12/20/2016
-online version: https://learn.microsoft.com/powershell/module/smbshare/remove-smbshare?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
+ms.date: 02/22/2024
+online version: https://learn.microsoft.com/powershell/module/smbshare/remove-smbshare?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Remove-SmbShare
 ---
@@ -16,39 +16,44 @@ Deletes the specified SMB shares.
 ## SYNTAX
 
 ### Query
+
 ```
 Remove-SmbShare [-Name] <String[]> [[-ScopeName] <String[]>] [-SmbInstance <SmbInstance>] [-Force]
  [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-PassThru] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
-### InputObject (cdxml)
+### InputObject
+
 ```
-Remove-SmbShare -InputObject <CimInstance[]> [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
- [-AsJob] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-SmbShare -InputObject <CimInstance[]> [-Force] [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>] [-AsJob] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Remove-SmbShare** cmdlet deletes one or more Server Message Block (SMB) shares.
 
-Removing an SMB share forcibly disconnects all of the existing connections to the share.
-Use this cmdlet with caution.
-Clients that are forcibly disconnected from a share are not able to flush locally cached data before they are disconnected.
-This may cause data loss.
-Use the Get-SmbSession cmdlet to determine whether users are connected to a share.
+The `Remove-SmbShare` cmdlet deletes one or more Server Message Block (SMB) shares.
+
+Removing an SMB share forcibly disconnects all of the existing connections to the share. Use this
+cmdlet with caution. Clients that are forcibly disconnected from a share aren't able to flush
+locally cached data before they are disconnected. This may cause data loss. Use the `Get-SmbSession`
+cmdlet to determine whether users are connected to a share.
 
 ## EXAMPLES
 
 ### Example 1: Delete an SMB share
-```
-PS C:\>Remove-SmbShare -Name "Data"
-Confirm 
-Are you sure you want to perform this action? 
-Performing operation 'Remove-Share' on Target 'Contoso-FS,Data'. 
+
+```powershell
+Remove-SmbShare -Name "Data"
+
+
+Confirm
+Are you sure you want to perform this action?
+Performing operation `Remove-Share` on Target 'Contoso-FS,Data'.
 [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"):
 ```
 
-This command deletes the SMB share named Data.
+This command deletes the SMB share named `Data`.
 
 ### Example 2: Delete a Windows Server failover cluster file server resource SMB share without confirmation
 
@@ -56,17 +61,20 @@ This command deletes the SMB share named Data.
 Remove-SmbShare -Name "VMFiles" -ScopeName "Contoso-SO" -Force
 ```
 
-This command deletes the SMB share named VMFiles on the `Contoso-SO` file server resource without user confirmation.
+This command deletes the SMB share named `VMFiles` on the `Contoso-SO` file server resource without
+user confirmation.
 
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -76,9 +84,11 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
-The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -93,12 +103,13 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Forces the command to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -108,12 +119,13 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies the input object that is used in a pipeline command.
+
+Specifies the input object that's used in a pipeline command.
 
 ```yaml
 Type: CimInstance[]
-Parameter Sets: InputObject (cdxml)
-Aliases: 
+Parameter Sets: InputObject
+Aliases:
 
 Required: True
 Position: Named
@@ -123,12 +135,13 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies an array of names of SMB shares.
 
 ```yaml
 Type: String[]
 Parameter Sets: Query
-Aliases: 
+Aliases:
 
 Required: True
 Position: 1
@@ -138,13 +151,14 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+
+Returns an object representing the item with which you're working. By default, this cmdlet doesn't
+generate any output.
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -155,12 +169,13 @@ Accept wildcard characters: False
 
 ### -ScopeName
 
-Specifies an array of the scopes of the SMB share to delete. For use with Windows Server failover cluster file server resources.
+Specifies an array of the scopes of the SMB share to delete. For use with Windows Server failover
+cluster file server resources.
 
 ```yaml
 Type: String[]
 Parameter Sets: Query
-Aliases: 
+Aliases:
 
 Required: False
 Position: 2
@@ -170,13 +185,14 @@ Accept wildcard characters: False
 ```
 
 ### -SmbInstance
-Specifies the input to this cmdlet.
-You can use this parameter, or you can pipe the input to this cmdlet.
+
+Specifies the input to this cmdlet. You can use this parameter, or you can pipe the input to this
+cmdlet.
 
 ```yaml
 Type: SmbInstance
 Parameter Sets: Query
-Aliases: 
+Aliases:
 Accepted values: Default, CSV, SBL, SR
 
 Required: False
@@ -187,14 +203,17 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-If this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
-The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
 
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -204,6 +223,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -213,14 +233,14 @@ Aliases: cf
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -229,33 +249,40 @@ Aliases: wi
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
 ### Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/SMB/MSFT_SmbShare
-The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays Windows Management Instrumentation (WMI) objects.
-The path after the pound sign (`#`) provides the namespace and class name for the underlying WMI object.
+
+The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays
+Windows Management Instrumentation (WMI) objects. The path after the pound sign (`#`) provides the
+namespace and class name for the underlying WMI object.
 
 ## OUTPUTS
 
 ### Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/SMB/MSFT_SmbShare
-The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays Windows Management Instrumentation (WMI) objects.
-The path after the pound sign (`#`) provides the namespace and class name for the underlying WMI object.
+
+The `Microsoft.Management.Infrastructure.CimInstance` object is a wrapper class that displays
+Windows Management Instrumentation (WMI) objects. The path after the pound sign (`#`) provides the
+namespace and class name for the underlying WMI object.
 
 ## NOTES
 
 ## RELATED LINKS
 
-[Get-SmbShare](./Get-SmbShare.md)
+[Get-SmbShare](Get-SmbShare.md)
 
-[New-SmbShare](./New-SmbShare.md)
+[New-SmbShare](New-SmbShare.md)
 
-[Set-SmbShare](./Set-SmbShare.md)
-
+[Set-SmbShare](Set-SmbShare.md)

--- a/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
@@ -2,8 +2,8 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbServerConfiguration.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 10/20/2022
-online version: http://go.microsoft.com/fwlink/?LinkID=241959
+ms.date: 02/22/2024
+online version: https://learn.microsoft.com/powershell/module/smbshare/reset-smbserverconfiguration?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Reset-SmbServerConfiguration
 ---
@@ -39,6 +39,7 @@ default values. For more information on SMB server and protocol specifications, 
 and [[MS-SMB2]:Server Message Block (SMB) Protocol Versions 2 and3](/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962).
 
 > [!NOTE]
+>
 > - This cmdlet is available beginning with 2022-06 Cumulative Update for Microsoft server operating
 > system version 21H2 for x64-based Systems
 > ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,
@@ -210,8 +211,8 @@ Accept wildcard characters: False
 ### -CimSession
 
 Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
-object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967)
-or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
 current session on the local computer.
 
 ```yaml
@@ -844,7 +845,7 @@ Accept wildcard characters: False
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -858,6 +859,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-SmbServerConfiguration](./Get-SmbServerConfiguration.md)
+[Get-SmbServerConfiguration](Get-SmbServerConfiguration.md)
 
-[Set-SmbServerConfiguration](./Set-SmbServerConfiguration.md)
+[Set-SmbServerConfiguration](Set-SmbServerConfiguration.md)

--- a/docset/winserver2022-ps/smbshare/Revoke-SmbClientAccessToServer.md
+++ b/docset/winserver2022-ps/smbshare/Revoke-SmbClientAccessToServer.md
@@ -1,0 +1,262 @@
+---
+description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
+external help file: SmbClientAccessToServer.cdxml-help.xml
+Module Name: SmbShare
+ms.date: 02/22/2024
+online version: https://learn.microsoft.com/powershell/module/smbshare/revoke-smbclientaccesstoserver?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Revoke-SmbClientAccessToServer
+---
+
+# Revoke-SmbClientAccessToServer
+
+## SYNOPSIS
+Revokes SMB client access to a specified server.
+
+## SYNTAX
+
+### Query
+
+```
+Revoke-SmbClientAccessToServer [-Name] <String[]> -IdentifierType <IdentifierType>
+ -Identifier <String> [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### InputObject
+
+```
+Revoke-SmbClientAccessToServer -InputObject <CimInstance[]> -IdentifierType <IdentifierType>
+ -Identifier <String> [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Revoke-SmbClientAccessToServer` cmdlet is used to remove a previously granted access rule for
+SMB clients to a specified server. When you run this cmdlet, it'll remove the firewall rule that
+allows incoming SMB traffic from the specified client IP address. If you need to grant access to
+the server again in the future, you can use the `Grant-SmbClientAccessToServer` cmdlet.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Revoke-SmbClientAccessToServer -Name "Server01" -IdentifierType "SHA256" -Identifier "ClientHash"
+```
+
+This example revokes the SMB client access to a server named `Server01` for a client with a
+specific SHA256 hash value.
+
+## PARAMETERS
+
+### -AsJob
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or
+[Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: (All)
+Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+
+Forces the command to run without asking for user confirmation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identifier
+
+Specifies the identity of the client that is being granted access to the SMB server. This parameter
+takes a string value that represents the identity of the client. The format of the string value
+will depend on the **IdentifierType** parameter that you're using.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IdentifierType
+
+Specifies the type of identifier that you're using to identify a client. The valid values for the
+**IdentifierType** parameter are:
+
+- SHA256
+- ISSUER
+
+If you're using the `SHA256` identifier type, you're specifying a hash value that uniquely
+identifies the client. If you're using the `ISSUER` identifier type, you're specifying the issuer
+of the client's certificate.
+
+```yaml
+Type: IdentifierType
+Parameter Sets: (All)
+Aliases:
+Accepted values: SHA256, ISSUER
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+
+Specifies the input object that's used in a pipeline command.
+
+```yaml
+Type: CimInstance[]
+Parameter Sets: InputObject
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Name
+
+Specifies a fully-qualified DNS name or NetBIOS name that must match the certificate's subject name
+or an entry in the certificate's subject alternative names.
+
+```yaml
+Type: String
+Parameter Sets: Query
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ThrottleLimit
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer.
+
+The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### System.String[]
+
+### Microsoft.Management.Infrastructure.CimInstance[]
+
+## OUTPUTS
+
+### Microsoft.Management.Infrastructure.CimInstance[]
+
+## NOTES
+
+## RELATED LINKS
+
+[Block-SmbClientAccessToServer](Block-SmbClientAccessToServer.md)
+
+[Get-SmbClientAccessToServer](Get-SmbClientAccessToServer.md)
+
+[Grant-SmbClientAccessToServer](Grant-SmbClientAccessToServer.md)
+
+[Unblock-SmbClientAccessToServer](Unblock-SmbClientAccessToServer.md)

--- a/docset/winserver2022-ps/smbshare/Set-SmbClientCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbClientCertificateMapping.md
@@ -1,0 +1,244 @@
+---
+description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
+external help file: SmbClientCertificateMapping.cdxml-help.xml
+Module Name: SmbShare
+ms.date: 02/22/2024
+online version: https://learn.microsoft.com/powershell/module/smbshare/set-smbclientcertificatemapping?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Set-SmbClientCertificateMapping
+---
+
+# Set-SmbClientCertificateMapping
+
+## SYNOPSIS
+Configures an existing client certificate mapping for the Server Message Block (SMB) protocol.
+
+## SYNTAX
+
+```
+Set-SmbClientCertificateMapping [-Namespace] <String> [-Flags <Flags>] [-Thumbprint <String>]
+ [-StoreName <String>] [-IssuerName <String>] [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Set-SmbClientCertificateMapping` cmdlet modifies an existing client certificate mapping for
+the SMB protocol. These mappings are used to authenticate clients that connect to SMB servers using
+certificates. You can use this cmdlet to modify an existing mapping between a client certificate
+and an SMB client name.
+
+## EXAMPLES
+
+### Example 1: Update the issuer name for a certificate mapping
+
+```powershell
+Set-SmbClientCertificateMapping -Thumbprint "1234567890abcdef" -IssuerName "CN=NewIssuerName"
+```
+
+This updates the issuer name for a certificate mapping with a specific thumbprint.
+
+## PARAMETERS
+
+### -AsJob
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: (All)
+Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Flags
+
+Specifies if `NamedPipes` are enabled for SMB over QUIC. The acceptable values for this parameter
+are:
+
+- `None`: Remove all flags
+- `AllowNamedPipe`: Enable use of named pipes in SMB over QUIC connections for this mapping (off by
+  default, overrides value of the **RestrictNamedPipeAccessOverQuic** parameter)
+- `DefaultCert`: Not used
+
+```yaml
+Type: Flags[]
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, AllowNamedPipe, DefaultCert
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -IssuerName
+
+Filters the certificate mappings based on the issuer name of the certificate.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Namespace
+
+Specifies the namespace of the QUIC server. For example, `server1.contoso.com`. By default, the
+cmdlet searches in the `root\cimv2\Security\MicrosoftTlsCertificateMappingProvider` namespace.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -StoreName
+
+Specifies the path to the certificate store for the certificate.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ThrottleLimit
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Thumbprint
+
+Specifies the thumbprint value of the certificate.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### System.String
+
+### Microsoft.PowerShell.Cmdletization.GeneratedTypes.SmbClientCertificateMapping.Flags
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-SmbClientCertificateMapping](Get-SmbClientCertificateMapping.md)
+
+[New-SmbClientCertificateMapping](New-SmbClientCertificateMapping.md)
+
+[Remove-SmbClientCertificateMapping](Remove-SmbClientCertificateMapping.md)

--- a/docset/winserver2022-ps/smbshare/Set-SmbServerCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbServerCertificateMapping.md
@@ -41,7 +41,7 @@ for SMB over QUIC. For more information, see [SMB over QUIC](https://aka.ms/smbo
 > [!NOTE]
 >
 > - The **RequireClientAuthentication** and **SkipClientCertificateAccessCheck** parameters are only
-> supported in Windows Server Datacenter: Azure Edition.
+> supported in Windows Server 2022 Datacenter: Azure Edition.
 >
 > - If the **RequireClientAuthentication** parameter is set to `$true` and
 > **SkipClientCertificateAccessCheck** is set to `$false`, the server will perform both client

--- a/docset/winserver2022-ps/smbshare/Set-SmbServerCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbServerCertificateMapping.md
@@ -200,13 +200,15 @@ Accept wildcard characters: False
 ### -SkipClientCertificateAccessCheck
 
 Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not perform the access control
-checks based on the client certificates. This can be useful in scenarios where the server is acting
-as a gateway or proxy, and does not need to perform full certificate validation.
+connects. This parameter only applies when the server certificate mapping
+**RequireClientAuthentication** value is `$true`. When this parameter is set to `$true`, the server
+will not perform the access control checks based on the client certificates. This can be useful in
+scenarios where the server is acting as a gateway or proxy and client certificate validation is
+sufficient.
 
 However, it can also increase the risk of security breaches. When this parameter is set to
-`$false`, the server will check whether the client has access to the certificate it presents before
-allowing the client to connect.
+`$false`, the server will perform the access control checks based on the client certificates in
+addition to the client certificate validation before allowing the client to connect.
 
 ```yaml
 Type: Boolean

--- a/docset/winserver2022-ps/smbshare/Set-SmbServerCertificateMapping.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbServerCertificateMapping.md
@@ -2,8 +2,8 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbServerCertificateMapping.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 08/21/2021
-online version: https://learn.microsoft.com/powershell/module/smbshare/Set-SmbServerCertificateMapping?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
+ms.date: 02/22/2024
+online version: https://learn.microsoft.com/powershell/module/smbshare/set-smbservercertificatemapping?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-SmbServerCertificateMapping
 ---
@@ -16,35 +16,64 @@ Modifies a certificate association with the SMB server for SMB over QUIC.
 ## SYNTAX
 
 ### Query
+
 ```
 Set-SmbServerCertificateMapping [-Name] <String[]> [-Flags <Flags>] [-Thumbprint <String>]
- [-StoreName <String>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-PassThru] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [-StoreName <String>] [-RequireClientAuthentication <Boolean>]
+ [-SkipClientCertificateAccessCheck <Boolean>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
+ [-AsJob] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### InputObject (cdxml)
+### InputObject
+
 ```
 Set-SmbServerCertificateMapping -InputObject <CimInstance[]> [-Flags <Flags>] [-Thumbprint <String>]
- [-StoreName <String>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-PassThru] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [-StoreName <String>] [-RequireClientAuthentication <Boolean>]
+ [-SkipClientCertificateAccessCheck <Boolean>] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
+ [-AsJob] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Set-SmbServerCertificateMapping** cmdlet modifies a certificate’s association to the SMB server for SMB over QUIC on Windows Server 2022 Datacenter: Azure Edition. This cmdlet is not used for Windows or other Windows Server editions. For more information, review [SMB over QUIC](https://aka.ms/smboverquic).
+
+The `Set-SmbServerCertificateMapping` cmdlet modifies a certificate's association to the SMB server
+for SMB over QUIC. For more information, see [SMB over QUIC](https://aka.ms/smboverquic).
+
+> [!NOTE]
+>
+> - The **RequireClientAuthentication** and **SkipClientCertificateAccessCheck** parameters are only
+> supported in Windows Server Datacenter: Azure Edition.
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is set to `$false`, the server will perform both client
+> certificate validation and access control checks.
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is also set to `$true`, the server will perform client
+> certificate validation but no access control checks.
 
 ## EXAMPLES
 
-### Example 1 - Enable Named Pipes for the SMB over QUIC endpoint
-This command enables Named Pipes for the SMB over QUIC endpoint, overriding the default behavior where Named Pipes are disabled for increased security.
+### Example 1: Enable Named Pipes for the SMB over QUIC endpoint
+
+This command enables Named Pipes for the SMB over QUIC endpoint, overriding the default behavior
+where Named Pipes are disabled for increased security.
 
 ```powershell
-PS C:\> Set-SmbServerCertificateMapping -Name 2022-ae-02.corp.contoso.com -Thumbprint 88032B3551FAF7DE26EFFFF814AA086E3DBD2A4F -StoreName my -Flags AllowNamedPipe
+$params = @{
+    Name = "2022-ae-02.corp.contoso.com"
+    Thumbprint = "88032B3551FAF7DE26EFFFF814AA086E3DBD2A4F"
+    StoreName = "My"
+    Flags = "AllowNamedPipe"
+}
+Set-SmbServerCertificateMapping @params
 ```
 
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
 
 ```yaml
 Type: SwitchParameter
@@ -59,7 +88,11 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet. The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or
+[Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -74,11 +107,14 @@ Accept wildcard characters: False
 ```
 
 ### -Flags
-Specifies if Named Pipes are enabled for SMB over QUIC. The acceptable values for this parameter are: 
 
-- `None:` Remove all flags.
-- `AllowNamedPipe:` Enable use of named pipes in SMB over QUIC connections for this mapping (off by default, overrides the value of RestrictNamedPipeAccessOverQuic).
-- `DefaultCert:` Not used.
+Specifies if Named Pipes are enabled for SMB over QUIC. The acceptable values for this parameter
+are:
+
+- `None`: Remove all flags.
+- `AllowNamedPipe`: Enable use of named pipes in SMB over QUIC connections for this mapping (off by
+  default, overrides the value of the **RestrictNamedpipeAccessOverQuic** parameter).
+- `DefaultCert`: Not used.
 
 ```yaml
 Type: Flags
@@ -94,11 +130,12 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies the input object that is used in a pipeline command.
+
+Specifies the input object that's used in a pipeline command.
 
 ```yaml
 Type: CimInstance[]
-Parameter Sets: InputObject (cdxml)
+Parameter Sets: InputObject
 Aliases:
 
 Required: True
@@ -109,7 +146,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies a fully-qualified DNS name or NetBIOS name that must match the certificate’s subject name or an entry in the certificate’s subject alternative names.
+
+Specifies a fully-qualified DNS name or NetBIOS name that must match the certificate's subject name
+or an entry in the certificate's subject alternative names.
 
 ```yaml
 Type: String[]
@@ -124,7 +163,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Returns an object representing the item with which you are working. By default, this cmdlet does not generate any output.
+
+Returns an object representing the item with which you're working. By default, this cmdlet doesn't
+generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -138,8 +179,51 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RequireClientAuthentication
+
+Specifies whether client authentication is required for connections to the server. When this
+parameter is set to `$true`, clients must present a valid certificate to connect to the server.
+When it is set to `$false`, clients can connect without presenting a certificate.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipClientCertificateAccessCheck
+
+Specifies whether the server should skip the check for client certificate access when a client
+connects. When this parameter is set to `$true`, the server will not perform the access control
+checks based on the client certificates. This can be useful in scenarios where the server is acting
+as a gateway or proxy, and does not need to perform full certificate validation.
+
+However, it can also increase the risk of security breaches. When this parameter is set to
+`$false`, the server will check whether the client has access to the certificate it presents before
+allowing the client to connect.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -StoreName
-Specifies the path to the certificate store for the certificate. The recommended value is “My” for the local machine personal store.
+
+Specifies the path to the certificate store for the certificate. The recommended value is "My" for
+the local machine personal store.
 
 ```yaml
 Type: String
@@ -154,7 +238,12 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If this parameter is omitted or a value of 0 is entered, then Windows PowerShell calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer. The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
 
 ```yaml
 Type: Int32
@@ -169,6 +258,7 @@ Accept wildcard characters: False
 ```
 
 ### -Thumbprint
+
 Specifies the thumbprint value of the certificate.
 
 ```yaml
@@ -184,6 +274,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -199,8 +290,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -215,7 +306,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -236,3 +331,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[Get-SmbServerCertificateMapping](Get-SmbServerCertificateMapping.md)
+
+[New-SmbServerCertificateMapping](New-SmbServerCertificateMapping.md)
+
+[Remove-SmbServerCertificateMapping](Remove-SmbServerCertificateMapping.md)

--- a/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
@@ -47,6 +47,7 @@ For more information on SMB server and protocol specifications, see
 and [[MS-SMB2]:Server Message Block (SMB) Protocol Versions 2 and 3](/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962).
 
 > [!NOTE]
+>
 > - The **EncryptionCiphers** parameter is available beginning with 2022-06 Cumulative Update for
 >   Microsoft server operating system version 21H2 for x64-based Systems
 >   ([KB5014665](https://support.microsoft.com/help/5014665)), and Cumulative Update for Windows 11,

--- a/docset/winserver2022-ps/smbshare/Set-SmbShare.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbShare.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbShare.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 12/20/2016
+ms.date: 02/22/2024
 online version: https://learn.microsoft.com/powershell/module/smbshare/set-smbshare?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-SmbShare
@@ -16,43 +16,51 @@ Modifies the properties of the SMB share.
 ## SYNTAX
 
 ### Query
+
 ```
-Set-SmbShare [-Name] <String[]> [[-ScopeName] <String[]>] [-SmbInstance <SmbInstance>] [-Description <String>]
- [-ConcurrentUserLimit <UInt32>] [-CATimeout <UInt32>] [-ContinuouslyAvailable <Boolean>]
- [-FolderEnumerationMode <FolderEnumerationMode>] [-CachingMode <CachingMode>] [-SecurityDescriptor <String>]
- [-EncryptData <Boolean>] [-CompressData <Boolean>] [-LeasingMode <LeasingMode>] [-Force]
- [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-PassThru] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Set-SmbShare [-Name] <String[]> [[-ScopeName] <String[]>] [-SmbInstance <SmbInstance>]
+ [-Description <String>] [-ConcurrentUserLimit <UInt32>] [-CATimeout <UInt32>]
+ [-ContinuouslyAvailable <Boolean>] [-FolderEnumerationMode <FolderEnumerationMode>]
+ [-CachingMode <CachingMode>] [-SecurityDescriptor <String>] [-EncryptData <Boolean>]
+ [-CompressData <Boolean>] [-LeasingMode <LeasingMode>] [-Force] [-CimSession <CimSession[]>]
+ [-ThrottleLimit <Int32>] [-AsJob] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### InputObject (cdxml)
+### InputObject
+
 ```
 Set-SmbShare -InputObject <CimInstance[]> [-Description <String>] [-ConcurrentUserLimit <UInt32>]
- [-CATimeout <UInt32>] [-ContinuouslyAvailable <Boolean>] [-FolderEnumerationMode <FolderEnumerationMode>]
- [-CachingMode <CachingMode>] [-SecurityDescriptor <String>] [-EncryptData <Boolean>] [-CompressData <Boolean>]
- [-LeasingMode <LeasingMode>] [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
- [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-CATimeout <UInt32>] [-ContinuouslyAvailable <Boolean>]
+ [-FolderEnumerationMode <FolderEnumerationMode>] [-CachingMode <CachingMode>]
+ [-SecurityDescriptor <String>] [-EncryptData <Boolean>] [-CompressData <Boolean>]
+ [-LeasingMode <LeasingMode>] [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
+ [-AsJob] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Set-SmbShare** cmdlet modifies the properties of the Server Message Block (SMB) share.
+
+The `Set-SmbShare` cmdlet modifies the properties of the Server Message Block (SMB) share.
 
 ## EXAMPLES
 
 ### Example 1: Modify properties of an SMB share
-```
-PS C:\>Set-SmbShare -Name "VMFiles" -EncryptData $True
-Confirm 
-Are you sure you want to perform this action? 
-Performing operation 'Modify' on Target 'Contoso-SO,VMFiles'. 
+
+```powershell
+Set-SmbShare -Name "VMFiles" -EncryptData $True
+
+
+Confirm
+Are you sure you want to perform this action?
+Performing operation 'Modify' on Target 'Contoso-SO,VMFiles'.
 [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"):
 ```
 
 This command modifies the properties of an SMB share.
 
 ### Example 2: Modify properties of an SMB share without confirmation
-```
-PS C:\>Set-SmbShare -Name "VMFiles" -EncryptData $True -Force
+
+```powershell
+Set-SmbShare -Name "VMFiles" -EncryptData $True -Force
 ```
 
 This command modifies the properties of an SMB share without user confirmation.
@@ -60,7 +68,9 @@ This command modifies the properties of an SMB share without user confirmation.
 ## PARAMETERS
 
 ### -AsJob
-Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to complete.
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
 
 ```yaml
 Type: SwitchParameter
@@ -75,6 +85,7 @@ Accept wildcard characters: False
 ```
 
 ### -CATimeout
+
 Specifies the continuous availability time-out of the SMB share.
 
 ```yaml
@@ -90,24 +101,19 @@ Accept wildcard characters: False
 ```
 
 ### -CachingMode
-Specifies the caching mode of the offline files for the SMB share.
-There are five caching modes:
 
-- None.
-Prevents users from storing documents and programs offline.
-- Manual.
-Allows users to identify the documents and programs that they want to store offline.
-- Programs.
-Automatically stores documents and programs offline.
-- Documents.
-Automatically stores documents offline.
-- BranchCache.
-Enables BranchCache and manual caching of documents on the shared folder.
+Specifies the caching mode of the offline files for the SMB share. There are five caching modes:
+
+- BranchCache - Enables BranchCache and manual caching of documents on the shared folder.
+- Documents - Automatically stores documents offline.
+- Manual - Allows users to identify the documents and programs that they want to store offline.
+- Programs - Automatically stores documents and programs offline.
+- None - Prevents users from storing documents and programs offline.
 
 ```yaml
 Type: CachingMode
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: None, Manual, Documents, Programs, BranchCache, Unknown
 
 Required: False
@@ -118,9 +124,11 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227967) or [Get-CimSession](https://go.microsoft.com/fwlink/p/?LinkId=227966) cmdlet.
-The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession)
+or [Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
 
 ```yaml
 Type: CimSession[]
@@ -135,6 +143,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompressData
+
 Indicates that the shares being enumerated should request compression from clients.
 
 ```yaml
@@ -150,6 +159,7 @@ Accept wildcard characters: False
 ```
 
 ### -ConcurrentUserLimit
+
 Specifies the maximum number of concurrently connected users that the SMB share may accommodate.
 If this parameter is set to zero (0), then the number of users is unlimited.
 By default, new SMB shares have no limit on the number of concurrent connections.
@@ -167,6 +177,7 @@ Accept wildcard characters: False
 ```
 
 ### -ContinuouslyAvailable
+
 Indicates whether the share is continuously available.
 
 ```yaml
@@ -182,10 +193,10 @@ Accept wildcard characters: False
 ```
 
 ### -Description
-Specifies an optional description of the SMB share.
-A description of the share can be displayed by running the Get-SmbShare cmdlet.
-Specify an empty string to clear the current description.
-The description may not contain more than 256 characters.
+
+Specifies an optional description of the SMB share. A description of the share can be displayed by
+running the Get-SmbShare cmdlet. Specify an empty string to clear the current description. The
+description may not contain more than 256 characters.
 
 ```yaml
 Type: String
@@ -200,6 +211,7 @@ Accept wildcard characters: False
 ```
 
 ### -EncryptData
+
 Indicates whether the SMB share is encrypted.
 
 ```yaml
@@ -215,16 +227,17 @@ Accept wildcard characters: False
 ```
 
 ### -FolderEnumerationMode
-Specifies which files and folders in the new SMB share will be visible to the users.
-The acceptable values for this parameter are:
 
-- AccessBased.
-SMB does not the display the files and folders for a share to a user unless that user has rights to access the files and folders.
-By default, access-based enumeration is disabled for new SMB shares.
-- Unrestricted.
-SMB displays files and folders to a user even when the user does not have permission to access those items. 
+Specifies which files and folders in the new SMB share will be visible to the users. The acceptable
+values for this parameter are:
 
-The default value is Unrestricted.
+- `AccessBased`: SMB doesn't the display the files and folders for a share to a user unless that
+  user has rights to access the files and folders. By default, access-based enumeration is disabled
+  for new SMB shares.
+- `Unrestricted`: SMB displays files and folders to a user even when the user doesn't have
+  permission to access those items.
+
+The default value is **Unrestricted**.
 
 ```yaml
 Type: FolderEnumerationMode
@@ -240,6 +253,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Forces the command to run without asking for user confirmation.
 
 ```yaml
@@ -255,11 +269,12 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
+
 Specifies the input object that is used in a pipeline command.
 
 ```yaml
 Type: CimInstance[]
-Parameter Sets: InputObject (cdxml)
+Parameter Sets: InputObject
 Aliases: 
 
 Required: True
@@ -268,21 +283,25 @@ Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
+
 ### -LeasingMode
 
-Specifies SMB leasing and oplock behaviors for application compatibility. The acceptable values for this parameter are: 
+Specifies SMB leasing and oplock behaviors for application compatibility. The acceptable values for
+this parameter are:
 
-- `Full:` Use default lease and oplock behaviors from SMB3.
-- `Shared:` Grant read-caching lease but not write or handle-caching.
-- `None:` No oplocks or leases, behave like SMB1 (not recommended).
+- `Full`: Use default lease and oplock behaviors from SMB3.
+- `Shared`: Grant read-caching lease but not write or handle-caching.
+- `None`: No oplocks or leases, behave like SMB1 (not recommended).
 
 > [!IMPORTANT]
-> We do not recommend disabling oplocks, but may be required in some scenarios. For more information, see [SMB1 Product Clearinghouse](https://techcommunity.microsoft.com/t5/Storage-at-Microsoft/SMB1-Product-Clearinghouse/ba-p/426008).
+> We don't recommend disabling oplocks, but may be required in some scenarios.
+> For more information, see [SMB1 Product Clearinghouse](https://techcommunity.microsoft.com/t5/Storage-at-Microsoft/SMB1-Product-Clearinghouse/ba-p/426008).
 
 ```yaml
 Type: LeasingMode
 Parameter Sets: (All)
-Aliases: 
+Aliases:
+Accepted values: Full, Shared, None
 
 Required: False
 Position: Named
@@ -292,6 +311,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies the name of one or more SMB shares.
 
 ```yaml
@@ -307,8 +327,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+
+Returns an object representing the item with which you are working. By default, this cmdlet does
+not generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -323,7 +344,9 @@ Accept wildcard characters: False
 ```
 
 ### -ScopeName
-Specifies the scope name of the SMB share. For use with Windows Server failover cluster file server resources.
+
+Specifies the scope name of the SMB share. For use with Windows Server failover cluster file server
+resources.
 
 ```yaml
 Type: String[]
@@ -338,6 +361,7 @@ Accept wildcard characters: False
 ```
 
 ### -SecurityDescriptor
+
 Specifies the security descriptor for the SMB share in string format.
 
 ```yaml
@@ -353,8 +377,9 @@ Accept wildcard characters: False
 ```
 
 ### -SmbInstance
-Specifies the input to this cmdlet.
-You can use this parameter, or you can pipe the input to this cmdlet.
+
+Specifies the input to this cmdlet. You can use this parameter, or you can pipe the input to this
+cmdlet.
 
 ```yaml
 Type: SmbInstance
@@ -370,9 +395,12 @@ Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-If this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
-The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell® calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer. The throttle limit applies only to the current cmdlet, not to the session or to the
+computer.
 
 ```yaml
 Type: Int32
@@ -387,6 +415,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -402,8 +431,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -418,7 +447,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -427,14 +460,15 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/SMB/MSFT_SmbShare
+
 This cmdlet returns a **MSFT_SmbShare** object that represents the modified share.
 
 ## NOTES
 
 ## RELATED LINKS
 
-[Get-SmbShare](./Get-SmbShare.md)
+[Get-SmbShare](Get-SmbShare.md)
 
-[New-SmbShare](./New-SmbShare.md)
+[New-SmbShare](New-SmbShare.md)
 
-[Remove-SmbShare](./Remove-SmbShare.md)
+[Remove-SmbShare](Remove-SmbShare.md)

--- a/docset/winserver2022-ps/smbshare/Unblock-SmbClientAccessToServer.md
+++ b/docset/winserver2022-ps/smbshare/Unblock-SmbClientAccessToServer.md
@@ -1,0 +1,269 @@
+---
+description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
+external help file: SmbClientAccessToServer.cdxml-help.xml
+Module Name: SmbShare
+ms.date: 02/22/2024
+online version: https://learn.microsoft.com/powershell/module/smbshare/unblock-smbclientaccesstoserver?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Unblock-SmbClientAccessToServer
+---
+
+# Unblock-SmbClientAccessToServer
+
+## SYNOPSIS
+Unblocks SMB client access to a previously blocked server.
+
+## SYNTAX
+
+### Query
+
+```
+Unblock-SmbClientAccessToServer [-Name] <String[]> -IdentifierType <IdentifierType>
+ -Identifier <String> [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### InputObject
+
+```
+Unblock-SmbClientAccessToServer -InputObject <CimInstance[]> -IdentifierType <IdentifierType>
+ -Identifier <String> [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Unblock-SmbClientAccessToServer` cmdlet is used to allow SMB clients to access a server that
+was previously blocked using the `Block-SmbClientAccessToServer` cmdlet. When you run this cmdlet,
+any existing block on SMB client connections to the specified server will be lifted, and new
+connections will be allowed.
+
+## EXAMPLES
+
+### Example 1: Unblock SMB client access to a server
+
+```powershell
+$params = @{
+    Name = "Server01"
+    IdentifierType = "ISSUER"
+    Identifier = "CN=MyCertificateIssuer"
+    Force = $true
+}
+Unblock-SmbClientAccessToServer @params
+```
+
+This command unblocks SMB client access to a server named `Server01` for the based on the client's
+certificate. This command runs without prompting for confirmation as the **Force** parameter is set
+to `$true`.
+
+## PARAMETERS
+
+### -AsJob
+
+Runs the cmdlet as a background job. Use this parameter to run commands that take a long time to
+complete.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CimSession
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output of a [New-CimSession](/powershell/module/cimcmdlets/new-cimsession) or
+[Get-CimSession](/powershell/module/cimcmdlets/get-cimsession) cmdlet. The default is the
+current session on the local computer.
+
+```yaml
+Type: CimSession[]
+Parameter Sets: (All)
+Aliases: Session
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+
+Forces the command to run without asking for user confirmation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identifier
+
+Specifies the identity of the client that is being granted access to the SMB server. This parameter
+takes a string value that represents the identity of the client. The format of the string value
+will depend on the **IdentifierType** parameter that you're using.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IdentifierType
+
+Specifies the type of identifier that you're using to identify a client. The valid values for the
+**IdentifierType** parameter are:
+
+- SHA256
+- ISSUER
+
+If you're using the `SHA256` identifier type, you're specifying a hash value that uniquely
+identifies the client. If you're using the `ISSUER` identifier type, you're specifying the issuer
+of the client's certificate.
+
+```yaml
+Type: IdentifierType
+Parameter Sets: (All)
+Aliases:
+Accepted values: SHA256, ISSUER
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+
+Specifies the input object that's used in a pipeline command.
+
+```yaml
+Type: CimInstance[]
+Parameter Sets: InputObject
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Name
+
+Specifies a fully-qualified DNS name or NetBIOS name that must match the certificate's subject name
+or an entry in the certificate's subject alternative names.
+
+```yaml
+Type: String
+Parameter Sets: Query
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ThrottleLimit
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet. If
+this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an
+optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the
+computer.
+
+The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+
+## INPUTS
+
+### System.String[]
+
+### Microsoft.Management.Infrastructure.CimInstance[]
+
+## OUTPUTS
+
+### Microsoft.Management.Infrastructure.CimInstance[]
+
+## NOTES
+
+## RELATED LINKS
+
+[Block-SmbClientAccessToServer](Block-SmbClientAccessToServer.md)
+
+[Get-SmbClientAccessToServer](Get-SmbClientAccessToServer.md)
+
+[Grant-SmbClientAccessToServer](Grant-SmbClientAccessToServer.md)
+
+[Revoke-SmbClientAccessToServer](Revoke-SmbClientAccessToServer.md)


### PR DESCRIPTION
# PR Summary

This PR includes new SMB cmdlets for WS22:

- SmbClientAccessToServer
- SmbClientCertificateMapping

Updates to the following cmdlets:

- SmbShare
- SmbServerCertificateMapping
- Clarification for **RequireClientAuthentication** and **SkipClientCertificateAccessCheck** parameters

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide