### PR TITLE
Enable auto reviewer assignment

### DIFF
--- a/.github/workflows/AutoLabelAssign.yml
+++ b/.github/workflows/AutoLabelAssign.yml
@@ -30,8 +30,11 @@ jobs:
         with:
             PayloadJson: ${{ needs.download-payload.outputs.WorkflowPayload }}
             AutoAssignUsers: 1
+            AutoAssignReviewers: 1
             AutoLabel: 1
             ExcludedUserList: '["user1", "user2"]'
             ExcludedBranchList: '["branch1", "branch2"]'
         secrets:
             AccessToken: ${{ secrets.GITHUB_TOKEN }}
+            PrivateKey: ${{ secrets.M365_APP_PRIVATE_KEY }}
+            ClientId: ${{ secrets.M365_APP_CLIENT_ID }}

--- a/.github/workflows/BackgroundTasks.yml
+++ b/.github/workflows/BackgroundTasks.yml
@@ -6,6 +6,7 @@ permissions:
   
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   upload:


### PR DESCRIPTION
Add client id and private key variables to AutoLabelAssignment.yml. Explicitly define action call types and add ready_for_review type.