### PR TITLE
Clarify SMB parameters RequireClientAuthentication & SkipClientCertificateAccessCheck WS25

### DIFF
--- a/docset/winserver2025-ps/smbshare/Get-SmbServerCertificateMapping.md
+++ b/docset/winserver2025-ps/smbshare/Get-SmbServerCertificateMapping.md
@@ -28,6 +28,16 @@ Get-SmbServerCertificateMapping [[-Name] <String[]>] [[-Subject] <String[]>]
 The `Get-SmbServerCertificateMapping` cmdlet retrieves the certificates associated with the SMB
 server for SMB over QUIC. For more information, see [SMB over QUIC](https://aka.ms/smboverquic).
 
+> [!NOTE]
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is set to `$false`, the server will perform both client
+> certificate validation and access control checks.
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is also set to `$true`, the server will perform client
+> certificate validation but no access control checks.
+
 ## EXAMPLES
 
 ### Example 1 - Retrieve the certificate mapped to two SMB over QUIC server names

--- a/docset/winserver2025-ps/smbshare/Get-SmbServerCertificateMapping.md
+++ b/docset/winserver2025-ps/smbshare/Get-SmbServerCertificateMapping.md
@@ -187,13 +187,15 @@ Accept wildcard characters: False
 ### -SkipClientCertificateAccessCheck
 
 Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not perform the access control
-checks based on the client certificates. This can be useful in scenarios where the server is acting
-as a gateway or proxy, and does not need to perform full certificate validation.
+connects. This parameter only applies when the server certificate mapping
+**RequireClientAuthentication** value is `$true`. When this parameter is set to `$true`, the server
+will not perform the access control checks based on the client certificates. This can be useful in
+scenarios where the server is acting as a gateway or proxy and client certificate validation is
+sufficient.
 
 However, it can also increase the risk of security breaches. When this parameter is set to
-`$false`, the server will check whether the client has access to the certificate it presents before
-allowing the client to connect.
+`$false`, the server will perform the access control checks based on the client certificates in
+addition to the client certificate validation before allowing the client to connect.
 
 ```yaml
 Type: Boolean[]

--- a/docset/winserver2025-ps/smbshare/Get-SmbServerCertificateMapping.md
+++ b/docset/winserver2025-ps/smbshare/Get-SmbServerCertificateMapping.md
@@ -187,8 +187,8 @@ Accept wildcard characters: False
 ### -SkipClientCertificateAccessCheck
 
 Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not check whether the client has
-access to the certificate it presents. This can be useful in scenarios where the server is acting
+connects. When this parameter is set to `$true`, the server will not perform the access control
+checks based on the client certificates. This can be useful in scenarios where the server is acting
 as a gateway or proxy, and does not need to perform full certificate validation.
 
 However, it can also increase the risk of security breaches. When this parameter is set to

--- a/docset/winserver2025-ps/smbshare/New-SmbServerCertificateMapping.md
+++ b/docset/winserver2025-ps/smbshare/New-SmbServerCertificateMapping.md
@@ -192,8 +192,8 @@ Accept wildcard characters: False
 ### -SkipClientCertificateAccessCheck
 
 Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not check whether the client has
-access to the certificate it presents. This can be useful in scenarios where the server is acting
+connects. When this parameter is set to `$true`, the server will not perform the access control
+checks based on the client certificates. This can be useful in scenarios where the server is acting
 as a gateway or proxy, and does not need to perform full certificate validation.
 
 However, it can also increase the risk of security breaches. When this parameter is set to

--- a/docset/winserver2025-ps/smbshare/New-SmbServerCertificateMapping.md
+++ b/docset/winserver2025-ps/smbshare/New-SmbServerCertificateMapping.md
@@ -192,13 +192,15 @@ Accept wildcard characters: False
 ### -SkipClientCertificateAccessCheck
 
 Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not perform the access control
-checks based on the client certificates. This can be useful in scenarios where the server is acting
-as a gateway or proxy, and does not need to perform full certificate validation.
+connects. This parameter only applies when the server certificate mapping
+**RequireClientAuthentication** value is `$true`. When this parameter is set to `$true`, the server
+will not perform the access control checks based on the client certificates. This can be useful in
+scenarios where the server is acting as a gateway or proxy and client certificate validation is
+sufficient.
 
 However, it can also increase the risk of security breaches. When this parameter is set to
-`$false`, the server will check whether the client has access to the certificate it presents before
-allowing the client to connect.
+`$false`, the server will perform the access control checks based on the client certificates in
+addition to the client certificate validation before allowing the client to connect.
 
 ```yaml
 Type: Boolean

--- a/docset/winserver2025-ps/smbshare/New-SmbServerCertificateMapping.md
+++ b/docset/winserver2025-ps/smbshare/New-SmbServerCertificateMapping.md
@@ -28,6 +28,16 @@ New-SmbServerCertificateMapping [-Name] <String> [-Thumbprint] <String> [-StoreN
 The `New-SmbServerCertificateMapping` cmdlet associates a certificate to the SMB server for SMB
 over QUIC. For more information, see [SMB over QUIC](https://aka.ms/smboverquic).
 
+> [!NOTE]
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is set to `$false`, the server will perform both client
+> certificate validation and access control checks.
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is also set to `$true`, the server will perform client
+> certificate validation but no access control checks.
+
 ## EXAMPLES
 
 ### Example 1 - Map a certificate located in the local machine's personal store

--- a/docset/winserver2025-ps/smbshare/Remove-SmbServerCertificateMapping.md
+++ b/docset/winserver2025-ps/smbshare/Remove-SmbServerCertificateMapping.md
@@ -252,13 +252,15 @@ Accept wildcard characters: False
 ### -SkipClientCertificateAccessCheck
 
 Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not perform the access control
-checks based on the client certificates. This can be useful in scenarios where the server is acting
-as a gateway or proxy, and does not need to perform full certificate validation.
+connects. This parameter only applies when the server certificate mapping
+**RequireClientAuthentication** value is `$true`. When this parameter is set to `$true`, the server
+will not perform the access control checks based on the client certificates. This can be useful in
+scenarios where the server is acting as a gateway or proxy and client certificate validation is
+sufficient.
 
 However, it can also increase the risk of security breaches. When this parameter is set to
-`$false`, the server will check whether the client has access to the certificate it presents before
-allowing the client to connect.
+`$false`, the server will perform the access control checks based on the client certificates in
+addition to the client certificate validation before allowing the client to connect.
 
 ```yaml
 Type: Boolean[]

--- a/docset/winserver2025-ps/smbshare/Remove-SmbServerCertificateMapping.md
+++ b/docset/winserver2025-ps/smbshare/Remove-SmbServerCertificateMapping.md
@@ -40,6 +40,16 @@ The `Remove-SmbServerCertificateMapping` cmdlet removes the certificates associa
 server for SMB over QUIC. For more information, review
 [SMB over QUIC](/windows-server/storage/file-server/smb-over-quic).
 
+> [!NOTE]
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is set to `$false`, the server will perform both client
+> certificate validation and access control checks.
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is also set to `$true`, the server will perform client
+> certificate validation but no access control checks.
+
 ## EXAMPLES
 
 ### Example 1 - Remove a certificate mapping for SMB server edge endpoint

--- a/docset/winserver2025-ps/smbshare/Remove-SmbServerCertificateMapping.md
+++ b/docset/winserver2025-ps/smbshare/Remove-SmbServerCertificateMapping.md
@@ -252,8 +252,8 @@ Accept wildcard characters: False
 ### -SkipClientCertificateAccessCheck
 
 Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not check whether the client has
-access to the certificate it presents. This can be useful in scenarios where the server is acting
+connects. When this parameter is set to `$true`, the server will not perform the access control
+checks based on the client certificates. This can be useful in scenarios where the server is acting
 as a gateway or proxy, and does not need to perform full certificate validation.
 
 However, it can also increase the risk of security breaches. When this parameter is set to

--- a/docset/winserver2025-ps/smbshare/Set-SmbServerCertificateMapping.md
+++ b/docset/winserver2025-ps/smbshare/Set-SmbServerCertificateMapping.md
@@ -197,13 +197,15 @@ Accept wildcard characters: False
 ### -SkipClientCertificateAccessCheck
 
 Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not perform the access control
-checks based on the client certificates. This can be useful in scenarios where the server is acting
-as a gateway or proxy, and does not need to perform full certificate validation.
+connects. This parameter only applies when the server certificate mapping
+**RequireClientAuthentication** value is `$true`. When this parameter is set to `$true`, the server
+will not perform the access control checks based on the client certificates. This can be useful in
+scenarios where the server is acting as a gateway or proxy and client certificate validation is
+sufficient.
 
 However, it can also increase the risk of security breaches. When this parameter is set to
-`$false`, the server will check whether the client has access to the certificate it presents before
-allowing the client to connect.
+`$false`, the server will perform the access control checks based on the client certificates in
+addition to the client certificate validation before allowing the client to connect.
 
 ```yaml
 Type: Boolean

--- a/docset/winserver2025-ps/smbshare/Set-SmbServerCertificateMapping.md
+++ b/docset/winserver2025-ps/smbshare/Set-SmbServerCertificateMapping.md
@@ -197,8 +197,8 @@ Accept wildcard characters: False
 ### -SkipClientCertificateAccessCheck
 
 Specifies whether the server should skip the check for client certificate access when a client
-connects. When this parameter is set to `$true`, the server will not check whether the client has
-access to the certificate it presents. This can be useful in scenarios where the server is acting
+connects. When this parameter is set to `$true`, the server will not perform the access control
+checks based on the client certificates. This can be useful in scenarios where the server is acting
 as a gateway or proxy, and does not need to perform full certificate validation.
 
 However, it can also increase the risk of security breaches. When this parameter is set to

--- a/docset/winserver2025-ps/smbshare/Set-SmbServerCertificateMapping.md
+++ b/docset/winserver2025-ps/smbshare/Set-SmbServerCertificateMapping.md
@@ -38,6 +38,16 @@ Set-SmbServerCertificateMapping -InputObject <CimInstance[]> [-Flags <Flags>] [-
 The `Set-SmbServerCertificateMapping` cmdlet modifies a certificate's association to the SMB server
 for SMB over QUIC. For more information, see [SMB over QUIC](https://aka.ms/smboverquic).
 
+> [!NOTE]
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is set to `$false`, the server will perform both client
+> certificate validation and access control checks.
+>
+> - If the **RequireClientAuthentication** parameter is set to `$true` and
+> **SkipClientCertificateAccessCheck** is also set to `$true`, the server will perform client
+> certificate validation but no access control checks.
+
 ## EXAMPLES
 
 ### Example 1: Enable Named Pipes for the SMB over QUIC endpoint


### PR DESCRIPTION
# PR Summary

This PR is to provide clarification for using the SMB **RequireClientAuthentication** and **SkipClientCertificateAccessCheck** parameters in WS25.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide