### PR TITLE
Update Get-MpComputerStatus.md

### DIFF
--- a/docset/winserver2025-ps/defender/Get-MpComputerStatus.md
+++ b/docset/winserver2025-ps/defender/Get-MpComputerStatus.md
@@ -32,6 +32,7 @@ computer.
 ```
 PS C:\> Get-MpComputerStatus
 AMEngineVersion                 : 1.1.9700.0
+AMRunningMode                   : True
 AMProductVersion                : 4.3.9463.0
 AMServiceEnabled                : True
 AMServiceVersion                : 4.3.9463.0


### PR DESCRIPTION
When the command Get-MpComputerStatus, you see the AMRunningMode parameter which basically shows, if the endpoint is running in active(true), passive, or EDR in Block Mode, but in this article the AMRunningMode parameter is missing from the command output

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
