### PR TITLE
Improves description of DisplayGroup & Group parameters of *-NetFirewallRule cmdlets

### DIFF
--- a/docset/winserver2016-ps/NetSecurity/Copy-NetFirewallRule.md
+++ b/docset/winserver2016-ps/NetSecurity/Copy-NetFirewallRule.md
@@ -431,24 +431,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are copied.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string. 
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -547,13 +542,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are copied.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -564,7 +555,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2016-ps/NetSecurity/Disable-NetFirewallRule.md
+++ b/docset/winserver2016-ps/NetSecurity/Disable-NetFirewallRule.md
@@ -140,7 +140,7 @@ PS C:\>Disable-NetFirewallRule -Group "@FirewallAPI.dll,-28502"
 ```
 
 This example disables all of the File and Printer Sharing rules on the local computer.
-Use the universal and world-ready indirect string @FirewallAPI to specify the group.
+"@FirewallAPI.dll,-28502" is an indirect string that specifies a "File and Printer Sharing" group.
 
 ### EXAMPLE 3
 ```
@@ -427,24 +427,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are disabled.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -539,13 +534,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are disabled.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -556,7 +547,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2016-ps/NetSecurity/Enable-NetFirewallRule.md
+++ b/docset/winserver2016-ps/NetSecurity/Enable-NetFirewallRule.md
@@ -126,7 +126,7 @@ PS C:\>Enable-NetFirewallRule -Group "@FirewallAPI.dll,-28502"
 ```
 
 This example enables all of the File and Printer Sharing rules.
-Use the universal and world-ready indirect string @FirewallAPI to specify the group.
+"@FirewallAPI.dll,-28502" is an indirect string that specifies a "File and Printer Sharing" group.
 
 ### EXAMPLE 2
 ```
@@ -424,24 +424,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are enabled.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -540,13 +535,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are enabled.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -557,7 +548,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2016-ps/NetSecurity/Get-NetFirewallRule.md
+++ b/docset/winserver2016-ps/NetSecurity/Get-NetFirewallRule.md
@@ -393,13 +393,8 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are retrieved.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
@@ -410,7 +405,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -509,13 +504,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are retrieved.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -526,7 +517,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -LocalOnlyMapping

--- a/docset/winserver2016-ps/NetSecurity/New-NetFirewallRule.md
+++ b/docset/winserver2016-ps/NetSecurity/New-NetFirewallRule.md
@@ -379,14 +379,12 @@ Accept wildcard characters: False
 ```
 
 ### -Group
-Specifies that only matching firewall rules of the indicated group association are copied.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+Specifies a group for the rule. Rule groups can be used to organize rules and allows easy batch modifications. 
+It is a good practice to use an indirect string here, pointing to a localized string in a DLL (for example, `@FirewallAPI.dll,-34002`).
+The value of this property influences the value of the read-only **DisplayGroup** property:
+
+- When a rule's **Group** property contains an indirect string, the **DisplayGroup** property contains the string located at the specified index.
+- When a rule's **Group** property contains a regular string, the **DisplayGroup** property just returns that string.
 
 ```yaml
 Type: String

--- a/docset/winserver2016-ps/NetSecurity/Remove-NetFirewallRule.md
+++ b/docset/winserver2016-ps/NetSecurity/Remove-NetFirewallRule.md
@@ -421,24 +421,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are removed.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -537,13 +532,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are removed.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -554,7 +545,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2016-ps/NetSecurity/Rename-NetFirewallRule.md
+++ b/docset/winserver2016-ps/NetSecurity/Rename-NetFirewallRule.md
@@ -404,24 +404,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are renamed.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -520,13 +515,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are renamed.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -537,7 +528,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2016-ps/NetSecurity/Set-NetFirewallRule.md
+++ b/docset/winserver2016-ps/NetSecurity/Set-NetFirewallRule.md
@@ -122,6 +122,13 @@ PS C:\>Set-NetFirewallRule -DisplayName "AllowMessenger" -Authentication Require
 This example changes a rule to require authentication and scopes the rule to apply on the domain profile.
 A separate IPsec rule must exist to perform the authentication.
 
+### EXAMPLE 4
+```
+PS C:\>Get-NetFirewallRule -DisplayName "Microsoft Lync" | %{$_.Group = "Office"; Set-NetFirewallRule -InputObject $_}
+```
+
+This example changes the **Group** and **DisplayGroup** properties of a rule. The **DisplayGroup** property changes automatically and reflects changes introduced to the **Group** property.
+
 ## PARAMETERS
 
 ### -Action
@@ -266,13 +273,9 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are modified.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
+**DisplayGroup** is a read-only property that can be modified only by modifying the **Group** property.
 
 ```yaml
 Type: String[]
@@ -283,7 +286,7 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -436,13 +439,12 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are modified.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the *DisplayGroup* parameter to filter by group display names.
+
+> [!NOTE]
+> You cannot modify the **Group** property through this parameter. See Example 4, which demonstrates how to modify a rule's **Group** property.
 
 ```yaml
 Type: String[]
@@ -453,7 +455,7 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -IcmpType

--- a/docset/winserver2019-ps/NetSecurity/Copy-NetFirewallRule.md
+++ b/docset/winserver2019-ps/NetSecurity/Copy-NetFirewallRule.md
@@ -431,24 +431,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are copied.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string. 
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -547,13 +542,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are copied.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -564,7 +555,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2019-ps/NetSecurity/Disable-NetFirewallRule.md
+++ b/docset/winserver2019-ps/NetSecurity/Disable-NetFirewallRule.md
@@ -140,7 +140,7 @@ PS C:\>Disable-NetFirewallRule -Group "@FirewallAPI.dll,-28502"
 ```
 
 This example disables all of the File and Printer Sharing rules on the local computer.
-Use the universal and world-ready indirect string @FirewallAPI to specify the group.
+"@FirewallAPI.dll,-28502" is an indirect string that specifies a "File and Printer Sharing" group.
 
 ### EXAMPLE 3
 ```
@@ -427,24 +427,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are disabled.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -539,13 +534,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are disabled.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -556,7 +547,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2019-ps/NetSecurity/Enable-NetFirewallRule.md
+++ b/docset/winserver2019-ps/NetSecurity/Enable-NetFirewallRule.md
@@ -126,7 +126,7 @@ PS C:\>Enable-NetFirewallRule -Group "@FirewallAPI.dll,-28502"
 ```
 
 This example enables all of the File and Printer Sharing rules.
-Use the universal and world-ready indirect string @FirewallAPI to specify the group.
+"@FirewallAPI.dll,-28502" is an indirect string that specifies a "File and Printer Sharing" group.
 
 ### EXAMPLE 2
 ```
@@ -424,24 +424,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are enabled.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -540,13 +535,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are enabled.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -557,7 +548,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2019-ps/NetSecurity/Get-NetFirewallRule.md
+++ b/docset/winserver2019-ps/NetSecurity/Get-NetFirewallRule.md
@@ -393,13 +393,8 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are retrieved.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
@@ -410,7 +405,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -509,13 +504,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are retrieved.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -526,7 +517,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -LocalOnlyMapping

--- a/docset/winserver2019-ps/NetSecurity/New-NetFirewallRule.md
+++ b/docset/winserver2019-ps/NetSecurity/New-NetFirewallRule.md
@@ -379,14 +379,12 @@ Accept wildcard characters: False
 ```
 
 ### -Group
-Specifies that only matching firewall rules of the indicated group association are copied.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+Specifies a group for the rule. Rule groups can be used to organize rules and allows easy batch modifications. 
+It is a good practice to use an indirect string here, pointing to a localized string in a DLL (for example, `@FirewallAPI.dll,-34002`).
+The value of this property influences the value of the read-only **DisplayGroup** property:
+
+- When a rule's **Group** property contains an indirect string, the **DisplayGroup** property contains the string located at the specified index.
+- When a rule's **Group** property contains a regular string, the **DisplayGroup** property just returns that string.
 
 ```yaml
 Type: String

--- a/docset/winserver2019-ps/NetSecurity/Remove-NetFirewallRule.md
+++ b/docset/winserver2019-ps/NetSecurity/Remove-NetFirewallRule.md
@@ -421,24 +421,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are removed.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -537,13 +532,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are removed.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -554,7 +545,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2019-ps/NetSecurity/Rename-NetFirewallRule.md
+++ b/docset/winserver2019-ps/NetSecurity/Rename-NetFirewallRule.md
@@ -404,24 +404,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are renamed.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -520,13 +515,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are renamed.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -537,7 +528,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2019-ps/NetSecurity/Set-NetFirewallRule.md
+++ b/docset/winserver2019-ps/NetSecurity/Set-NetFirewallRule.md
@@ -122,6 +122,13 @@ PS C:\>Set-NetFirewallRule -DisplayName "AllowMessenger" -Authentication Require
 This example changes a rule to require authentication and scopes the rule to apply on the domain profile.
 A separate IPsec rule must exist to perform the authentication.
 
+### EXAMPLE 4
+```
+PS C:\>Get-NetFirewallRule -DisplayName "Microsoft Lync" | %{$_.Group = "Office"; Set-NetFirewallRule -InputObject $_}
+```
+
+This example changes the **Group** and **DisplayGroup** properties of a rule. The **DisplayGroup** property changes automatically and reflects changes introduced to the **Group** property.
+
 ## PARAMETERS
 
 ### -Action
@@ -266,13 +273,9 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are modified.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
+**DisplayGroup** is a read-only property that can be modified only by modifying the **Group** property.
 
 ```yaml
 Type: String[]
@@ -283,7 +286,7 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -436,13 +439,12 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are modified.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
+
+> [!NOTE]
+> You cannot modify the **Group** property through this parameter. See Example 4, which demonstrates how to modify a rule's **Group** property.
 
 ```yaml
 Type: String[]
@@ -453,7 +455,7 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -IcmpType

--- a/docset/winserver2022-ps/NetSecurity/Copy-NetFirewallRule.md
+++ b/docset/winserver2022-ps/NetSecurity/Copy-NetFirewallRule.md
@@ -428,24 +428,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are copied.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string. 
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -522,13 +517,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are copied.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -539,7 +530,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2022-ps/NetSecurity/Disable-NetFirewallRule.md
+++ b/docset/winserver2022-ps/NetSecurity/Disable-NetFirewallRule.md
@@ -139,7 +139,7 @@ PS C:\>Disable-NetFirewallRule -Group "@FirewallAPI.dll,-28502"
 ```
 
 This example disables all of the File and Printer Sharing rules on the local computer.
-Use the universal and world-ready indirect string @FirewallAPI to specify the group.
+"@FirewallAPI.dll,-28502" is an indirect string that specifies a "File and Printer Sharing" group.
 
 ### EXAMPLE 3
 ```
@@ -426,24 +426,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are disabled.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the *Group* property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -516,13 +511,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are disabled.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -533,7 +524,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2022-ps/NetSecurity/Enable-NetFirewallRule.md
+++ b/docset/winserver2022-ps/NetSecurity/Enable-NetFirewallRule.md
@@ -125,7 +125,7 @@ PS C:\>Enable-NetFirewallRule -Group "@FirewallAPI.dll,-28502"
 ```
 
 This example enables all of the File and Printer Sharing rules.
-Use the universal and world-ready indirect string @FirewallAPI to specify the group.
+"@FirewallAPI.dll,-28502" is an indirect string that specifies a "File and Printer Sharing" group.
 
 ### EXAMPLE 2
 ```
@@ -423,24 +423,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are enabled.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup*.*
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -517,13 +512,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are enabled.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -534,7 +525,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2022-ps/NetSecurity/Get-NetFirewallRule.md
+++ b/docset/winserver2022-ps/NetSecurity/Get-NetFirewallRule.md
@@ -386,13 +386,8 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are retrieved.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
@@ -403,7 +398,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -480,13 +475,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are retrieved.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -497,7 +488,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -LocalOnlyMapping

--- a/docset/winserver2022-ps/NetSecurity/New-NetFirewallRule.md
+++ b/docset/winserver2022-ps/NetSecurity/New-NetFirewallRule.md
@@ -379,14 +379,12 @@ Accept wildcard characters: False
 ```
 
 ### -Group
-Specifies that only matching firewall rules of the indicated group association are copied.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+Specifies a group for the rule. Rule groups can be used to organize rules and allows easy batch modifications. 
+It is a good practice to use an indirect string here, pointing to a localized string in a DLL (for example, `@FirewallAPI.dll,-34002`).
+The value of this property influences the value of the read-only **DisplayGroup** property:
+
+- When a rule's **Group** property contains an indirect string, the **DisplayGroup** property contains the string located at the specified index.
+- When a rule's **Group** property contains a regular string, the **DisplayGroup** property just returns that string.
 
 ```yaml
 Type: String

--- a/docset/winserver2022-ps/NetSecurity/Remove-NetFirewallRule.md
+++ b/docset/winserver2022-ps/NetSecurity/Remove-NetFirewallRule.md
@@ -420,24 +420,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are removed.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -514,13 +509,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are removed.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -531,7 +522,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2022-ps/NetSecurity/Rename-NetFirewallRule.md
+++ b/docset/winserver2022-ps/NetSecurity/Rename-NetFirewallRule.md
@@ -404,24 +404,19 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are renamed.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByQuery
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -498,13 +493,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are renamed.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -515,7 +506,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2022-ps/NetSecurity/Set-NetFirewallRule.md
+++ b/docset/winserver2022-ps/NetSecurity/Set-NetFirewallRule.md
@@ -126,6 +126,13 @@ PS C:\>Set-NetFirewallRule -DisplayName "AllowMessenger" -Authentication Require
 This example changes a rule to require authentication and scopes the rule to apply on the domain profile.
 A separate IPsec rule must exist to perform the authentication.
 
+### EXAMPLE 4
+```
+PS C:\>Get-NetFirewallRule -DisplayName "Microsoft Lync" | %{$_.Group = "Office"; Set-NetFirewallRule -InputObject $_}
+```
+
+This example changes the **Group** and **DisplayGroup** properties of a rule. The **DisplayGroup** property changes automatically and reflects changes introduced to the **Group** property.
+
 ## PARAMETERS
 
 ### -Action
@@ -270,13 +277,9 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are modified.
-Wildcard characters are accepted. 
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name. 
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
+**DisplayGroup** is a read-only property that can be modified only by modifying the **Group** property.
 
 ```yaml
 Type: String[]
@@ -287,7 +290,7 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -418,13 +421,12 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are modified.
-Wildcard characters are accepted. 
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name. 
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
+
+> [!NOTE]
+> You cannot modify the **Group** property through this parameter. See Example 4, which demonstrates how to modify a rule's **Group** property.
 
 ```yaml
 Type: String[]
@@ -435,7 +437,7 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -IcmpType

--- a/docset/winserver2025-ps/NetSecurity/Copy-NetFirewallRule.md
+++ b/docset/winserver2025-ps/NetSecurity/Copy-NetFirewallRule.md
@@ -428,13 +428,8 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are copied.
-Wildcard characters are accepted.
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name.
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
@@ -445,7 +440,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -522,13 +517,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are copied.
-Wildcard characters are accepted.
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name.
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -539,7 +530,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2025-ps/NetSecurity/Disable-NetFirewallRule.md
+++ b/docset/winserver2025-ps/NetSecurity/Disable-NetFirewallRule.md
@@ -139,7 +139,7 @@ PS C:\>Disable-NetFirewallRule -Group "@FirewallAPI.dll,-28502"
 ```
 
 This example disables all of the File and Printer Sharing rules on the local computer.
-Use the universal and world-ready indirect string @FirewallAPI to specify the group.
+"@FirewallAPI.dll,-28502" is an indirect string that specifies a "File and Printer Sharing" group.
 
 ### EXAMPLE 3
 ```
@@ -426,13 +426,8 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are disabled.
-Wildcard characters are accepted.
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name.
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
@@ -443,7 +438,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -516,13 +511,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are disabled.
-Wildcard characters are accepted.
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name.
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -533,7 +524,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2025-ps/NetSecurity/Enable-NetFirewallRule.md
+++ b/docset/winserver2025-ps/NetSecurity/Enable-NetFirewallRule.md
@@ -125,7 +125,7 @@ PS C:\>Enable-NetFirewallRule -Group "@FirewallAPI.dll,-28502"
 ```
 
 This example enables all of the File and Printer Sharing rules.
-Use the universal and world-ready indirect string @FirewallAPI to specify the group.
+"@FirewallAPI.dll,-28502" is an indirect string that specifies a "File and Printer Sharing" group.
 
 ### EXAMPLE 2
 ```
@@ -423,13 +423,8 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are enabled.
-Wildcard characters are accepted.
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name.
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
@@ -440,7 +435,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -517,13 +512,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are enabled.
-Wildcard characters are accepted.
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name.
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -534,7 +525,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2025-ps/NetSecurity/Get-NetFirewallRule.md
+++ b/docset/winserver2025-ps/NetSecurity/Get-NetFirewallRule.md
@@ -386,13 +386,8 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are retrieved.
-Wildcard characters are accepted.
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name.
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
@@ -403,7 +398,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -480,13 +475,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are retrieved.
-Wildcard characters are accepted.
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name.
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -497,7 +488,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -LocalOnlyMapping

--- a/docset/winserver2025-ps/NetSecurity/New-NetFirewallRule.md
+++ b/docset/winserver2025-ps/NetSecurity/New-NetFirewallRule.md
@@ -379,14 +379,12 @@ Accept wildcard characters: False
 ```
 
 ### -Group
-Specifies that only matching firewall rules of the indicated group association are copied.
-Wildcard characters are accepted.
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name.
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+Specifies a group for the rule. Rule groups can be used to organize rules and allows easy batch modifications. 
+It is a good practice to use an indirect string here, pointing to a localized string in a DLL (for example, `@FirewallAPI.dll,-34002`).
+The value of this property influences the value of the read-only **DisplayGroup** property:
+
+- When a rule's **Group** property contains an indirect string, the **DisplayGroup** property contains the string located at the specified index.
+- When a rule's **Group** property contains a regular string, the **DisplayGroup** property just returns that string.
 
 ```yaml
 Type: String

