### PR TITLE
Restore ReversibleEncryptionEnabled default value

### DIFF
--- a/docset/winserver2025-ps/ActiveDirectory/New-ADFineGrainedPasswordPolicy.md
+++ b/docset/winserver2025-ps/ActiveDirectory/New-ADFineGrainedPasswordPolicy.md
@@ -2,7 +2,7 @@
 description: Use this topic to help manage Windows and Windows Server technologies with Windows PowerShell.
 external help file: Microsoft.ActiveDirectory.Management.dll-Help.xml
 Module Name: ActiveDirectory
-ms.date: 12/27/2016
+ms.date: 08/19/2026
 online version: https://learn.microsoft.com/powershell/module/activedirectory/new-adfinegrainedpasswordpolicy?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-ADFineGrainedPasswordPolicy
@@ -537,7 +537,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
# PR Summary

This change restores the documented default value for `-ReversibleEncryptionEnabled` in `New-ADFineGrainedPasswordPolicy` from `False` to `None` so the reference matches currently released behavior. 

- Reverts the documentation value introduced by [PR 4119](https://github.com/MicrosoftDocs/windows-powershell-docs/pull/4119)

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide