### PR TITLE
Fixed a typo in Format-SecureBootUEFI.md

### DIFF
--- a/docset/winserver2025-ps/SecureBoot/Format-SecureBootUEFI.md
+++ b/docset/winserver2025-ps/SecureBoot/Format-SecureBootUEFI.md
@@ -62,7 +62,7 @@ AppendWrite : True
 Content     : {18, 165, 108, 130...}
 ```
 
-This command formats the hash to beg appended to the DBX UEFI variable when the result is piped to the Set-SecureBootUEFI cmdlet.
+This command formats the hash to be appended to the DBX UEFI variable when the result is piped to the Set-SecureBootUEFI cmdlet.
 
 ### Example 3: Format for a variable to be deleted
 ```


### PR DESCRIPTION
# PR Summary
This corrects a typo by removing a spurious letter `g`.

## PR Checklist
- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].
