### PR TITLE
Update stale branch workflow to run on 1st of the month at 9am UTC

### DIFF
--- a/.github/workflows/StaleBranch.yml
+++ b/.github/workflows/StaleBranch.yml
@@ -5,9 +5,9 @@ permissions:
       
 on:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 1 * *"
 
-  workflow_dispatch:
+  # workflow_dispatch:
   
 
 jobs:
@@ -21,6 +21,6 @@ jobs:
                               "ExampleBranch1",
                               "ExampleBranch2"
                              ]'
-        ReportOnly: true
+        ReportOnly: false
     secrets:
         AccessToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update stale branch workflow to run on 1st of the month at 9am UTC. Disable manual trigger. Disable reporting mode.