### PR TITLE
Update documentation for -PrincipalsAllowedToDelegateToAccount

### DIFF
--- a/docset/winserver2025-ps/ActiveDirectory/Set-ADComputer.md
+++ b/docset/winserver2025-ps/ActiveDirectory/Set-ADComputer.md
@@ -816,7 +816,7 @@ Accept wildcard characters: False
 Specifies the accounts which can act on the behalf of users to services running as this computer account.
 This parameter sets the **msDS-AllowedToActOnBehalfOfOtherIdentity** attribute of a computer account object.
 
-`Running Set-ADComputer without specifying the first principal will cause it to get overridden`
+You can specify the Distinguished Name of an account when it is from the same domain as the account in focus. When you want a security principal from another domain, you need to construct an ADPrincipal object with the desired account, for example using Get-ADGroup.
 
 ```yaml
 Type: ADPrincipal[]


### PR DESCRIPTION
Clarify usage of Set-ADComputer for principals delegation.

# PR Summary

change is a result of discussing [Bug 33273932](https://microsoft.visualstudio.com/OS/_workitems/edit/33273932)
set-adcomputer PrincipalsAllowedToDelegateToAccount does not accept accounts outside of the computer domain

## PR Checklist

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