--- a/docset/winserver2025-ps/NetSecurity/Remove-NetFirewallRule.md
+++ b/docset/winserver2025-ps/NetSecurity/Remove-NetFirewallRule.md
@@ -420,13 +420,8 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are removed.
-Wildcard characters are accepted.
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name.
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
@@ -437,7 +432,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -514,13 +509,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are removed.
-Wildcard characters are accepted.
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name.
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -531,7 +522,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2025-ps/NetSecurity/Rename-NetFirewallRule.md
+++ b/docset/winserver2025-ps/NetSecurity/Rename-NetFirewallRule.md
@@ -403,14 +403,9 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayGroup
-Specifies that only matching firewall rules of the indicated group association are renamed.
-Wildcard characters are accepted.
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name.
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+Specifies that only matching firewall rules of the indicated group association are removed.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
 
 ```yaml
 Type: String[]
@@ -421,7 +416,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -498,13 +493,9 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are renamed.
-Wildcard characters are accepted.
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name.
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
 
 ```yaml
 Type: String[]
@@ -515,7 +506,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -InputObject

--- a/docset/winserver2025-ps/NetSecurity/Set-NetFirewallRule.md
+++ b/docset/winserver2025-ps/NetSecurity/Set-NetFirewallRule.md
@@ -126,6 +126,13 @@ PS C:\>Set-NetFirewallRule -DisplayName "AllowMessenger" -Authentication Require
 This example changes a rule to require authentication and scopes the rule to apply on the domain profile.
 A separate IPsec rule must exist to perform the authentication.
 
+### EXAMPLE 4
+```
+PS C:\>Get-NetFirewallRule -DisplayName "Microsoft Lync" | %{$_.Group = "Office"; Set-NetFirewallRule -InputObject $_}
+```
+
+This example changes the **Group** and **DisplayGroup** properties of a rule. The **DisplayGroup** property changes automatically and reflects changes introduced to the **Group** property.
+
 ## PARAMETERS
 
 ### -Action
@@ -270,13 +277,9 @@ Accept wildcard characters: False
 
 ### -DisplayGroup
 Specifies that only matching firewall rules of the indicated group association are modified.
-Wildcard characters are accepted.
-The *Group* parameter specifies the source string for this parameter.
-If the value for this parameter is a localizable string, then the *Group* parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlet, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is good practice to specify the *Group* parameter value with a universal and world-ready indirect @FirewallAPI name.
-This parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+The **Group** property specifies the source string for **DisplayGroup**.
+If the **Group** property contains an indirect string, then you should use a localized string, located at the address specified in the **Group** property, as a value for this parameter.
+**DisplayGroup** is a read-only property that can be modified only by modifying the **Group** property.
 
 ```yaml
 Type: String[]
@@ -287,7 +290,7 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DisplayName
@@ -418,13 +421,12 @@ Accept wildcard characters: False
 
 ### -Group
 Specifies that only matching firewall rules of the indicated group association are modified.
-Wildcard characters are accepted.
-This parameter specifies the source string for the *DisplayGroup* parameter.
-If the *DisplayGroup* parameter value is a localizable string, then this parameter contains an indirect string.
-Rule groups can be used to organize rules by influence and allows batch rule modifications.
-Using the Set-NetFirewallRule cmdlets, if the group name is specified for a set of rules or sets, then all of the rules or sets in that group receive the same set of modifications.
-It is a good practice to specify this parameter value with a universal and world-ready indirect @FirewallAPI name.
-The *DisplayGroup* parameter cannot be specified upon object creation using the New-NetFirewallRule cmdlet, but can be modified using dot-notation and the Set-NetFirewallRule cmdlet.
+
+> [!TIP]
+> For most built-in rules, the group string is specified as an indirect string (for example, `@FirewallAPI.dll,-34002`). To retrieve such rules you should use those indirect strings in this parameter, rather their localized counterparts displayed in the UI. Alternatively, you can use the **DisplayGroup** parameter to filter by group display names.
+
+> [!NOTE]
+> You cannot modify the **Group** property through this parameter. See Example 4, which demonstrates how to modify a rule's **Group** property.
 
 ```yaml
 Type: String[]
@@ -435,7 +437,7 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -IcmpType


### PR DESCRIPTION
# PR Summary

For a long time the documentation haven't explained clearly the relationship between the **Group** and **DisplayGroup** properties of Windows Firewall rules and the corresponding cmdlet parameters. With this PR I hope to bring more clarity into explanation of those terms.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
