### PR TITLE
Enhance documentation for -PrincipalsAllowedToDelegateToAccount

### DIFF
--- a/docset/winserver2025-ps/ActiveDirectory/Set-ADServiceAccount.md
+++ b/docset/winserver2025-ps/ActiveDirectory/Set-ADServiceAccount.md
@@ -595,6 +595,8 @@ Accept wildcard characters: False
 Specifies the accounts which can act on the behalf of users to services running as this Managed Service Account or Group Managed Service Account.
 This parameter sets the **msDS-AllowedToActOnBehalfOfOtherIdentity** attribute of the object.
 
+You can specify the Distinguished Name of an account when it is from the same domain as the account in focus. When you want a security principal from another domain, you need to construct an ADPrincipal object with the desired account, for example using Get-ADGroup.
+
 ```yaml
 Type: ADPrincipal[]
 Parameter Sets: Identity


### PR DESCRIPTION
Added information on specifying accounts from the same and different domains.

# PR Summary

change is a result of discussing [Bug 33273932](https://microsoft.visualstudio.com/OS/_workitems/edit/33273932)
set-adcomputer PrincipalsAllowedToDelegateToAccount does not accept accounts outside of the computer domain

## PR Checklist
