### PR TITLE
Remove unnecessary content

### DIFF
--- a/docset/winserver2022-ps/ActiveDirectory/New-ADUser.md
+++ b/docset/winserver2022-ps/ActiveDirectory/New-ADUser.md
@@ -1202,8 +1202,7 @@ operating systems, create a SAM account name that is 20 characters or less. This
 property is `sAMAccountName`.
 
 > [!NOTE]
-> Information the user should notice even if skimmingIf the string value provided is not terminated
-> with a `$` character, the system adds one if needed.
+> If the string value provided is not terminated with a `$` character, the system adds one if needed.
 
 ```yaml
 Type: System.String

--- a/docset/winserver2025-ps/ActiveDirectory/New-ADUser.md
+++ b/docset/winserver2025-ps/ActiveDirectory/New-ADUser.md
@@ -1202,8 +1202,7 @@ operating systems, create a SAM account name that is 20 characters or less. This
 property is `sAMAccountName`.
 
 > [!NOTE]
-> Information the user should notice even if skimmingIf the string value provided is not terminated
-> with a `$` character, the system adds one if needed.
+> If the string value provided is not terminated with a `$` character, the system adds one if needed.
 
 ```yaml
 Type: System.String


### PR DESCRIPTION
# PR Summary

Remove "Information the user should notice even if skimming" from the beginning of a note on the `-SamAccountName` parameter of the `New-ADUser` cmdlet for both the Windows Server 2022 and 2025 PowerShell docs. This change removes content which was likely part of a template and never fully replaced. Its goal is to make the docs more succinct and accurate.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide