### PR TITLE
Search-ADAccount.md - TimeSpan parameter - Undocumented Behaviour

### DIFF
--- a/docset/winserver2019-ps/activedirectory/Search-ADAccount.md
+++ b/docset/winserver2019-ps/activedirectory/Search-ADAccount.md
@@ -543,6 +543,26 @@ For example, to search for all accounts that are expiring in 10 days, specify th
 
   `-AccountExpiring -TimeSpan "10.00:00.00"`
 
+Note that this parameter is aware of the [*ms-DS-Logon-Time-Sync-Interval*](https://learn.microsoft.com/en-us/windows/win32/adschema/a-msds-logontimesyncinterval) attribute when using with the *AccountInactive* parameter - it will try to correct for the upper range of this selection
+
+For example, with *ms-DS-Logon-Time-Sync-Interval* at the default of 14 days, we have the following situation:
+
+```
+User last logged on with timestamps:
+lastLogon          = 23/05/2024
+lastLogonTimestamp = 13/05/2024
+
+At date: 19/06/2024
+ -TimeSpan 22 = will return it:     22+14 days ago was 14/05/2024
+ -TimeSpan 23 = will not return it: 23+14 days ago was 13/05/2024
+ -TimeSpan 24 = will not return it: 24+14 days ago was 12/05/2024
+
+At date: 20/06/2024
+ -TimeSpan 22 = will return it:     22+14 days ago was 15/05/2024
+ -TimeSpan 23 = will return it:     23+14 days ago was 14/05/2024
+ -TimeSpan 24 = will not return it: 24+14 days ago was 13/05/2024
+```
+
 ```yaml
 Type: TimeSpan
 Parameter Sets: AccountExpiring, AccountInactive


### PR DESCRIPTION
Previously undocumented behaviour/interaction with *ms-DS-Logon-Time-Sync-Interval* 

Usage of *AccountInactive* & *TimeSpan* has the undocumented behaviour of incorporating the *ms-DS-Logon-Time-Sync-Interval*  attribute value interval [seen with the default 14 days]

Likely would've similar impacts on *DateTime* parameter - but didn't've opportunity to confirm

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [ ] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [ ] **Summary:** This PR's summary describes the scope and intent of the change.
- [ ] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [ ] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
