### PR TITLE
Defender no longer support Update-Help

### DIFF
--- a/docset/mapping/cabgenConfig.json
+++ b/docset/mapping/cabgenConfig.json
@@ -3,6 +3,7 @@
         {
             "WindowsServer2025-ps": {
                 "exclude": [
+                    "docset/winserver2025-ps/Defender",
                     "docset/winserver2025-ps/Microsoft.DiagnosticDataViewer",
                     "docset/winserver2025-ps/Microsoft.Windows.ServerManager.Migration",
                     "docset/winserver2025-ps/WindowsDiagnosticData"
@@ -10,6 +11,7 @@
             },
             "WindowsServer2022-ps": {
                 "exclude": [
+                    "docset/winserver2022-ps/Defender",
                     "docset/winserver2022-ps/Microsoft.DiagnosticDataViewer",
                     "docset/winserver2022-ps/Microsoft.Windows.ServerManager.Migration",
                     "docset/winserver2022-ps/WindowsDiagnosticData"
@@ -17,6 +19,7 @@
             },
             "WindowsServer2019-ps": {
                 "exclude": [
+                    "docset/winserver2019-ps/Defender",
                     "docset/winserver2019-ps/Microsoft.DiagnosticDataViewer",
                     "docset/winserver2019-ps/Microsoft.Windows.ServerManager.Migration",
                     "docset/winserver2019-ps/WindowsDiagnosticData"
@@ -24,6 +27,7 @@
             },
             "WindowsServer2016-ps": {
                 "exclude": [
+                    "docset/winserver2016-ps/Defender",
                     "docset/winserver2016-ps/Microsoft.DiagnosticDataViewer",
                     "docset/winserver2016-ps/Microsoft.Windows.ServerManager.Migration",
                     "docset/winserver2016-ps/WindowsDiagnosticData"

--- a/docset/winserver2016-ps/Defender/Defender.md
+++ b/docset/winserver2016-ps/Defender/Defender.md
@@ -1,6 +1,6 @@
 ---
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
-Download Help Link: https://aka.ms/winsvr-2016-pshelp
+Download Help Link:
 Help Version: 5.0.3.1
 Locale: en-US
 Module Guid: c46be3dc-30a9-452f-a5fd-4bf9ca87a854

--- a/docset/winserver2019-ps/Defender/Defender.md
+++ b/docset/winserver2019-ps/Defender/Defender.md
@@ -1,6 +1,6 @@
 ---
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
-Download Help Link: https://aka.ms/winsvr-2019-pshelp
+Download Help Link:
 Help Version: 5.0.3.1
 Locale: en-US
 Module Guid: c46be3dc-30a9-452f-a5fd-4bf9ca87a854

--- a/docset/winserver2022-ps/Defender/Defender.md
+++ b/docset/winserver2022-ps/Defender/Defender.md
@@ -1,6 +1,6 @@
 ---
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
-Download Help Link: https://aka.ms/winsvr-2022-pshelp
+Download Help Link:
 Help Version: 5.0.3.1
 Locale: en-US
 Module Guid: c46be3dc-30a9-452f-a5fd-4bf9ca87a854
@@ -13,7 +13,7 @@ title: Defender
 
 ## Description
 
-This reference provides functions descriptions and syntax for all Defender-specific functions. 
+This reference provides functions descriptions and syntax for all Defender-specific functions.
 It lists the functions in alphabetical order based on the verb at the beginning of the functions.
 
 > [!NOTE]

--- a/docset/winserver2025-ps/Defender/Defender.md
+++ b/docset/winserver2025-ps/Defender/Defender.md
@@ -1,6 +1,6 @@
 ---
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
-Download Help Link: https://aka.ms/winsvr-2025-pshelp
+Download Help Link:
 Help Version: 5.0.3.1
 Locale: en-US
 Module Guid: c46be3dc-30a9-452f-a5fd-4bf9ca87a854
@@ -13,7 +13,7 @@ title: Defender
 
 ## Description
 
-This reference provides functions descriptions and syntax for all Defender-specific functions. 
+This reference provides functions descriptions and syntax for all Defender-specific functions.
 It lists the functions in alphabetical order based on the verb at the beginning of the functions.
 
 > [!NOTE]


### PR DESCRIPTION
# PR Summary

The Defender module no longer supports updateable help. This PR removes the HelpInfoUri from the module.md file and adds Defender to the list of modules to skip for CabGen.

- Fixes AB#597485

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
