### PR TITLE
Remove manager field from docfx.json

### DIFF
--- a/docset/docfx.json
+++ b/docset/docfx.json
@@ -70,7 +70,6 @@
         ],
         "feedback_product_url": "https://support.microsoft.com/windows/send-feedback-to-microsoft-with-the-feedback-hub-app-f59187f8-8739-22d6-ba93-f66612949332",
         "feedback_system": "Standard",
-        "manager": "tedhudek",
         "ms.author": "roharwoo",
         "ms.devlang": "powershell",
         "ms.service": "windows-11",


### PR DESCRIPTION
This pull request makes a minor change to the documentation configuration by removing the `manager` field from the `docset/docfx.json` file. This streamlines metadata and may help avoid confusion or redundancy.