### PR TITLE
Add missing parameter to SmbServerConfiguration commands WS22

### DIFF
--- a/docset/winserver2022-ps/smbshare/Get-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Get-SmbServerConfiguration.md
@@ -34,14 +34,16 @@ Get-SmbServerConfiguration
 ```
 
 ```output
-AnnounceComment                        :
+AnnounceComment                        : 
 AnnounceServer                         : False
 AsynchronousCredits                    : 512
+AuditClientCertificateAccess           : False
 AuditSmb1Access                        : False
 AutoDisconnectTimeout                  : 15
 AutoShareServer                        : True
 AutoShareWorkstation                   : True
 CachedOpenLimit                        : 10
+DisableCompression                     : False
 DisableSmbEncryptionOnSecureConnection : True
 DurableHandleV2TimeoutInSeconds        : 180
 EnableAuthenticateUserSharing          : False
@@ -53,8 +55,10 @@ EnableOplocks                          : True
 EnableSecuritySignature                : False
 EnableSMB1Protocol                     : False
 EnableSMB2Protocol                     : True
+EnableSMBQUIC                          : True
 EnableStrictNameChecking               : True
 EncryptData                            : False
+EncryptionCiphers                      : AES_128_GCM, AES_128_CCM, AES_256_GCM, AES_256_CCM
 IrpStackSize                           : 15
 KeepAliveTime                          : 2
 MaxChannelPerSession                   : 32
@@ -62,12 +66,14 @@ MaxMpxCount                            : 50
 MaxSessionPerConnection                : 16384
 MaxThreadsPerQueue                     : 20
 MaxWorkItems                           : 1
-NullSessionPipes                       :
-NullSessionShares                      :
+NullSessionPipes                       : 
+NullSessionShares                      : 
 OplockBreakWait                        : 35
 PendingClientTimeoutInSeconds          : 120
 RejectUnencryptedAccess                : True
+RequestCompression                     : False
 RequireSecuritySignature               : False
+RestrictNamedpipeAccessViaQuic         : True
 ServerHidden                           : True
 Smb2CreditsMax                         : 8192
 Smb2CreditsMin                         : 512
@@ -77,9 +83,6 @@ ValidateAliasNotCircular               : True
 ValidateShareScope                     : True
 ValidateShareScopeNotAliased           : True
 ValidateTargetName                     : True
-RestrictNamedpipeAccessViaQuic         : True
-EnableSMBQUIC                          : True
-EncryptionCiphers                      : AES_128_GCM, AES_128_CCM, AES_256_GCM, AES_256_CCM
 ```
 
 This command retrieves the SMB server configuration.

--- a/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Reset-SmbServerConfiguration.md
@@ -17,15 +17,15 @@ Resets the Server Message Block (SMB) server configuration parameters to their d
 
 ```
 Reset-SmbServerConfiguration [-All] [-AnnounceComment] [-AnnounceServer] [-AsynchronousCredits]
