### PR TITLE
Enhance Set-ADUser documentation for PrincipalsAllowedToDelegateToAcc…

### DIFF
--- a/docset/winserver2025-ps/ActiveDirectory/Set-ADUser.md
+++ b/docset/winserver2025-ps/ActiveDirectory/Set-ADUser.md
@@ -1230,6 +1230,8 @@ Accept wildcard characters: False
 Specifies an array of principal objects. This parameter sets the
 **msDS-AllowedToActOnBehalfOfOtherIdentity** attribute of a computer account object.
 
+You can specify the Distinguished Name of an account when it is from the same domain as the account in focus. When you want a security principal from another domain, you need to construct an ADPrincipal object with the desired account, for example using Get-ADGroup.
+
 ```yaml
 Type: ADPrincipal[]
 Parameter Sets: Identity


### PR DESCRIPTION
…ount

Added information on specifying accounts from the same or different domains.

# PR Summary

change is a result of discussing [Bug 33273932](https://microsoft.visualstudio.com/OS/_workitems/edit/33273932)
set-adcomputer PrincipalsAllowedToDelegateToAccount does not accept accounts outside of the computer domain

## PR Checklist

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
