### PR TITLE
Fix typo in Remove-NetSwitchTeamMember.md

### DIFF
--- a/docset/winserver2012-ps/netswitchteam/Remove-NetSwitchTeamMember.md
+++ b/docset/winserver2012-ps/netswitchteam/Remove-NetSwitchTeamMember.md
@@ -26,7 +26,7 @@ The member designated must exist in the specified switch team.
 
 ### EXAMPLE 1
 ```
-PS C:\>Remove-NetSwitchTeamMember -Team "MyTeam1" -Member "Ethernet 2"
+PS C:\>Remove-NetSwitchTeamMember -Team "MyTeam1" -Name "Ethernet 2"
 ```
 
 This example will remove the network adapter named Ethernet 2 from the switch team named MyTeam1.

--- a/docset/winserver2012r2-ps/netswitchteam/Remove-NetSwitchTeamMember.md
+++ b/docset/winserver2012r2-ps/netswitchteam/Remove-NetSwitchTeamMember.md
@@ -28,7 +28,7 @@ The member designated must exist in the specified switch team.
 
 ### EXAMPLE 1
 ```
-PS C:\>Remove-NetSwitchTeamMember -Team "MyTeam1" -Member "Ethernet 2"
+PS C:\>Remove-NetSwitchTeamMember -Team "MyTeam1" -Name "Ethernet 2"
 ```
 
 This example will remove the network adapter named Ethernet 2 from the switch team named MyTeam1.

--- a/docset/winserver2016-ps/netswitchteam/Remove-NetSwitchTeamMember.md
+++ b/docset/winserver2016-ps/netswitchteam/Remove-NetSwitchTeamMember.md
@@ -29,7 +29,7 @@ The member designated must exist in the specified switch team.
 
 ### Example 1: Remove a member from a team
 ```
-PS C:\>Remove-NetSwitchTeamMember -Team "SwitchTeam01" -Member "Ethernet 2"
+PS C:\>Remove-NetSwitchTeamMember -Team "SwitchTeam01" -Name "Ethernet 2"
 ```
 
 This command removes the network adapter named Ethernet 2 from the switch team named SwitchTeam01.

--- a/docset/winserver2019-ps/netswitchteam/Remove-NetSwitchTeamMember.md
+++ b/docset/winserver2019-ps/netswitchteam/Remove-NetSwitchTeamMember.md
@@ -29,7 +29,7 @@ The member designated must exist in the specified switch team.
 
 ### Example 1: Remove a member from a team
 ```
-PS C:\>Remove-NetSwitchTeamMember -Team "SwitchTeam01" -Member "Ethernet 2"
+PS C:\>Remove-NetSwitchTeamMember -Team "SwitchTeam01" -Name "Ethernet 2"
 ```
 
 This command removes the network adapter named Ethernet 2 from the switch team named SwitchTeam01.

--- a/docset/winserver2022-ps/netswitchteam/Remove-NetSwitchTeamMember.md
+++ b/docset/winserver2022-ps/netswitchteam/Remove-NetSwitchTeamMember.md
@@ -29,7 +29,7 @@ The member designated must exist in the specified switch team.
 
 ### Example 1: Remove a member from a team
 ```
-PS C:\>Remove-NetSwitchTeamMember -Team "SwitchTeam01" -Member "Ethernet 2"
+PS C:\>Remove-NetSwitchTeamMember -Team "SwitchTeam01" -Name "Ethernet 2"
 ```
 
 This command removes the network adapter named Ethernet 2 from the switch team named SwitchTeam01.

--- a/docset/winserver2025-ps/netswitchteam/Remove-NetSwitchTeamMember.md
+++ b/docset/winserver2025-ps/netswitchteam/Remove-NetSwitchTeamMember.md
@@ -29,7 +29,7 @@ The member designated must exist in the specified switch team.
 
 ### Example 1: Remove a member from a team
 ```
-PS C:\>Remove-NetSwitchTeamMember -Team "SwitchTeam01" -Member "Ethernet 2"
+PS C:\>Remove-NetSwitchTeamMember -Team "SwitchTeam01" -Name "Ethernet 2"
 ```
 
 This command removes the network adapter named Ethernet 2 from the switch team named SwitchTeam01.


### PR DESCRIPTION
# PR Summary

The argument is `Name`, not `Member`. Using the incorrect string yields an error message.

This PR corrects all of the incorrect examples in the documentation

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
