### PR TITLE
Add missing -ProtectPrivateKey parameter to Import-PfxCertificate documentation

### DIFF
--- a/docset/winserver2016-ps/pki/Import-PfxCertificate.md
+++ b/docset/winserver2016-ps/pki/Import-PfxCertificate.md
@@ -16,8 +16,9 @@ Imports certificates and private keys from a Personal Information Exchange (PFX)
 ## SYNTAX
 
 ```
-Import-PfxCertificate [-Exportable] [-Password <SecureString>] [[-CertStoreLocation] <String>]
- [-FilePath] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Import-PfxCertificate [-Exportable] [-ProtectPrivateKey <ProtectPrivateKeyType>] [-Password <SecureString>]
+ [[-CertStoreLocation] <String>] [-FilePath] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -55,6 +56,15 @@ PS Cert:\localMachine\my>Import-PfxCertificate -FilePath c:\mypfx.pfx
 This example imports the PFX file mypfx.pfx into the My store for the machine account.
 The **Password** parameter is not required since this PFX file is protected using the domain account of this machine.
 This requires a Windows Server® 2012 domain controller.
+
+### EXAMPLE 4
+```
+PS C:\>Get-ChildItem -Path c:\mypfx\my.pfx | Import-PfxCertificate -CertStoreLocation Cert:\CurrentUser\My -ProtectPrivateKey vsm 
+```
+
+This example imports the PFX file `my.pfx` with a private key into the My store for the current user.
+The **Password** parameter is not required since this PFX file is not password protected.
+The private key will be protected by virtualized-based security (VBS) and cannot be exported.
 
 ## PARAMETERS
 
@@ -97,6 +107,24 @@ If this parameter is not specified, then the private key cannot be exported.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProtectPrivateKey
+Specifies whether to protect the imported private key by virtualized-based security.
+If this parameter is specified with the value `vsm`, then the private key cannot be exported.
+Virtual Secure Mode (VSM) capabilities were introduced in Windows 10 and Windows Server 2016.
+
+```yaml
+Type: Microsoft.CertificateServices.Commands.ProtectPrivateKeyType
+Parameter Sets: (All)
+Aliases: 
+Accepted values: none, vsm
 
 Required: False
 Position: Named
@@ -177,3 +205,5 @@ The imported **X509Certificate2** object contained in the PFX file that is assoc
 [Export-PfxCertificate](./Export-PfxCertificate.md)
 
 [System Store Locations](/windows/desktop/seccrypto/system-store-locations)
+
+[Virtualization-based Security](https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-vbs)

--- a/docset/winserver2019-ps/pki/Import-PfxCertificate.md
+++ b/docset/winserver2019-ps/pki/Import-PfxCertificate.md
@@ -16,8 +16,9 @@ Imports certificates and private keys from a Personal Information Exchange (PFX)
 ## SYNTAX
 
 ```
-Import-PfxCertificate [-Exportable] [-Password <SecureString>] [[-CertStoreLocation] <String>]
- [-FilePath] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Import-PfxCertificate [-Exportable] [-ProtectPrivateKey <ProtectPrivateKeyType>] [-Password <SecureString>] 
+ [[-CertStoreLocation] <String>] [-FilePath] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -55,6 +56,15 @@ PS Cert:\localMachine\my>Import-PfxCertificate -FilePath c:\mypfx.pfx
 This example imports the PFX file mypfx.pfx into the My store for the machine account.
 The **Password** parameter is not required since this PFX file is protected using the domain account of this machine.
 This requires a Windows Server® 2012 domain controller.
+
+### EXAMPLE 4
+```
+PS C:\>Get-ChildItem -Path c:\mypfx\my.pfx | Import-PfxCertificate -CertStoreLocation Cert:\CurrentUser\My -ProtectPrivateKey vsm 
+```
+
+This example imports the PFX file `my.pfx` with a private key into the My store for the current user.
+The **Password** parameter is not required since this PFX file is not password protected.
+The private key will be protected by virtualized-based security (VBS) and cannot be exported.
 
 ## PARAMETERS
 
@@ -97,6 +107,24 @@ If this parameter is not specified, then the private key cannot be exported.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProtectPrivateKey
+Specifies whether to protect the imported private key by virtualized-based security.
+If this parameter is specified with the value `vsm`, then the private key cannot be exported.
+Virtual Secure Mode (VSM) capabilities were introduced in Windows 10 and Windows Server 2016.
+
+```yaml
+Type: Microsoft.CertificateServices.Commands.ProtectPrivateKeyType
+Parameter Sets: (All)
+Aliases: 
+Accepted values: none, vsm
 
 Required: False
 Position: Named
@@ -177,3 +205,5 @@ The imported **X509Certificate2** object contained in the PFX file that is assoc
 [Export-PfxCertificate](./Export-PfxCertificate.md)
 
 [System Store Locations](/windows/desktop/seccrypto/system-store-locations)
+
+[Virtualization-based Security](https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-vbs)