- [-AuditSmb1Access] [-AutoShareServer] [-AutoShareWorkstation] [-CachedOpenLimit]
- [-DisableCompression] [-DisableSmbEncryptionOnSecureConnection] [-DurableHandleV2TimeoutInSeconds]
- [-EnableDownlevelTimewarp] [-EnableLeasing] [-EnableMultiChannel] [-EnableOplocks]
- [-EnableSMB2Protocol] [-EnableSMBQUIC] [-EnableStrictNameChecking] [-EncryptData]
- [-EncryptionCiphers] [-IrpStackSize] [-KeepAliveTime] [-MaxChannelPerSession] [-MaxMpxCount]
- [-MaxSessionPerConnection] [-MaxThreadsPerQueue] [-MaxWorkItems] [-NullSessionShares]
- [-OplockBreakWait] [-PendingClientTimeoutInSeconds] [-RejectUnencryptedAccess]
- [-RequestCompression] [-RestrictNamedpipeAccessViaQuic] [-ServerHidden] [-Smb2CreditsMax]
- [-Smb2CreditsMin] [-SmbServerNameHardeningLevel] [-TreatHostAsStableStorage]
+ [-AuditClientCertificateAccess] [-AuditSmb1Access] [-AutoShareServer] [-AutoShareWorkstation]
+ [-CachedOpenLimit] [-DisableCompression] [-DisableSmbEncryptionOnSecureConnection]
+ [-DurableHandleV2TimeoutInSeconds] [-EnableDownlevelTimewarp] [-EnableLeasing]
+ [-EnableMultiChannel] [-EnableOplocks] [-EnableSMB2Protocol] [-EnableSMBQUIC]
+ [-EnableStrictNameChecking] [-EncryptData] [-EncryptionCiphers] [-IrpStackSize] [-KeepAliveTime]
+ [-MaxChannelPerSession] [-MaxMpxCount] [-MaxSessionPerConnection] [-MaxThreadsPerQueue]
+ [-MaxWorkItems] [-NullSessionShares] [-OplockBreakWait] [-PendingClientTimeoutInSeconds]
+ [-RejectUnencryptedAccess] [-RequestCompression] [-RestrictNamedpipeAccessViaQuic] [-ServerHidden]
+ [-Smb2CreditsMax] [-Smb2CreditsMin] [-SmbServerNameHardeningLevel] [-TreatHostAsStableStorage]
  [-ValidateAliasNotCircular] [-ValidateShareScope] [-ValidateShareScopeNotAliased]
  [-ValidateTargetName] [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
  [-WhatIf] [-Confirm] [<CommonParameters>]
@@ -131,6 +131,25 @@ Accept wildcard characters: False
 ### -AsynchronousCredits
 
 Resets the asynchronous credits to its default value.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AuditClientCertificateAccess
+
+Resets the SMB over QUIC client access control audit events to its default value.
+
+> [!NOTE]
+> Devices running Windows 11 version 22H2 and earlier may not have access to this parameter.
 
 ```yaml
 Type: SwitchParameter

--- a/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
+++ b/docset/winserver2022-ps/smbshare/Set-SmbServerConfiguration.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: SmbServerConfiguration.cdxml-help.xml
 Module Name: SmbShare
-ms.date: 10/20/2022
+ms.date: 02/22/2024
 online version: /powershell/module/smbshare/set-smbserverconfiguration?view=windowsserver2022-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-SmbServerConfiguration
@@ -17,26 +17,26 @@ Sets the Server Message Block (SMB) server configuration.
 
 ```
 Set-SmbServerConfiguration [-AnnounceComment <String>] [-AnnounceServer <Boolean>]
- [-AsynchronousCredits <UInt32>] [-AuditSmb1Access <Boolean>] [-AutoDisconnectTimeout <UInt32>]
- [-AutoShareServer <Boolean>] [-AutoShareWorkstation <Boolean>] [-CachedOpenLimit <UInt32>]
- [-DisableCompression <Boolean>] [-DisableSmbEncryptionOnSecureConnection <Boolean>]
- [-DurableHandleV2TimeoutInSeconds <UInt32>] [-EnableAuthenticateUserSharing <Boolean>]
- [-EnableDownlevelTimewarp <Boolean>] [-EnableForcedLogoff <Boolean>] [-EnableLeasing <Boolean>]
- [-EnableMultiChannel <Boolean>] [-EnableOplocks <Boolean>] [-EnableSecuritySignature <Boolean>]
- [-EnableSMB1Protocol <Boolean>] [-EnableSMB2Protocol <Boolean>] [-EnableSMBQUIC <Boolean>]
- [-EnableStrictNameChecking <Boolean>] [-EncryptData <Boolean>] [-EncryptionCiphers <String>]
- [-IrpStackSize <UInt32>] [-KeepAliveTime <UInt32>] [-MaxChannelPerSession <UInt32>]
- [-MaxMpxCount <UInt32>] [-MaxSessionPerConnection <UInt32>] [-MaxThreadsPerQueue <UInt32>]
- [-MaxWorkItems <UInt32>] [-NullSessionPipes <String>] [-NullSessionShares <String>]
- [-OplockBreakWait <UInt32>] [-PendingClientTimeoutInSeconds <UInt32>]
- [-RejectUnencryptedAccess <Boolean>] [-RequestCompression <Boolean>]
- [-RequireSecuritySignature <Boolean>] [-RestrictNamedpipeAccessViaQuic <Boolean>]
- [-ServerHidden <Boolean>] [-Smb2CreditsMax <UInt32>] [-Smb2CreditsMin <UInt32>]
- [-SmbServerNameHardeningLevel <UInt32>] [-TreatHostAsStableStorage <Boolean>]
- [-ValidateAliasNotCircular <Boolean>] [-ValidateShareScope <Boolean>]
- [-ValidateShareScopeNotAliased <Boolean>] [-ValidateTargetName <Boolean>] [-Force]
- [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-AsynchronousCredits <UInt32>] [-AuditClientCertificateAccess <Boolean>]
+ [-AuditSmb1Access <Boolean>] [-AutoDisconnectTimeout <UInt32>] [-AutoShareServer <Boolean>]
+ [-AutoShareWorkstation <Boolean>] [-CachedOpenLimit <UInt32>] [-DisableCompression <Boolean>]
+ [-DisableSmbEncryptionOnSecureConnection <Boolean>] [-DurableHandleV2TimeoutInSeconds <UInt32>]
+ [-EnableAuthenticateUserSharing <Boolean>] [-EnableDownlevelTimewarp <Boolean>]
+ [-EnableForcedLogoff <Boolean>] [-EnableLeasing <Boolean>] [-EnableMultiChannel <Boolean>]
+ [-EnableOplocks <Boolean>] [-EnableSecuritySignature <Boolean>] [-EnableSMB1Protocol <Boolean>]
+ [-EnableSMB2Protocol <Boolean>] [-EnableSMBQUIC <Boolean>] [-EnableStrictNameChecking <Boolean>]
+ [-EncryptData <Boolean>] [-EncryptionCiphers <String>] [-IrpStackSize <UInt32>]
+ [-KeepAliveTime <UInt32>] [-MaxChannelPerSession <UInt32>] [-MaxMpxCount <UInt32>]
+ [-MaxSessionPerConnection <UInt32>] [-MaxThreadsPerQueue <UInt32>] [-MaxWorkItems <UInt32>]
+ [-NullSessionPipes <String>] [-NullSessionShares <String>] [-OplockBreakWait <UInt32>]
+ [-PendingClientTimeoutInSeconds <UInt32>] [-RejectUnencryptedAccess <Boolean>]
+ [-RequestCompression <Boolean>] [-RequireSecuritySignature <Boolean>]
+ [-RestrictNamedpipeAccessViaQuic <Boolean>] [-ServerHidden <Boolean>] [-Smb2CreditsMax <UInt32>]
+ [-Smb2CreditsMin <UInt32>] [-SmbServerNameHardeningLevel <UInt32>]
+ [-TreatHostAsStableStorage <Boolean>] [-ValidateAliasNotCircular <Boolean>]
+ [-ValidateShareScope <Boolean>] [-ValidateShareScopeNotAliased <Boolean>]
+ [-ValidateTargetName <Boolean>] [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>]
+ [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -174,6 +174,25 @@ Specifies the asynchronous credits.
 
 ```yaml
 Type: UInt32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AuditClientCertificateAccess
+
+Enables SMB over QUIC client access control audit events. There are three possible events: access
+allowed, access denied, and error. The access allowed and access denied events list properties of
+the client certificate chain and any allow and deny access control entries that apply to the
+client certificates.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 


### PR DESCRIPTION
# PR Summary

This PR updates:

- The **SmbServerConfiguration** command set to include the `-AuditClientCertificateAccess` parameter.
- **Get-** output 

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide