### PR TITLE
Fix #3982: Correct "maximum"->"minimum" for Smb2DialectMin parameter in Set-SmbServerConfiguration help text

### DIFF
--- a/docset/winserver2025-ps/smbshare/Set-SmbServerConfiguration.md
+++ b/docset/winserver2025-ps/smbshare/Set-SmbServerConfiguration.md
@@ -1017,12 +1017,12 @@ Accept wildcard characters: False
 
 This parameter specifies the minimum version of the SMB protocol to be used. Acceptable values are:
 
-- None – There is no maximum protocol version specified, the server can use any supported version.
-- SMB202 – SMB 2.0.2 is the maximum version accepted by the SMB Server
-- SMB210 - SMB 2.1.0 is the maximum version accepted by the SMB Server
-- SMB300 - SMB 3.0.0 is the maximum version accepted by the SMB Server
-- SMB302 - SMB 3.0.2 is the maximum version accepted by the SMB Server
-- SMB311 - SMB 3.1.1 is the maximum version accepted by the SMB Server
+- None – There is no minimum protocol version specified, the server can use any supported version.
+- SMB202 – SMB 2.0.2 is the minimum version accepted by the SMB Server
+- SMB210 - SMB 2.1.0 is the minimum version accepted by the SMB Server
+- SMB300 - SMB 3.0.0 is the minimum version accepted by the SMB Server
+- SMB302 - SMB 3.0.2 is the minimum version accepted by the SMB Server
+- SMB311 - SMB 3.1.1 is the minimum version accepted by the SMB Server
 
 ```yaml
 Type: Smb2DialectMin


### PR DESCRIPTION
# PR Summary
The help text for the `Smb2DialectMin` parameter for `Set-SmbServerConfiguration` of the `smbshare` module uses the word "maximum" when it should use the word "minimum" when describing the values.

This just fixes that.

 - Fixes #3982 

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].
