### PR TITLE
Update Move-ADObject.md

### DIFF
--- a/docset/winserver2025-ps/ActiveDirectory/Move-ADObject.md
+++ b/docset/winserver2025-ps/ActiveDirectory/Move-ADObject.md
@@ -284,7 +284,7 @@ Accept wildcard characters: False
 ### -TargetServer
 Specifies the Active Directory instance to use by providing the following value for a corresponding domain name or directory server.
 
-Note: A cross-domain move requires a fully qualified server name and the use of the RID Master in both domains.
+Note: A cross-domain move requires a fully qualified server name and the use of the RID Master in both source and target domains. When the Administrator account used for the task cannot be delegated, you have to run the cmdlet on the Rid Master of the source domain. When you do this, delegation is not required.
 
 Domain name values:
 


### PR DESCRIPTION
adding hint to run cmdlet on RID Master of source domain to avoid delegation

# PR Summary

Found cmdlet breaks with error when account can't be delegated. This happens as source domain Rid Master calls out to Target Domain Rid Master for the move.

## PR Checklist

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
