### PR TITLE
Updating ms.topic values for manual reference topics

### DIFF
--- a/docset/docfx.json
+++ b/docset/docfx.json
@@ -75,7 +75,7 @@
       "ROBOTS": "INDEX, FOLLOW",
       "breadcrumb_path": "/powershell/windows/bread/toc.json",
       "ms.service": "windows-11",
-      "ms.topic": "managed-reference",
+      "ms.topic": "reference",
       "ms.author": "jgerend",
       "author": "JasonGerend",
       "manager": "femila",


### PR DESCRIPTION
# PR Summary

This pull request includes a small change to the `docset/docfx.json` file. The change updates the `ms.topic` metadata value from "managed-reference" to "reference" to better align with the content type. This is a revised definition. The 'refereence' slug is used for consistently-structured documentation of a technical artifact, like an API or SDK, that’s entirely written by people or is a combination of manual writing and autogeneration. 

Change in metadata:

* [`docset/docfx.json`](diffhunk://#diff-8ddb74b7f219f6112772160d98888eaeea235b4fbd9f5110831d35daa3f4dafeL78-R78): Updated `ms.topic` from "managed-reference" to "reference".

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
