### PR TITLE
Fix mismatched option code in example in Add-DhcpServerv6OptionDefinition.md

### DIFF
--- a/docset/winserver2025-ps/DhcpServer/Add-DhcpServerv6OptionDefinition.md
+++ b/docset/winserver2025-ps/DhcpServer/Add-DhcpServerv6OptionDefinition.md
@@ -29,7 +29,7 @@ The **Add-DhcpServerv6OptionDefinition** cmdlet adds a DHCPv6 option definition 
 
 ### Example 1: Add an option definition
 ```
-PS C:\> Add-DhcpServerv6OptionDefinition -Name "Broadcast and Multicast Service Controller IPv6 Address" -OptionId 36 -Type "IPv6Address"
+PS C:\> Add-DhcpServerv6OptionDefinition -Name "Broadcast and Multicast Service Controller IPv6 Address" -OptionId 34 -Type "IPv6Address"
 ```
 
 This example adds the Broadcast and Multi-cast Service Controller IPv6 Address option definition to the DHCPv6 server service.


### PR DESCRIPTION
Changed one character:

The option code used in the example does not match the IANA registered code for that option name.

See the official IANA number assignments here:\
https://www.iana.org/assignments/dhcpv6-parameters/dhcpv6-parameters.xhtml#table-dhcpv6-parameters-2

If someone were to actually run that example as-is, invalid data would be served for a different option that has a very different format, no matter what they configured as the value for the option.

Option 36 is for civic geolocation data.\
The example is talking about the BCMCS address option, which is 34.

# PR Summary

 - Changed the mismatched option code 36 to 34 for the example, to match the rest of the example and explanation.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

CLA previously signed.

R2G.