### PR TITLE
Update Set-MpPreference documentation

### DIFF
--- a/docset/winserver2025-ps/Defender/Set-MpPreference.md
+++ b/docset/winserver2025-ps/Defender/Set-MpPreference.md
@@ -72,6 +72,9 @@ Set-MpPreference [-ExclusionPath <String[]>] [-ExclusionExtension <String[]>] [-
 The **Set-MpPreference** cmdlet configures preferences for Windows Defender scans and updates.
 You can modify exclusion file name extensions, paths, or processes, and specify the default action for high, moderate, and low threat levels.
 
+>[!NOTE]
+>To undo an override set using `Set-MpPreference`, use the [`Remove-MpPreference`](./Remove-MpPreference.md) command to ensure that default or server-controlled values are subsequently respected.
+
 **REMEDIATION VALUES**
 
 The following table provides remediation action values for detected threats at low, medium, high, and severe alert levels.


### PR DESCRIPTION
# PR Summary
Added note about using Remove-MpPreference to undo overrides. Customers previously ended up "stuck" in a forced-config state when trying to undo their manual changes.