--- a/docset/winserver2022-ps/pki/Import-PfxCertificate.md
+++ b/docset/winserver2022-ps/pki/Import-PfxCertificate.md
@@ -17,9 +17,9 @@ destination store.
 ## SYNTAX
 
 ```
-Import-PfxCertificate [-Exportable] [-Password <SecureString>]
- [[-CertStoreLocation] <String>] [-FilePath] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Import-PfxCertificate [-Exportable] [-ProtectPrivateKey <ProtectPrivateKeyType>] [-Password <SecureString>]
+ [[-CertStoreLocation] <String>] [-FilePath] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -72,6 +72,17 @@ This example imports the PFX file `mypfx.pfx` into the My store for the machine 
 **Password** parameter is not required since this PFX file is protected using the domain account of
 this machine. This requires a Windows Server 2012 or later domain controller.
 
+### EXAMPLE 4
+
+```powershell
+Get-ChildItem -Path C:\mypfx.pfx |
+    Import-PfxCertificate -CertStoreLocation Cert:\CurrentUser\My -ProtectPrivateKey vsm
+```
+
+This example imports the PFX file `mypfx.pfx` with a private key into the My store for the current user.
+The **Password** parameter is not required since this PFX file is not password protected.
+The private key will be protected by virtualized-based security (VBS) and cannot be exported.
+
 ## PARAMETERS
 
 ### -CertStoreLocation
@@ -116,6 +127,25 @@ the private key cannot be exported.
 Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProtectPrivateKey
+
+Specifies whether to protect the imported private key by virtualized-based security.
+If this parameter is specified with the value `vsm`, then the private key cannot be exported.
+Virtual Secure Mode (VSM) capabilities were introduced in Windows 10 and Windows Server 2016.
+
+```yaml
+Type: Microsoft.CertificateServices.Commands.ProtectPrivateKeyType
+Parameter Sets: (All)
+Aliases: 
+Accepted values: none, vsm
 
 Required: False
 Position: Named
@@ -206,3 +236,5 @@ keys.
 [Export-PfxCertificate](./Export-PfxCertificate.md)
 
 [System Store Locations](/windows/desktop/seccrypto/system-store-locations)
+
+[Virtualization-based Security](https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-vbs)

--- a/docset/winserver2025-ps/pki/Import-PfxCertificate.md
+++ b/docset/winserver2025-ps/pki/Import-PfxCertificate.md
@@ -17,9 +17,9 @@ destination store.
 ## SYNTAX
 
 ```
-Import-PfxCertificate [-Exportable] [-Password <SecureString>]
- [[-CertStoreLocation] <String>] [-FilePath] <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Import-PfxCertificate [-Exportable] [-ProtectPrivateKey <ProtectPrivateKeyType>] [-Password <SecureString>]
+ [[-CertStoreLocation] <String>] [-FilePath] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -72,6 +72,17 @@ This example imports the PFX file `mypfx.pfx` into the My store for the machine 
 **Password** parameter is not required since this PFX file is protected using the domain account of
 this machine. This requires a Windows Server 2012 or later domain controller.
 
+### EXAMPLE 4
+
+```powershell
+Get-ChildItem -Path C:\mypfx.pfx |
+    Import-PfxCertificate -CertStoreLocation Cert:\CurrentUser\My -ProtectPrivateKey vsm
+```
+
+This example imports the PFX file `mypfx.pfx` with a private key into the My store for the current user.
+The **Password** parameter is not required since this PFX file is not password protected.
+The private key will be protected by virtualized-based security (VBS) and cannot be exported.
+
 ## PARAMETERS
 
 ### -CertStoreLocation
@@ -116,6 +127,25 @@ the private key cannot be exported.
 Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProtectPrivateKey
+
+Specifies whether to protect the imported private key by virtualized-based security.
+If this parameter is specified with the value `vsm`, then the private key cannot be exported.
+Virtual Secure Mode (VSM) capabilities were introduced in Windows 10 and Windows Server 2016.
+
+```yaml
+Type: Microsoft.CertificateServices.Commands.ProtectPrivateKeyType
+Parameter Sets: (All)
+Aliases: 
+Accepted values: none, vsm
 
 Required: False
 Position: Named
@@ -206,3 +236,5 @@ keys.
 [Export-PfxCertificate](./Export-PfxCertificate.md)
 
 [System Store Locations](/windows/desktop/seccrypto/system-store-locations)
+
+[Virtualization-based Security](https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-vbs)


### PR DESCRIPTION
# PR Summary

Add missing `-ProtectPrivateKey` parameter to the Import-PfxCertificate cmdlet documentation.
Parameter functionality is synonymous with the import option "Protect private key using virtualized-based security(Non-exportable)" in the Certificate Import Wizard:
![image](https://github.com/user-attachments/assets/2e8f6465-57e9-4728-891a-0dc8d180d14c)

Functionality of the option is explained by [Crypt32 (Vadims Podans)](https://github.com/Crypt32), creator of PSPKI:
https://security.stackexchange.com/a/186523/268642

Explanation for enum option `vsm` is hinted in the documentation for [Virtualization-based Security (VBS)](https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-vbs).

[Virtual Secure Mode (VSM)](https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/vsm) capabilities were introduced in Windows 10 and Windows Server 2016, that is why the update only ranges until there.

- Resolves #3263 

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
