### PR TITLE
Fix ReversibleEncryptionEnabled default value in New-ADFineGrainedPasswordPolicy

### DIFF
--- a/docset/winserver2025-ps/ActiveDirectory/New-ADFineGrainedPasswordPolicy.md
+++ b/docset/winserver2025-ps/ActiveDirectory/New-ADFineGrainedPasswordPolicy.md
@@ -537,7 +537,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
# PR Summary

This change fixes the documented default value for the `-ReversibleEncryptionEnabled` parameter in `New-ADFineGrainedPasswordPolicy` (winserver2025-ps), changing it from `None` to `False` to match verified product behavior. The Active Directory team recently fixed a related bug, and the reference incorrectly listed the default as `None`, which can mislead administrators about the parameter's actual default behavior.

- Resolves Content/589481

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide