### PR TITLE
Fix DisableCpuThrottleOnIdleScans parameter description

### DIFF
--- a/docset/winserver2022-ps/Defender/Remove-MpPreference.md
+++ b/docset/winserver2022-ps/Defender/Remove-MpPreference.md
@@ -736,14 +736,7 @@ Accept wildcard characters: False
 
 ### -DisableCpuThrottleOnIdleScans
 
-Specifies whether to disable CPU throttling for scheduled scans while the device is idle. You don't
-need to specify a value with this switch.
-
-**Tip**: This switch works only if the current value of the DisableCpuThrottleOnIdleScans
-property is False (enabled). If the value is already True (disabled), this switch does nothing.
-
-This setting doesn't affect other types scheduled scans. Normal CPU throttling occurs on other
-types of scheduled scans.
+Indicates that the cmdlet removes whether the CPU will be throttled for scheduled scans while the device is idle.
 
 ```yaml
 Type: SwitchParameter

--- a/docset/winserver2022-ps/Defender/Set-MpPreference.md
+++ b/docset/winserver2022-ps/Defender/Set-MpPreference.md
@@ -758,15 +758,7 @@ Accept wildcard characters: False
 
 ### -DisableCpuThrottleOnIdleScans
 
-Specifies whether to disable CPU throttling for scheduled scans while the device is idle. Valid
-values are:
-
-- $true: The CPU isn't throttled for scheduled scans, regardless of the value of the
-**ScanAvgCPULoadFactor** parameter.
-- $false: The CPU is throttled for scheduled scans.
-
-This parameter doesn't affect other types scheduled scans. Normal CPU throttling occurs on other
-types of scheduled scans.
+Indicates whether the CPU will be throttled for scheduled scans while the device is idle. This parameter is enabled by default, thus ensuring that the CPU won't be throttled for scheduled scans performed when the device is idle, regardless of what **ScanAvgCPULoadFactor** is set to. For all other scheduled scans, this flag does not have any impact and normal throttling will occur.
 
 ```yaml
 Type: Boolean


### PR DESCRIPTION
## Problem

The winserver2022 Defender docs for `-DisableCpuThrottleOnIdleScans` describe the parameter backwards and use stale `$true` / `$false` bullets that do not match current product behavior.

## Root cause

The winserver2022 topic diverged from the corrected winserver2025 wording after idle-scan CPU throttling behavior changed.

## Fix

Align `Set-MpPreference.md` and `Remove-MpPreference.md` in the winserver2022 docset with the current winserver2025 description so admins understand that the parameter is enabled by default and only affects idle scheduled scans.

Fixes #4020