### PR TITLE
Update Set-MpPreference.md

### DIFF
--- a/docset/winserver2022-ps/defender/Set-MpPreference.md
+++ b/docset/winserver2022-ps/defender/Set-MpPreference.md
@@ -1871,7 +1871,7 @@ Accept wildcard characters: False
 
 ### -ProxyPacUrl
 
-Specifies the Privilege Attribute Certificate (PAC) proxy.
+Specifies the URL for Proxy Auto-Configuration (PAC) file.
 
 ```yaml
 Type: String


### PR DESCRIPTION
fixed obvious crap

PAC = Proxy Auto-Configuration
it can be hosted on a web server

please see https://learn.microsoft.com/en-us/defender-endpoint/configure-proxy-internet?view=o365-worldwide

# PR Summary

I fixed an obvious error in documentation - PAC is a proxy auto-config file (.pac)

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
