### PR TITLE
Corrected PK terminology from "private key" to "Platform Key" in Format-SecureBootUEFI documentation

### DIFF
--- a/docset/winserver2019-ps/SecureBoot/Format-SecureBootUEFI.md
+++ b/docset/winserver2019-ps/SecureBoot/Format-SecureBootUEFI.md
@@ -42,7 +42,7 @@ This cmdlet this runs on both UEFI and BIOS (non-UEFI) computers.
 
 ## EXAMPLES
 
-### Example 1: Format a private key
+### Example 1: Format a platform key
 ```
 PS C:\> Format-SecureBootUefi -Name PK -SignatureOwner 12345678-1234-1234-1234-123456789abc -CertificateFilePath PK.cer -SignableFilePath GeneratedFileToSign.bin -Time 2011-11-01T13:30:00Z | Format-List
 Name        : PK 
@@ -51,7 +51,7 @@ AppendWrite : False
 Content     : {232, 102, 87, 60...}
 ```
 
-This command formats the private key in PK.cer that is later piped to the Set-SecureBootUEFI cmdlet.
+This command formats the platform key in PK.cer that is later piped to the Set-SecureBootUEFI cmdlet.
 
 ### Example 2: Format a hash
 ```


### PR DESCRIPTION
# PR Summary

The current documentation incorrectly refers to PK as a "private key" in Example 1 and its description. According to the UEFI specification, PK stands for Platform Key

## PR Checklist

- [*] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [*] **Summary:** This PR's summary describes the scope and intent of the change.
- [*] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [*] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
