### PR TITLE
Fix Typo in Example 1 - Update Set-CIPolicySetting.md

### DIFF
--- a/docset/winserver2025-ps/ConfigCI/Set-CIPolicySetting.md
+++ b/docset/winserver2025-ps/ConfigCI/Set-CIPolicySetting.md
@@ -36,7 +36,7 @@ Secure Settings are queried by Windows APIs to set security behaviors.
 
 ### Example 1: Set the Code Integrity policy
 ```powershell
-Set-CIPolicySetting -FilePath C:\Policies\WDAC_policy.xml -Key "{12345678-9abc-def0-1234-56789abcdef0}" -Provider WSH -Value $True -ValueName EnterpriseDefinedClsId -ValueType Boolean
+Set-CIPolicySetting -FilePath C:\Policies\WDAC_policy.xml -Key "{12345678-9abc-def0-1234-56789abcdef0}" -Provider WSH -Value true -ValueName EnterpriseDefinedClsId -ValueType Boolean
 ```
 
 This command sets the Code Integrity policy to allow for the specified **Provider**, **Key** and **ValueName**.


### PR DESCRIPTION
# PR Summary

Fix typo in example 1.

The reason is that supplying "$True" actually results in a typo in the XML file where "True" is capitalized -- this doesn't fit the XML specifications of code integrity policies, and actually leads to an error. (See https://github.com/PowerShell/PowerShell/issues/21286 for a discussion on this particular bug).

This change makes example 1 conform to other Microsoft documentation which uses a **correct** example of this cmdlet, see:  https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/design/allow-com-object-registration-in-appcontrol-policy

## PR Checklist

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].
