### PR TITLE
Add OSLicense PowerShell reference

### DIFF
--- a/docset/winserver2025-ps/OSLicense/Get-ADLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Get-ADLicenseInfo.md
@@ -1,0 +1,194 @@
+---
+document type: cmdlet
+external help file: OSLicense-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: OSLicense
+ms.date: 09/07/2026
+PlatyPS schema version: 2024-05-01
+title: Get-ADLicenseInfo
+---
+
+# Get-ADLicenseInfo
+
+## SYNOPSIS
+Gets Active Directory-based activation license information.
+
+## SYNTAX
+
+### Default
+
+```
+Get-ADLicenseInfo [-AsJob] [<CommonParameters>]
+```
+
+### ForestInstallationId
+
+```
+Get-ADLicenseInfo [-ProductKey <String>] [-AsJob] [<CommonParameters>]
+```
+
+### ActivationObjects
+
+```
+Get-ADLicenseInfo [-ActivationObjects] [-AsJob] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Get-ADLicenseInfo` cmdlet queries Active Directory-based activation information for Windows.
+Without parameters, it returns the current operating system licensing product's activation ID,
+license status, and Active Directory activation properties.
+
+Use **ProductKey** to generate an offline forest installation ID for Active Directory-based
+activation. Use **ActivationObjects** to enumerate activation objects in the Active Directory
+configuration naming context.
+
+This cmdlet is read-only. It doesn't install a product key, activate Windows, or change activation
+objects. The applicable Windows update KB number for this cmdlet is pending confirmation.
+
+## EXAMPLES
+
+### Example 1: Generate a forest installation ID
+
+This example uses a fictitious product key to show how to generate the installation ID needed for
+offline forest activation. The returned object includes the supplied product key, so avoid writing
+the object to shared logs when you use an actual key.
+
+```powershell
+$result = Get-ADLicenseInfo -ProductKey 'XXXXX-XXXXX-XXXXX-XXXXX-XXXXX'
+$result.ForestInstallationId
+```
+
+The command generates the installation ID without installing the product key or changing the
+activation state.
+
+### Example 2: List activation objects as a background job
+
+When you access the module through an implicit-remoting wrapper, this example starts the query as a
+background job and receives its results. The command lists selected properties from each activation
+object.
+
+```powershell
+$job = Get-ADLicenseInfo -ActivationObjects -AsJob
+$activationObjects = Receive-Job -Job $job -Wait -AutoRemoveJob
+$activationObjects | Select-Object Name, DistinguishedName, ObjectClass
+```
+
+## PARAMETERS
+
+### -ActivationObjects
+
+Enumerates the activation objects stored in the `CN=Activation Objects,CN=Microsoft SPP` container
+in the Active Directory configuration naming context.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivationObjects
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -AsJob
+
+Runs the command as a background job when the module is accessed through an implicit-remoting
+wrapper. This parameter returns a job object immediately. Use `Receive-Job` to retrieve the license
+information from the job.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ProductKey
+
+Specifies the product key for which the cmdlet generates an offline forest installation ID. The
+returned object contains both the product key and the generated installation ID. Protect the output
+as sensitive information when you specify an actual product key.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ForestInstallationId
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+## INPUTS
+
+### None
+
+This cmdlet doesn't accept input from the pipeline.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+For the `Default` parameter set, the cmdlet returns an object with **Name**, **Description**,
+**ActivationID**, **LicenseStatus**, **ADActivationObjectName**, **ADActivationObjectDN**,
+**ADActivationCsvlkPid**, and **ADActivationCsvlkSkuId** properties.
+
+For the `ForestInstallationId` parameter set, it returns an object with **ProductKey** and
+**ForestInstallationId** properties. For the `ActivationObjects` parameter set, it returns one
+object for each activation object with **DistinguishedName**, **Name**, and **ObjectClass**
+properties. When the `ActiveDirectory` module is available, each activation object also includes
+**Created** and **Modified** properties.
+
+If a top-level query fails, the cmdlet returns an object with **Success**, **ErrorCode**, and
+**ErrorMessage** properties.
+
+### System.Management.Automation.Job
+
+When you use **AsJob** through an implicit-remoting wrapper, the cmdlet returns a job object. The
+job's output contains the objects described in the preceding section.
+
+## NOTES
+
+The default and **ProductKey** operations query the local Software Licensing service. The
+**ActivationObjects** operation uses the `ActiveDirectory` module when it's available and otherwise
+uses Active Directory Service Interfaces (ADSI). The computer must be able to reach the domain, and
+your account must be able to read the activation-object container.
+
+The source function doesn't define **AsJob**. The parameter is added by the implicit-remoting
+wrapper and isn't available when you import the source function directly.
+
+The cmdlet can return `$null` when no applicable Windows licensing product is found or when
+activation objects can't be queried.
+
+## RELATED LINKS
+
+- [Active Directory-Based Activation overview](/windows/deployment/volume-activation/active-directory-based-activation-overview)
+- [Activate using Active Directory-based activation](/windows/deployment/volume-activation/activate-using-active-directory-based-activation-client)
+- [Slmgr.vbs Active Directory-based activation options](/windows-server/get-started/activation-slmgr-vbs-options#active-directory-based-activation-configuration-options)
+- [about_Jobs](/powershell/module/microsoft.powershell.core/about/about_jobs)

--- a/docset/winserver2025-ps/OSLicense/Get-ADLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Get-ADLicenseInfo.md
@@ -4,7 +4,7 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/07/2026
+ms.date: 09/09/2026
 PlatyPS schema version: 2024-05-01
 title: Get-ADLicenseInfo
 ---
@@ -45,15 +45,19 @@ activation. Use **ActivationObjects** to enumerate activation objects in the Act
 configuration naming context.
 
 This cmdlet is read-only. It doesn't install a product key, activate Windows, or change activation
-objects. The applicable Windows update KB number for this cmdlet is pending confirmation.
+objects.
+
+> [!NOTE]
+> `Get-ADLicenseInfo` is available in [Windows Server vNext Preview Build 29651](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29651/4549702)
+> and the [2026-09 security update for Windows 11 (KB5124008)](https://support.microsoft.com/help/5124008).
 
 ## EXAMPLES
 
 ### Example 1: Generate a forest installation ID
 
-This example uses a fictitious product key to show how to generate the installation ID needed for
-offline forest activation. The returned object includes the supplied product key, so avoid writing
-the object to shared logs when you use an actual key.
+This example uses a fictitious product key to generate the installation ID for offline forest
+activation. The cmdlet returns an object that includes the supplied product key. Avoid writing the
+object to shared logs when you use an actual key.
 
 ```powershell
 $result = Get-ADLicenseInfo -ProductKey 'XXXXX-XXXXX-XXXXX-XXXXX-XXXXX'
@@ -79,8 +83,8 @@ $activationObjects | Select-Object Name, DistinguishedName, ObjectClass
 
 ### -ActivationObjects
 
-Enumerates the activation objects stored in the `CN=Activation Objects,CN=Microsoft SPP` container
-in the Active Directory configuration naming context.
+Enumerates the activation objects in the `CN=Activation Objects,CN=Microsoft SPP` container in the
+Active Directory configuration naming context.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -101,7 +105,7 @@ HelpMessage: ''
 
 ### -AsJob
 
-Runs the command as a background job when the module is accessed through an implicit-remoting
+Runs the command as a background job when you access the module through an implicit-remoting
 wrapper. This parameter returns a job object immediately. Use `Receive-Job` to retrieve the license
 information from the job.
 
@@ -124,9 +128,9 @@ HelpMessage: ''
 
 ### -ProductKey
 
-Specifies the product key for which the cmdlet generates an offline forest installation ID. The
-returned object contains both the product key and the generated installation ID. Protect the output
-as sensitive information when you specify an actual product key.
+Specifies the product key that the cmdlet uses to generate an offline forest installation ID. The
+cmdlet returns an object that contains both the product key and the installation ID. Treat
+the output as sensitive information when you specify an actual product key.
 
 ```yaml
 Type: System.String
@@ -171,20 +175,20 @@ If a top-level query fails, the cmdlet returns an object with **Success**, **Err
 ### System.Management.Automation.Job
 
 When you use **AsJob** through an implicit-remoting wrapper, the cmdlet returns a job object. The
-job's output contains the objects described in the preceding section.
+job's output contains the objects that the preceding section describes.
 
 ## NOTES
 
 The default and **ProductKey** operations query the local Software Licensing service. The
-**ActivationObjects** operation uses the `ActiveDirectory` module when it's available and otherwise
+**ActivationObjects** operation uses the `ActiveDirectory` module if it's available and otherwise
 uses Active Directory Service Interfaces (ADSI). The computer must be able to reach the domain, and
 your account must be able to read the activation-object container.
 
-The source function doesn't define **AsJob**. The parameter is added by the implicit-remoting
-wrapper and isn't available when you import the source function directly.
+The source function doesn't define **AsJob**. The implicit-remoting wrapper adds the parameter,
+which isn't available when you import the source function directly.
 
-The cmdlet can return `$null` when no applicable Windows licensing product is found or when
-activation objects can't be queried.
+The cmdlet returns `$null` when it finds no applicable Windows licensing product or can't query
+activation objects.
 
 ## RELATED LINKS
 

--- a/docset/winserver2025-ps/OSLicense/Get-OSLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Get-OSLicenseInfo.md
@@ -1,0 +1,243 @@
+---
+document type: cmdlet
+external help file: OSLicense-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: OSLicense
+ms.date: 09/07/2026
+PlatyPS schema version: 2024-05-01
+title: Get-OSLicenseInfo
+---
+
+# Get-OSLicenseInfo
+
+## SYNOPSIS
+Gets Windows operating system licensing information.
+
+## SYNTAX
+
+### Default
+
+```
+Get-OSLicenseInfo [-AsJob] [<CommonParameters>]
+```
+
+### All
+
+```
+Get-OSLicenseInfo [-All] [-AsJob] [<CommonParameters>]
+```
+
+### ActivationID
+
+```
+Get-OSLicenseInfo [-ActivationID <String>] [-AsJob] [<CommonParameters>]
+```
+
+### TokenLicenses
+
+```
+Get-OSLicenseInfo [-TokenBasedLicenses] [-AsJob] [<CommonParameters>]
+```
+
+### TokenCertificates
+
+```
+Get-OSLicenseInfo [-TokenBasedCertificates] [-AsJob] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Get-OSLicenseInfo` cmdlet queries the local Software Licensing CIM classes and returns
+structured licensing information. Without parameters, the cmdlet returns the first Windows
+operating system product that has a partial product key and isn't an add-on license.
+
+Use **ActivationID** to query a specific product, **All** to query every product that has an
+application ID and name, or the token parameters to query token-based licenses or certificates.
+
+The cmdlet is available through an applicable Windows update. The KB number for that update is
+pending confirmation.
+
+## EXAMPLES
+
+### Example 1: Get the primary Windows license status
+
+```powershell
+Get-OSLicenseInfo |
+    Select-Object Name, ActivationID, LicenseStatus, PartialProductKey,
+        GracePeriodRemaining, EvaluationEndDate
+```
+
+This example gets the primary Windows operating system license and selects properties useful for
+checking its activation state and expiration.
+
+### Example 2: Review token-based licenses
+
+```powershell
+Get-OSLicenseInfo -TokenBasedLicenses |
+    Sort-Object ExpirationDate |
+    Select-Object ILID, ILvID, AuthorizationStatus, Description, ExpirationDate
+```
+
+This example lists token-based licenses in expiration-date order and selects their identifying and
+status properties.
+
+## PARAMETERS
+
+### -ActivationID
+
+Specifies the activation ID of the software licensing product to return. The cmdlet performs an
+exact match against the **ID** property of the `SoftwareLicensingProduct` CIM instance.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivationID
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -All
+
+Returns every software licensing product whose **ApplicationID** and **Name** properties are
+populated. The results can include products other than the primary Windows operating system
+license.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: All
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -AsJob
+
+Runs the command as a background job when you invoke it through an implicit-remoting wrapper. This
+parameter is supplied by the wrapper and isn't declared by the local `OSLicense` module function.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TokenBasedCertificates
+
+Returns token-based activation certificate information from the local software licensing service,
+including the issued certificate thumbprint list, grant number, ILID, ILvID, and additional
+information.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: TokenCertificates
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TokenBasedLicenses
+
+Returns installed token-based activation licenses. Each result includes the ILID, ILvID,
+authorization status, description, and expiration date.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: TokenLicenses
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+## INPUTS
+
+### None
+
+This cmdlet doesn't accept pipeline input.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+For the default, **All**, and **ActivationID** parameter sets, the cmdlet returns objects that
+combine product and licensing-service data. Notable properties include **Name**, **ActivationID**,
+**ApplicationID**, **PartialProductKey**, **LicenseStatus**, **LicenseStatusReason**,
+**GracePeriodRemaining**, **EvaluationEndDate**, **OfflineInstallationId**, rearm counts,
+**Version**, **ClientMachineID**, and **IsKeyManagementServiceMachine**. KMS properties such as
+**KeyManagementServiceMachine**, **KeyManagementServicePort**, and activation and renewal intervals
+are present only when KMS configuration or discovery data exists.
+
+For **TokenBasedLicenses**, each object has **ILID**, **ILvID**, **AuthorizationStatus**,
+**Description**, and **ExpirationDate** properties. For **TokenBasedCertificates**, the object has
+**TokenBasedActivationCertificateIssuedList**, **TokenBasedActivationGrantNumber**,
+**TokenBasedActivationILID**, **TokenBasedActivationILVID**, and
+**TokenBasedActivationAdditionalInfo** properties.
+
+### System.Management.Automation.Job
+
+When you use **AsJob** through an implicit-remoting wrapper, the cmdlet returns a job object. Use
+`Receive-Job` to retrieve the licensing objects from the completed job.
+
+## NOTES
+
+The cmdlet returns no object when it finds no matching licensing data or when its CIM query fails.
+It returns unset date values as `$null`. It also converts licensing sentinel values to contextual
+strings such as `Unlimited`, `No Limit`, `N/A`, or `Not Set` where applicable.
+
+The **LicenseStatus** value is a localized status string. **LicenseStatusReason** is formatted as a
+hexadecimal error code when the source value isn't `$null`.
+
+## RELATED LINKS
+
+- [Slmgr.vbs options for obtaining volume activation information](/windows-server/get-started/activation-slmgr-vbs-options)
+- [Activate using Key Management Service](/windows/deployment/volume-activation/activate-using-key-management-service-vamt)
+- [Monitor activation](/windows/deployment/volume-activation/monitor-activation-client)
+- [SoftwareLicensingProduct class](/previous-versions/windows/desktop/sppwmi/softwarelicensingproduct)
+- [SoftwareLicensingService class](/previous-versions/windows/desktop/sppwmi/softwarelicensingservice)

--- a/docset/winserver2025-ps/OSLicense/Get-OSLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Get-OSLicenseInfo.md
@@ -4,7 +4,7 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/07/2026
+ms.date: 09/09/2026
 PlatyPS schema version: 2024-05-01
 title: Get-OSLicenseInfo
 ---
@@ -48,15 +48,17 @@ Get-OSLicenseInfo [-TokenBasedCertificates] [-AsJob] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The `Get-OSLicenseInfo` cmdlet queries the local Software Licensing CIM classes and returns
-structured licensing information. Without parameters, the cmdlet returns the first Windows
+The `Get-OSLicenseInfo` cmdlet queries local software licensing Common Information Model
+(CIM) classes to return structured licensing information.
+Without parameters, the cmdlet returns the first Windows
 operating system product that has a partial product key and isn't an add-on license.
 
 Use **ActivationID** to query a specific product, **All** to query every product that has an
 application ID and name, or the token parameters to query token-based licenses or certificates.
 
-The cmdlet is available through an applicable Windows update. The KB number for that update is
-pending confirmation.
+> [!NOTE]
+> `Get-OSLicenseInfo` is available in [Windows Server vNext Preview Build 29651](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29651/4549702)
+> and the [2026-09 security update for Windows 11 (KB5124008)](https://support.microsoft.com/help/5124008).
 
 ## EXAMPLES
 
@@ -68,8 +70,8 @@ Get-OSLicenseInfo |
         GracePeriodRemaining, EvaluationEndDate
 ```
 
-This example gets the primary Windows operating system license and selects properties useful for
-checking its activation state and expiration.
+This example gets the primary Windows operating system license and selects properties that show its
+activation state and expiration.
 
 ### Example 2: Review token-based licenses
 
@@ -79,15 +81,15 @@ Get-OSLicenseInfo -TokenBasedLicenses |
     Select-Object ILID, ILvID, AuthorizationStatus, Description, ExpirationDate
 ```
 
-This example lists token-based licenses in expiration-date order and selects their identifying and
+This example sorts token-based licenses by expiration date and selects their identifying and
 status properties.
 
 ## PARAMETERS
 
 ### -ActivationID
 
-Specifies the activation ID of the software licensing product to return. The cmdlet performs an
-exact match against the **ID** property of the `SoftwareLicensingProduct` CIM instance.
+Specifies the activation ID of the software licensing product that the cmdlet returns. The cmdlet
+performs an exact match against the **ID** property of the **SoftwareLicensingProduct** CIM instance.
 
 ```yaml
 Type: System.String
@@ -108,9 +110,8 @@ HelpMessage: ''
 
 ### -All
 
-Returns every software licensing product whose **ApplicationID** and **Name** properties are
-populated. The results can include products other than the primary Windows operating system
-license.
+Returns every software licensing product whose **ApplicationID** and **Name** properties contain
+values. The results can include products other than the primary Windows operating system license.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -132,7 +133,7 @@ HelpMessage: ''
 ### -AsJob
 
 Runs the command as a background job when you invoke it through an implicit-remoting wrapper. This
-parameter is supplied by the wrapper and isn't declared by the local `OSLicense` module function.
+wrapper supplies the parameter, and the local `OSLicense` module function doesn't declare it.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -154,8 +155,7 @@ HelpMessage: ''
 ### -TokenBasedCertificates
 
 Returns token-based activation certificate information from the local software licensing service,
-including the issued certificate thumbprint list, grant number, ILID, ILvID, and additional
-information.
+including the issued certificate thumbprint list, grant number, ILID, and ILvID.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -206,13 +206,13 @@ This cmdlet doesn't accept pipeline input.
 
 ### System.Management.Automation.PSCustomObject
 
-For the default, **All**, and **ActivationID** parameter sets, the cmdlet returns objects that
+For the default, `All`, and `ActivationID` parameter sets, the cmdlet returns objects that
 combine product and licensing-service data. Notable properties include **Name**, **ActivationID**,
 **ApplicationID**, **PartialProductKey**, **LicenseStatus**, **LicenseStatusReason**,
 **GracePeriodRemaining**, **EvaluationEndDate**, **OfflineInstallationId**, rearm counts,
-**Version**, **ClientMachineID**, and **IsKeyManagementServiceMachine**. KMS properties such as
-**KeyManagementServiceMachine**, **KeyManagementServicePort**, and activation and renewal intervals
-are present only when KMS configuration or discovery data exists.
+**Version**, **ClientMachineID**, and **IsKeyManagementServiceMachine**. Objects include Key Management
+Service (KMS) properties such as **KeyManagementServiceMachine**, **KeyManagementServicePort**, and
+activation and renewal intervals only when KMS configuration or discovery data exists.
 
 For **TokenBasedLicenses**, each object has **ILID**, **ILvID**, **AuthorizationStatus**,
 **Description**, and **ExpirationDate** properties. For **TokenBasedCertificates**, the object has
@@ -231,8 +231,8 @@ The cmdlet returns no object when it finds no matching licensing data or when it
 It returns unset date values as `$null`. It also converts licensing sentinel values to contextual
 strings such as `Unlimited`, `No Limit`, `N/A`, or `Not Set` where applicable.
 
-The **LicenseStatus** value is a localized status string. **LicenseStatusReason** is formatted as a
-hexadecimal error code when the source value isn't `$null`.
+The **LicenseStatus** value is a localized status string. The cmdlet formats **LicenseStatusReason** as
+a hexadecimal error code when the source value isn't `$null`.
 
 ## RELATED LINKS
 

--- a/docset/winserver2025-ps/OSLicense/Invoke-ADLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-ADLicense.md
@@ -1,0 +1,339 @@
+---
+document type: cmdlet
+external help file: OSLicense-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: OSLicense
+ms.date: 09/07/2026
+PlatyPS schema version: 2024-05-01
+title: Invoke-ADLicense
+---
+
+# Invoke-ADLicense
+
+## SYNOPSIS
+Performs Active Directory-based licensing operations.
+
+## SYNTAX
+
+### ActivateOnline
+
+```
+Invoke-ADLicense [-ActivateOnline] [-ProductKey <String>] [-ConfirmationID <String>]
+ [-ActivationObjectName <String>] [-AsJob] [<CommonParameters>]
+```
+
+### ActivateForest
+
+```
+Invoke-ADLicense [-ActivateForest] [-ProductKey <String>] [-ConfirmationID <String>]
+ [-ActivationObjectName <String>] [-AsJob] [<CommonParameters>]
+```
+
+### DeleteActivationObjects
+
+```
+Invoke-ADLicense [-DeleteActivationObjects <String>] [-AsJob] [<CommonParameters>]
+```
+
+### None
+
+```
+Invoke-ADLicense [-AsJob] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Invoke-ADLicense` cmdlet performs Active Directory-based activation and deletes Active
+Directory activation objects. Online activation calls the software licensing service to create an
+activation object. Forest activation deposits an offline activation confirmation. The deletion
+operation accepts either the distinguished name or the relative name of an activation object.
+
+The cmdlet returns structured objects for completed operations and caught failures. It returns no
+object when the software licensing service query returns no instance or when you don't select an
+operation.
+
+The applicable Windows update KB number for this cmdlet is pending confirmation.
+
+## EXAMPLES
+
+### Example 1: Deposit a fictitious offline activation confirmation
+
+> [!CAUTION]
+> This example uses a fictitious product key, confirmation ID, and activation object name. The
+> command changes Active Directory-based activation state. Replace the values only in an authorized
+> test environment after you verify the intended licensing operation.
+
+```powershell
+$activationParameters = @{
+    ActivateForest      = $true
+    ProductKey           = 'AAAAA-BBBBB-CCCCC-DDDDD-EEEEE'
+    ConfirmationID       = '000000000000000000000000000000000000000000000000'
+    ActivationObjectName = 'Fabrikam-Docs-Activation-Object'
+}
+
+Invoke-ADLicense @activationParameters
+```
+
+This example requests forest activation by depositing a fictitious offline activation confirmation.
+It doesn't represent an executed activation or actual command output.
+
+### Example 2: Delete a fictitious activation object by relative name
+
+> [!CAUTION]
+> Deleting an activation object is immediate and the cmdlet doesn't prompt for confirmation. The
+> object name in this example is fictitious. Verify the target object and your recovery plan before
+> you run a deletion command in an authorized environment.
+
+```powershell
+Invoke-ADLicense -DeleteActivationObjects 'Fabrikam-Docs-Obsolete-Activation-Object'
+```
+
+This example requests deletion by relative name. The cmdlet resolves a relative name under the
+`CN=Activation Objects,CN=Microsoft SPP` container in the configuration naming context. It doesn't
+represent an executed deletion or actual command output.
+
+## PARAMETERS
+
+### -ActivateForest
+
+Requests forest activation by depositing an offline activation confirmation through the software
+licensing service. **ProductKey** and **ConfirmationID** are validated at runtime and must have
+values when you use this parameter.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivateForest
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ActivateOnline
+
+Requests online Active Directory-based activation through the software licensing service. The
+**ProductKey** parameter is validated at runtime and must have a value when you use this parameter.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivateOnline
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ActivationObjectName
+
+Specifies the name of the activation object for online or forest activation. When you omit this
+parameter, the cmdlet passes an empty string to the corresponding software licensing service method.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivateOnline
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: ActivateForest
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -AsJob
+
+Runs the command as a background job. The implicit-remoting wrapper that exposes this command adds
+this parameter; the `Invoke-ADLicense` function in the OSLicense module doesn't declare it. Use
+`Receive-Job` to retrieve the operation result.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ConfirmationID
+
+Specifies the offline activation confirmation ID. The function declares this parameter for both
+activation parameter sets, but uses it only with **ActivateForest**. The value is validated at
+runtime and is required for forest activation. The **ActivateOnline** operation ignores this value.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivateOnline
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: ActivateForest
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -DeleteActivationObjects
+
+Specifies an activation object to delete. Enter a distinguished name that starts with `CN=`, or
+enter the relative name without the `CN=` prefix for an object in the
+`CN=Activation Objects,CN=Microsoft SPP` container. The cmdlet uses `Remove-ADObject` when the
+ActiveDirectory module is available. Otherwise, it uses Active Directory Service Interfaces (ADSI)
+to delete the object tree.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: DeleteActivationObjects
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ProductKey
+
+Specifies the product key for online or forest activation. The cmdlet validates this value at
+runtime and requires it for either activation operation. A successful activation result includes
+this value in its **ProductKey** property. Protect command output that contains a product key.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivateOnline
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: ActivateForest
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+## INPUTS
+
+### None
+
+This cmdlet doesn't accept pipeline input.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+For a successful online or forest activation request, the cmdlet returns an object with these
+properties:
+
+- **Success** is `$true`.
+- **Operation** is `ActivateOnline` or `ActivateForest`.
+- **ProductKey** is the value supplied to **ProductKey**.
+- **ActivationObjectName** is the value supplied to **ActivationObjectName**, or an empty string
+  when omitted.
+
+For a successful deletion, the cmdlet returns an object with these properties:
+
+- **Success** is `$true`.
+- **Operation** is `DeleteActivationObject`.
+- **ActivationObject** is the value supplied to **DeleteActivationObjects**.
+
+For a caught failure, the cmdlet returns an object with these properties:
+
+- **Success** is `$false`.
+- **ErrorCode** is the CIM `error_Code` value formatted as an eight-digit hexadecimal string with a
+  `0x` prefix, or `$null` when CIM error data doesn't provide a code.
+- **ErrorMessage** is the CIM `error_WindowsErrorMessage` value when available. Otherwise, it is the
+  exception message or the string representation of the caught error.
+
+The cmdlet returns no object when the CIM query returns no `SoftwareLicensingService` instance or
+when no operation is selected.
+
+### System.Management.Automation.Job
+
+When you use **AsJob**, the implicit-remoting wrapper returns a job object instead of returning the
+operation result directly. Use `Receive-Job` to receive the underlying structured result, or no
+output when the underlying command returns no object.
+
+## NOTES
+
+Run this cmdlet with the permissions required to invoke software licensing service methods and to
+modify Active Directory activation objects.
+
+The `Invoke-ADLicense` function doesn't implement `SupportsShouldProcess`. For deletion, it calls
+`Remove-ADObject` with confirmation disabled when the ActiveDirectory module is available, or calls
+the ADSI `DeleteTree()` method otherwise.
+
+The **ProductKey**, **ConfirmationID**, and activation switches aren't marked as mandatory in the
+function metadata. The function performs runtime validation: both activation operations require a
+product key, and forest activation also requires a confirmation ID.
+
+The generated implicit-remoting wrapper adds **AsJob** to every parameter set. This wrapper
+parameter is intentionally retained even though it isn't present in the module function source.
+
+## RELATED LINKS
+
+- [Monitor activation](/windows/deployment/volume-activation/monitor-activation-client)
+- [Slmgr.vbs Active Directory-based activation options](/windows-server/get-started/activation-slmgr-vbs-options#active-directory-based-activation-configuration-options)
+- [Receive-Job](/powershell/module/microsoft.powershell.core/receive-job)

--- a/docset/winserver2025-ps/OSLicense/Invoke-ADLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-ADLicense.md
@@ -4,7 +4,7 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/07/2026
+ms.date: 09/09/2026
 PlatyPS schema version: 2024-05-01
 title: Invoke-ADLicense
 ---
@@ -47,13 +47,15 @@ Invoke-ADLicense [-AsJob] [<CommonParameters>]
 The `Invoke-ADLicense` cmdlet performs Active Directory-based activation and deletes Active
 Directory activation objects. Online activation calls the software licensing service to create an
 activation object. Forest activation deposits an offline activation confirmation. The deletion
-operation accepts either the distinguished name or the relative name of an activation object.
+operation accepts an activation object's distinguished or relative name.
 
-The cmdlet returns structured objects for completed operations and caught failures. It returns no
-object when the software licensing service query returns no instance or when you don't select an
+The cmdlet returns structured objects when it completes operations or catches failures. It returns
+no object when the software licensing service query returns no instance or when you don't select an
 operation.
 
-The applicable Windows update KB number for this cmdlet is pending confirmation.
+> [!NOTE]
+> `Invoke-ADLicense` is available in [Windows Server vNext Preview Build 29651](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29651/4549702)
+> and the [2026-09 security update for Windows 11 (KB5124008)](https://support.microsoft.com/help/5124008).
 
 ## EXAMPLES
 
@@ -61,8 +63,8 @@ The applicable Windows update KB number for this cmdlet is pending confirmation.
 
 > [!CAUTION]
 > This example uses a fictitious product key, confirmation ID, and activation object name. The
-> command changes Active Directory-based activation state. Replace the values only in an authorized
-> test environment after you verify the intended licensing operation.
+> command changes Active Directory-based activation state. After you verify the intended licensing
+> operation, replace the values only in an authorized test environment.
 
 ```powershell
 $activationParameters = @{
@@ -76,12 +78,12 @@ Invoke-ADLicense @activationParameters
 ```
 
 This example requests forest activation by depositing a fictitious offline activation confirmation.
-It doesn't represent an executed activation or actual command output.
+It doesn't represent an actual activation or include command output.
 
 ### Example 2: Delete a fictitious activation object by relative name
 
 > [!CAUTION]
-> Deleting an activation object is immediate and the cmdlet doesn't prompt for confirmation. The
+> The cmdlet immediately deletes an activation object and doesn't prompt for confirmation. The
 > object name in this example is fictitious. Verify the target object and your recovery plan before
 > you run a deletion command in an authorized environment.
 
@@ -91,15 +93,15 @@ Invoke-ADLicense -DeleteActivationObjects 'Fabrikam-Docs-Obsolete-Activation-Obj
 
 This example requests deletion by relative name. The cmdlet resolves a relative name under the
 `CN=Activation Objects,CN=Microsoft SPP` container in the configuration naming context. It doesn't
-represent an executed deletion or actual command output.
+represent an actual deletion or include command output.
 
 ## PARAMETERS
 
 ### -ActivateForest
 
 Requests forest activation by depositing an offline activation confirmation through the software
-licensing service. **ProductKey** and **ConfirmationID** are validated at runtime and must have
-values when you use this parameter.
+licensing service. The cmdlet validates **ProductKey** and **ConfirmationID** at runtime and
+requires values for both parameters.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -121,7 +123,7 @@ HelpMessage: ''
 ### -ActivateOnline
 
 Requests online Active Directory-based activation through the software licensing service. The
-**ProductKey** parameter is validated at runtime and must have a value when you use this parameter.
+cmdlet validates **ProductKey** at runtime and requires a value for online activation.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -194,8 +196,8 @@ HelpMessage: ''
 ### -ConfirmationID
 
 Specifies the offline activation confirmation ID. The function declares this parameter for both
-activation parameter sets, but uses it only with **ActivateForest**. The value is validated at
-runtime and is required for forest activation. The **ActivateOnline** operation ignores this value.
+activation parameter sets but uses it only with **ActivateForest**. It validates the value at
+runtime and requires it for forest activation. The **ActivateOnline** operation ignores this value.
 
 ```yaml
 Type: System.String
@@ -289,48 +291,49 @@ properties:
 
 - **Success** is `$true`.
 - **Operation** is `ActivateOnline` or `ActivateForest`.
-- **ProductKey** is the value supplied to **ProductKey**.
-- **ActivationObjectName** is the value supplied to **ActivationObjectName**, or an empty string
-  when omitted.
+- **ProductKey** is the value that you supply to **ProductKey**.
+- **ActivationObjectName** is the value that you supply to **ActivationObjectName**, or an empty
+  string when you omit **ActivationObjectName**.
 
 For a successful deletion, the cmdlet returns an object with these properties:
 
 - **Success** is `$true`.
 - **Operation** is `DeleteActivationObject`.
-- **ActivationObject** is the value supplied to **DeleteActivationObjects**.
+- **ActivationObject** is the value that you supply to **DeleteActivationObjects**.
 
-For a caught failure, the cmdlet returns an object with these properties:
+When the cmdlet catches a failure, it returns an object with these properties:
 
 - **Success** is `$false`.
-- **ErrorCode** is the CIM `error_Code` value formatted as an eight-digit hexadecimal string with a
-  `0x` prefix, or `$null` when CIM error data doesn't provide a code.
-- **ErrorMessage** is the CIM `error_WindowsErrorMessage` value when available. Otherwise, it is the
-  exception message or the string representation of the caught error.
+- **ErrorCode** is the Common Information Model (CIM) `error_Code` value. The cmdlet formats the
+  value as an eight-digit hexadecimal string with a `0x` prefix. If CIM error data doesn't provide
+  a code, **ErrorCode** is `$null`.
+- **ErrorMessage** is the CIM `error_WindowsErrorMessage` value when CIM provides one. Otherwise,
+  it's the exception message or the string representation of the error that the cmdlet catches.
 
-The cmdlet returns no object when the CIM query returns no `SoftwareLicensingService` instance or
-when no operation is selected.
+The cmdlet returns no object when the CIM query returns no **SoftwareLicensingService** instance or
+when you don't select an operation.
 
 ### System.Management.Automation.Job
 
-When you use **AsJob**, the implicit-remoting wrapper returns a job object instead of returning the
-operation result directly. Use `Receive-Job` to receive the underlying structured result, or no
-output when the underlying command returns no object.
+When you use **AsJob**, the implicit-remoting wrapper returns a job object rather than the operation
+result. Use `Receive-Job` to receive the underlying structured result. If the underlying command
+returns no object, `Receive-Job` produces no output.
 
 ## NOTES
 
-Run this cmdlet with the permissions required to invoke software licensing service methods and to
-modify Active Directory activation objects.
+To invoke software licensing service methods and modify Active Directory activation objects, run
+this cmdlet with the necessary permissions.
 
 The `Invoke-ADLicense` function doesn't implement `SupportsShouldProcess`. For deletion, it calls
-`Remove-ADObject` with confirmation disabled when the ActiveDirectory module is available, or calls
-the ADSI `DeleteTree()` method otherwise.
+`Remove-ADObject` without confirmation when the `ActiveDirectory` module is available. Otherwise,
+it calls the ADSI `DeleteTree()` method.
 
-The **ProductKey**, **ConfirmationID**, and activation switches aren't marked as mandatory in the
-function metadata. The function performs runtime validation: both activation operations require a
+The function metadata doesn't mark the **ProductKey**, **ConfirmationID**, and activation switches
+as mandatory. The function performs runtime validation: both activation operations require a
 product key, and forest activation also requires a confirmation ID.
 
 The generated implicit-remoting wrapper adds **AsJob** to every parameter set. This wrapper
-parameter is intentionally retained even though it isn't present in the module function source.
+intentionally retains the parameter even though the module function source doesn't include it.
 
 ## RELATED LINKS
 

--- a/docset/winserver2025-ps/OSLicense/Invoke-KmsLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-KmsLicense.md
@@ -1,0 +1,272 @@
+---
+document type: cmdlet
+external help file: OSLicense-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: OSLicense
+ms.date: 09/07/2026
+PlatyPS schema version: 2024-05-01
+title: Invoke-KmsLicense
+---
+
+# Invoke-KmsLicense
+
+## SYNOPSIS
+Clears selected Key Management Service (KMS) configuration overrides.
+
+## SYNTAX
+
+### ClearServer
+
+```
+Invoke-KmsLicense [-ClearServer] [-AsJob] [<CommonParameters>]
+```
+
+### ClearPort
+
+```
+Invoke-KmsLicense [-ClearPort] [-AsJob] [<CommonParameters>]
+```
+
+### ClearDomain
+
+```
+Invoke-KmsLicense [-ClearDomain] [-AsJob] [<CommonParameters>]
+```
+
+### ClearListeningPort
+
+```
+Invoke-KmsLicense [-ClearListeningPort] [-AsJob] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Invoke-KmsLicense` cmdlet clears a manually configured KMS client or KMS host setting from the
+local software licensing service. It can clear the KMS client host name, client port, DNS lookup
+domain, or KMS host listening port. Each clearing operation uses a separate parameter set, so you
+can select only one operation per invocation.
+
+The cmdlet returns a structured result object for successful operations and CIM errors. It doesn't
+write operation status or error details to the console. For output details, see the OUTPUTS and
+NOTES sections.
+
+The cmdlet is available through an applicable Windows update. The KB number for that update is
+pending confirmation.
+
+## EXAMPLES
+
+### Example 1: Clear KMS client host and port overrides
+
+This example reviews the configured KMS client host and port, and then clears each override with a
+separate command. The `kms.example.com` host name in the sample output is fictitious. Verify the
+current settings before you clear them because the command doesn't prompt for confirmation.
+
+```powershell
+Get-KmsLicenseInfo |
+  Select-Object KeyManagementServiceMachine, KeyManagementServicePort
+```
+
+```Output
+KeyManagementServiceMachine KeyManagementServicePort
+--------------------------- ------------------------
+kms.example.com                                 1688
+```
+
+```powershell
+$serverResult = Invoke-KmsLicense -ClearServer
+$portResult = Invoke-KmsLicense -ClearPort
+$serverResult
+$portResult
+```
+
+```Output
+Success Operation
+------- ---------
+   True ClearServer
+   True ClearPort
+```
+
+Clearing the server and port overrides doesn't clear a configured KMS lookup domain.
+
+### Example 2: Clear a KMS host listening-port override and inspect the result
+
+This example clears the configured listening-port override on a KMS host and reports whether the
+operation succeeded. Before you run the command, confirm that clearing the override won't disrupt
+KMS client connectivity.
+
+```powershell
+$result = Invoke-KmsLicense -ClearListeningPort
+
+if ($result.Success) {
+  "Cleared operation: $($result.Operation)"
+} else {
+  "Clear failed: $($result.ErrorCode) $($result.ErrorMessage)"
+}
+```
+
+On success, **Operation** is `ClearListeningPort`. On failure, **ErrorCode** contains the Windows
+HRESULT when the CIM exception provides one, and **ErrorMessage** contains the Windows error text
+or the exception message.
+
+## PARAMETERS
+
+### -AsJob
+
+Runs the command as a background job when you invoke it through an implicit-remoting wrapper. This
+parameter is supplied by the wrapper and isn't declared by the local `OSLicense` module function.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ClearDomain
+
+Clears the KMS client DNS lookup domain override by calling the
+`ClearKeyManagementServiceLookupDomain` method of the local software licensing service. This
+operation doesn't clear the configured KMS client host name or port.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ClearDomain
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ClearListeningPort
+
+Clears the KMS host listening-port override by calling the
+`ClearKeyManagementServiceListeningPort` method of the local software licensing service. This
+operation doesn't disable the KMS host or clear KMS client connection settings.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ClearListeningPort
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ClearPort
+
+Clears the manually configured KMS client port override by calling the
+`ClearKeyManagementServicePort` method of the local software licensing service. This operation
+doesn't clear the configured KMS client host name or DNS lookup domain.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ClearPort
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ClearServer
+
+Clears the manually configured KMS client host name by calling the
+`ClearKeyManagementServiceMachine` method of the local software licensing service. This operation
+doesn't clear the configured KMS client port or DNS lookup domain.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ClearServer
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+## INPUTS
+
+### None
+
+This cmdlet doesn't accept pipeline input.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+When you run the cmdlet synchronously, it returns a result object after it attempts a clearing
+operation. A successful result contains **Success** set to `true` and **Operation** set to
+`ClearServer`, `ClearPort`, `ClearDomain`, or `ClearListeningPort`.
+
+If a CIM operation fails, the result contains **Success** set to `false`, **ErrorCode** set to the
+Windows HRESULT when available, and **ErrorMessage** set to the Windows error text or exception
+message. Failure results don't contain an **Operation** property.
+
+### System.Management.Automation.Job
+
+When you use **AsJob** through an implicit-remoting wrapper, the cmdlet returns a job object. Use
+`Receive-Job` to retrieve the result object from the completed job.
+
+## NOTES
+
+Run this cmdlet in an elevated PowerShell session to change machine-wide licensing settings. The
+cmdlet doesn't support **WhatIf** or **Confirm**, and it doesn't prompt before clearing a setting.
+Use `Get-KmsLicenseInfo` to review the current KMS configuration before you make a change.
+
+The clearing switches are mutually exclusive. If you invoke the underlying function without a
+clearing switch, it returns no object and makes no change. It also returns no object if the local
+`SoftwareLicensingService` CIM instance isn't available without raising a CIM error. Other CIM
+failures return the structured failure object described in OUTPUTS instead of writing to the error
+stream or throwing a terminating error to the caller.
+
+The **AsJob** parameter is an implicit-remoting wrapper feature. The underlying local
+`Invoke-KmsLicense` function doesn't declare that parameter. Objects received from the remote job
+can be deserialized representations of the result objects.
+
+## RELATED LINKS
+
+- [Slmgr.vbs options for obtaining volume activation information](/windows-server/get-started/activation-slmgr-vbs-options)
+- [Activate using Key Management Service](/windows/deployment/volume-activation/activate-using-key-management-service-vamt)
+- [Monitor activation](/windows/deployment/volume-activation/monitor-activation-client)
+- [SoftwareLicensingService class](/previous-versions/windows/desktop/sppwmi/softwarelicensingservice)

--- a/docset/winserver2025-ps/OSLicense/Invoke-KmsLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-KmsLicense.md
@@ -4,7 +4,7 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/07/2026
+ms.date: 09/09/2026
 PlatyPS schema version: 2024-05-01
 title: Invoke-KmsLicense
 ---
@@ -44,15 +44,16 @@ Invoke-KmsLicense [-ClearListeningPort] [-AsJob] [<CommonParameters>]
 
 The `Invoke-KmsLicense` cmdlet clears a manually configured KMS client or KMS host setting from the
 local software licensing service. It can clear the KMS client host name, client port, DNS lookup
-domain, or KMS host listening port. Each clearing operation uses a separate parameter set, so you
-can select only one operation per invocation.
+domain, or KMS host listening port. Each clearing operation uses a separate parameter set, so
+select only one operation per invocation.
 
 The cmdlet returns a structured result object for successful operations and CIM errors. It doesn't
 write operation status or error details to the console. For output details, see the OUTPUTS and
 NOTES sections.
 
-The cmdlet is available through an applicable Windows update. The KB number for that update is
-pending confirmation.
+> [!NOTE]
+> `Invoke-KmsLicense` is available in [Windows Server vNext Preview Build 29651](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29651/4549702)
+> and the [2026-09 security update for Windows 11 (KB5124008)](https://support.microsoft.com/help/5124008).
 
 ## EXAMPLES
 
@@ -92,7 +93,7 @@ Clearing the server and port overrides doesn't clear a configured KMS lookup dom
 ### Example 2: Clear a KMS host listening-port override and inspect the result
 
 This example clears the configured listening-port override on a KMS host and reports whether the
-operation succeeded. Before you run the command, confirm that clearing the override won't disrupt
+operation succeeds. Before you run the command, confirm that clearing the override won't disrupt
 KMS client connectivity.
 
 ```powershell
@@ -105,8 +106,8 @@ if ($result.Success) {
 }
 ```
 
-On success, **Operation** is `ClearListeningPort`. On failure, **ErrorCode** contains the Windows
-HRESULT when the CIM exception provides one, and **ErrorMessage** contains the Windows error text
+On success, **Operation** is `ClearListeningPort`. On failure, **ErrorCode** contains a Windows
+HRESULT if the CIM exception provides one, and **ErrorMessage** contains the Windows error text
 or the exception message.
 
 ## PARAMETERS
@@ -114,7 +115,7 @@ or the exception message.
 ### -AsJob
 
 Runs the command as a background job when you invoke it through an implicit-remoting wrapper. This
-parameter is supplied by the wrapper and isn't declared by the local `OSLicense` module function.
+parameter comes from the wrapper, but the local `OSLicense` module function doesn't declare it.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -235,13 +236,13 @@ This cmdlet doesn't accept pipeline input.
 
 ### System.Management.Automation.PSCustomObject
 
-When you run the cmdlet synchronously, it returns a result object after it attempts a clearing
-operation. A successful result contains **Success** set to `true` and **Operation** set to
-`ClearServer`, `ClearPort`, `ClearDomain`, or `ClearListeningPort`.
+When you run the cmdlet synchronously, it attempts a clearing operation and returns a result
+object. In a successful result, **Success** is `$true`, and **Operation** is `ClearServer`, `ClearPort`,
+`ClearDomain`, or `ClearListeningPort`.
 
-If a CIM operation fails, the result contains **Success** set to `false`, **ErrorCode** set to the
-Windows HRESULT when available, and **ErrorMessage** set to the Windows error text or exception
-message. Failure results don't contain an **Operation** property.
+If a CIM operation fails, **Success** is `$false`, **ErrorCode** contains the Windows HRESULT when
+available, and **ErrorMessage** contains the Windows error text or exception message. Failure
+results don't contain an **Operation** property.
 
 ### System.Management.Automation.Job
 
@@ -255,14 +256,14 @@ cmdlet doesn't support **WhatIf** or **Confirm**, and it doesn't prompt before c
 Use `Get-KmsLicenseInfo` to review the current KMS configuration before you make a change.
 
 The clearing switches are mutually exclusive. If you invoke the underlying function without a
-clearing switch, it returns no object and makes no change. It also returns no object if the local
-`SoftwareLicensingService` CIM instance isn't available without raising a CIM error. Other CIM
-failures return the structured failure object described in OUTPUTS instead of writing to the error
-stream or throwing a terminating error to the caller.
+clearing switch, it returns no object and makes no change. The function also returns no object and
+doesn't raise a CIM error if the local **SoftwareLicensingService** CIM instance isn't available. For
+other CIM failures, the function returns the structured failure object that the OUTPUTS section
+describes instead of writing to the error stream or throwing a terminating error to the caller.
 
 The **AsJob** parameter is an implicit-remoting wrapper feature. The underlying local
-`Invoke-KmsLicense` function doesn't declare that parameter. Objects received from the remote job
-can be deserialized representations of the result objects.
+`Invoke-KmsLicense` function doesn't declare that parameter.
+The remote job can return deserialized representations of the result objects.
 
 ## RELATED LINKS
 

--- a/docset/winserver2025-ps/OSLicense/Invoke-OSLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-OSLicense.md
@@ -1,0 +1,588 @@
+---
+document type: cmdlet
+external help file: OSLicense-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: OSLicense
+ms.date: 09/07/2026
+PlatyPS schema version: 2024-05-01
+title: Invoke-OSLicense
+---
+
+# Invoke-OSLicense
+
+## SYNOPSIS
+Performs a selected Windows operating system licensing operation.
+
+## SYNTAX
+
+### None
+
+```
+Invoke-OSLicense [-AsJob] [<CommonParameters>]
+```
+
+### ClearKey
+
+```
+Invoke-OSLicense [-ClearProductKeyFromRegistry] [-AsJob] [<CommonParameters>]
+```
+
+### InstallKey
+
+```
+Invoke-OSLicense [-InstallProductKey <String>] [-AsJob] [<CommonParameters>]
+```
+
+### InstallLicense
+
+```
+Invoke-OSLicense [-InstallLicenseFile <String>] [-AsJob] [<CommonParameters>]
+```
+
+### ReinstallLicenses
+
+```
+Invoke-OSLicense [-ReinstallSystemLicenses] [-AsJob] [<CommonParameters>]
+```
+
+### Rearm
+
+```
+Invoke-OSLicense [-Rearm] [-RearmID <String>] [-AsJob] [<CommonParameters>]
+```
+
+### UninstallKey
+
+```
+Invoke-OSLicense [-UninstallProductKey] [-ActivationID <String>] [-AsJob]
+ [<CommonParameters>]
+```
+
+### ActivateOnline
+
+```
+Invoke-OSLicense [-ActivateOnline] [-ActivationID <String>] [-AsJob]
+ [<CommonParameters>]
+```
+
+### ActivateOffline
+
+```
+Invoke-OSLicense [-ActivateOffline <String>] [-ConfirmationID <String>] [-AsJob]
+ [<CommonParameters>]
+```
+
+### ActivateToken
+
+```
+Invoke-OSLicense [-TokenCertThumbprint <String>] [-TokenPIN <String>] [-AsJob]
+ [<CommonParameters>]
+```
+
+### RemoveToken
+
+```
+Invoke-OSLicense [-ILID <String>] [-ILvID <Int32>] [-AsJob] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Invoke-OSLicense` performs one state-changing Windows licensing operation on the local computer.
+The operation parameter that you provide selects a parameter set and the corresponding licensing
+operation. For example, **InstallProductKey** selects product-key installation, and
+**ReinstallSystemLicenses** selects system-license reinstallation. If you don't provide an operation
+parameter, the command returns no output and doesn't perform an operation.
+
+For online activation and product-key removal, you can provide **ActivationID** to target a specific
+licensing product. If you omit **ActivationID**, the command selects the first primary Windows
+product that has a partial product key and isn't an add-on product. For rearm operations, omit
+**RearmID** to rearm Windows. Provide **RearmID** to target a licensing SKU by activation ID or an
+application by application ID.
+
+Offline activation requires **ConfirmationID**. You can also provide **ActivateOffline** with an
+activation ID or offline installation ID. If you provide only **ConfirmationID**, the command
+selects the first primary Windows product that has a partial product key and an offline
+installation ID. Token activation requires **TokenCertThumbprint** and can include **TokenPIN**.
+Token-license removal requires both **ILID** and **ILvID**.
+
+Direct operations return structured objects instead of status text. Successful results contain
+**Success**, **Operation**, and operation-specific properties. Caught failures return **Success**
+set to `false`, **Operation**, **ErrorCode**, and **ErrorMessage**. When available, **ErrorCode**
+contains the Windows HRESULT reported by the CIM operation. An online or offline activation
+failure after product resolution also includes **ActivationID** and **ProductName**.
+
+The applicable Windows update KB number is pending confirmation.
+
+## EXAMPLES
+
+### Example 1: Install a product key and inspect the result
+
+Caution: This example changes the product key on the local computer. It uses a fictitious key that
+you must replace with an authorized key. Run state-changing licensing operations only from an
+elevated PowerShell session and validate the command in a nonproduction environment first.
+
+```powershell
+$result = Invoke-OSLicense -InstallProductKey 'AAAAA-BBBBB-CCCCC-DDDDD-EEEEE'
+$result | Select-Object Success, Operation, ErrorCode, ErrorMessage
+```
+
+This example shows how to select the product-key installation operation and inspect the common
+result properties. The command doesn't claim that the fictitious key is valid or that activation
+succeeds.
+
+### Example 2: Activate a specific product online and inspect the result
+
+Caution: Online activation contacts the activation service and can change licensing state. The
+activation ID in this example is fictitious. Replace it with the intended product's activation ID
+only after you verify the target.
+
+```powershell
+$activationParameters = @{
+  ActivateOnline = $true
+  ActivationID   = '00000000-0000-0000-0000-000000000000'
+}
+$result = Invoke-OSLicense @activationParameters
+$result |
+  Select-Object Success, Operation, ActivationID, ProductName, ErrorCode, ErrorMessage
+```
+
+This example shows how to select online activation, target a product explicitly, and inspect both
+success and error properties. It doesn't claim that the fictitious activation ID resolves or that
+the operation succeeds.
+
+## PARAMETERS
+
+### -ActivateOffline
+
+Specifies the activation ID or offline installation ID of the product to activate offline. If you
+omit this parameter and provide **ConfirmationID**, the command selects the first primary Windows
+product that has a partial product key and an offline installation ID.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivateOffline
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ActivateOnline
+
+Selects online activation. Use **ActivationID** to target a specific licensing product. If you omit
+**ActivationID**, the command selects the first primary Windows product that has a partial product
+key and isn't an add-on product.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivateOnline
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ActivationID
+
+Specifies the activation ID of a licensing product for online activation or product-key removal.
+If you omit this parameter, the command selects the first primary Windows product that has a partial
+product key and isn't an add-on product.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivateOnline
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: UninstallKey
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -AsJob
+
+Runs the command as a background job when you invoke the module through an implicit-remoting
+wrapper. The target `Invoke-OSLicense` function doesn't declare this parameter; the generated
+implicit-remoting wrapper adds it. Use `Receive-Job` to retrieve the operation result.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ClearProductKeyFromRegistry
+
+Selects the operation that removes the product key from the registry. This operation doesn't
+uninstall the product key from the licensing product.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ClearKey
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ConfirmationID
+
+Specifies the confirmation ID to deposit for offline activation. A successful offline activation
+operation requires this parameter. If you omit **ActivateOffline**, the command attempts to select
+the first primary Windows product that has a partial product key and an offline installation ID.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivateOffline
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ILID
+
+Specifies the installation license ID of the token-based license to remove. Provide **ILvID** with
+this parameter. If either value is missing, the command doesn't perform the removal operation.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: RemoveToken
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ILvID
+
+Specifies the version ID of the token-based license to remove. Provide **ILID** with this parameter.
+If either value is missing, the command doesn't perform the removal operation.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: RemoveToken
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -InstallLicenseFile
+
+Specifies the path of an `.xrm-ms` license file to install. The command reads the complete file and
+passes its contents to the licensing service. An invalid or inaccessible path produces a structured
+failure result.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: InstallLicense
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -InstallProductKey
+
+Specifies the product key to install. The direct result object includes the supplied value in its
+**ProductKey** property. Don't write that property to logs or other locations that unauthorized
+users can access.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: InstallKey
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Rearm
+
+Selects a rearm operation. If you omit **RearmID**, the command rearms Windows. Use **RearmID** to
+target a licensing SKU or application. The success result sets **RestartRequired** to `true`.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Rearm
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RearmID
+
+Specifies an activation ID for a licensing SKU or an application ID for an application-level rearm.
+The command first searches for a licensing product whose activation ID matches the value. If it
+doesn't find a product, it passes the value to the application-level rearm operation.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Rearm
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ReinstallSystemLicenses
+
+Selects the operation that reinstalls `.xrm-ms` files from the Windows system licensing-token and
+OEM directories. The command continues after an individual file fails and reports installed and
+failed file counts and paths in the result object.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ReinstallLicenses
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TokenCertThumbprint
+
+Specifies the thumbprint of a certificate in the local computer certificate store for token-based
+activation. The certificate must include an RSA private key, and its certificate chain must build
+successfully. This parameter selects token activation; **TokenPIN** alone doesn't select an
+operation.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivateToken
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TokenPIN
+
+Specifies the optional PIN for token-based activation. Provide **TokenCertThumbprint** to select the
+token activation operation. Avoid including the PIN in command history or logs.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ActivateToken
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -UninstallProductKey
+
+Selects the operation that uninstalls a product key from a licensing product. Use **ActivationID**
+to target a specific product. If you omit **ActivationID**, the command selects the first primary
+Windows product that has a partial product key and isn't an add-on product.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: UninstallKey
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+## INPUTS
+
+### None
+
+You can't pipe objects to this cmdlet.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+A direct operation returns a structured result object. Every operation result includes **Success**
+and **Operation**. Successful operations can also include these properties:
+
+- Product-key installation: **ProductKey**.
+- License-file installation: **LicenseFile**.
+- System-license reinstallation: **LicensesInstalled**, **LicensesFailed**, **InstalledFiles**, and
+  **FailedFiles**. **Success** is `true` only when no individual license file fails.
+- Rearm: **Target** and **RestartRequired**.
+- Product-key removal: **ActivationID**.
+- Online activation: **ActivationID** and **ProductName**.
+- Offline activation: **ActivationID**, **ProductName**, and **ConfirmationID**.
+- Token activation: **CertificateThumbprint**.
+- Token-license removal: **ILID** and **ILvID**.
+
+A caught failure returns **Success** set to `false`, **Operation**, **ErrorCode**, and
+**ErrorMessage**. **ErrorCode** is a hexadecimal Windows HRESULT when the CIM exception provides
+one; otherwise, its value is `null`. If an online or offline activation operation resolved a
+product before the failure, the object also includes **ActivationID** and **ProductName**.
+
+The command returns no object when you don't select an operation or when you provide an incomplete
+token-license removal combination that doesn't reach the operation.
+
+### System.Management.Automation.Job
+
+When you use **AsJob** through an implicit-remoting wrapper, the command returns a background job.
+Use `Receive-Job` to retrieve the structured operation result from the job.
+
+## NOTES
+
+Run this cmdlet from an elevated PowerShell session. Its operations can change the product key,
+activation state, installed license files, token licenses, or rearm state of the local computer.
+Confirm the target and back up any required licensing information before you run an operation.
+
+The operation parameters aren't declared mandatory in the target function. Therefore, PowerShell
+can bind a parameter set even when the selector needed to perform that operation is absent. In
+particular, token activation requires **TokenCertThumbprint**, token-license removal requires both
+**ILID** and **ILvID**, and offline activation requires **ConfirmationID**.
+
+After product-key installation, product-key removal, and activation operations, the command requests
+a best-effort licensing-status refresh. A refresh failure doesn't replace the result of the primary
+operation. System-license reinstallation continues across individual file failures and reports the
+aggregate result. A successful rearm result indicates that a restart is required.
+
+The direct function catches operation errors and returns them as structured objects. Inspect
+**Success**, **ErrorCode**, and **ErrorMessage** instead of relying on console output. Protect
+product keys and token PINs from command history, transcripts, logs, and other unauthorized
+disclosure.
+
+## RELATED LINKS
+
+- [Slmgr.vbs options for obtaining volume activation information](/windows-server/get-started/activation-slmgr-vbs-options)
+- [Activate using Key Management Service](/windows/deployment/volume-activation/activate-using-key-management-service-vamt)
+- [Monitor activation](/windows/deployment/volume-activation/monitor-activation-client)

--- a/docset/winserver2025-ps/OSLicense/Invoke-OSLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-OSLicense.md
@@ -4,7 +4,7 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/07/2026
+ms.date: 09/09/2026
 PlatyPS schema version: 2024-05-01
 title: Invoke-OSLicense
 ---
@@ -94,25 +94,27 @@ operation. For example, **InstallProductKey** selects product-key installation, 
 **ReinstallSystemLicenses** selects system-license reinstallation. If you don't provide an operation
 parameter, the command returns no output and doesn't perform an operation.
 
-For online activation and product-key removal, you can provide **ActivationID** to target a specific
+For online activation and product-key removal, provide **ActivationID** to target a specific
 licensing product. If you omit **ActivationID**, the command selects the first primary Windows
 product that has a partial product key and isn't an add-on product. For rearm operations, omit
 **RearmID** to rearm Windows. Provide **RearmID** to target a licensing SKU by activation ID or an
 application by application ID.
 
-Offline activation requires **ConfirmationID**. You can also provide **ActivateOffline** with an
-activation ID or offline installation ID. If you provide only **ConfirmationID**, the command
+Offline activation requires **ConfirmationID**. To use an activation ID or offline installation ID,
+provide **ActivateOffline**. If you provide only **ConfirmationID**, the command
 selects the first primary Windows product that has a partial product key and an offline
-installation ID. Token activation requires **TokenCertThumbprint** and can include **TokenPIN**.
+installation ID. Token activation requires **TokenCertThumbprint**. **TokenPIN** is optional.
 Token-license removal requires both **ILID** and **ILvID**.
 
 Direct operations return structured objects instead of status text. Successful results contain
 **Success**, **Operation**, and operation-specific properties. Caught failures return **Success**
-set to `false`, **Operation**, **ErrorCode**, and **ErrorMessage**. When available, **ErrorCode**
+as `$false`, **Operation**, **ErrorCode**, and **ErrorMessage**. When available, **ErrorCode**
 contains the Windows HRESULT reported by the CIM operation. An online or offline activation
 failure after product resolution also includes **ActivationID** and **ProductName**.
 
-The applicable Windows update KB number is pending confirmation.
+> [!NOTE]
+> `Invoke-OSLicense` is available in [Windows Server vNext Preview Build 29651](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29651/4549702)
+> and the [2026-09 security update for Windows 11 (KB5124008)](https://support.microsoft.com/help/5124008).
 
 ## EXAMPLES
 
@@ -127,8 +129,8 @@ $result = Invoke-OSLicense -InstallProductKey 'AAAAA-BBBBB-CCCCC-DDDDD-EEEEE'
 $result | Select-Object Success, Operation, ErrorCode, ErrorMessage
 ```
 
-This example shows how to select the product-key installation operation and inspect the common
-result properties. The command doesn't claim that the fictitious key is valid or that activation
+The first command requests product-key installation. The second command displays the common result
+properties. The example doesn't indicate that the fictitious key is valid or that activation
 succeeds.
 
 ### Example 2: Activate a specific product online and inspect the result
@@ -147,9 +149,9 @@ $result |
   Select-Object Success, Operation, ActivationID, ProductName, ErrorCode, ErrorMessage
 ```
 
-This example shows how to select online activation, target a product explicitly, and inspect both
-success and error properties. It doesn't claim that the fictitious activation ID resolves or that
-the operation succeeds.
+The first command requests online activation for a specific product. The second command displays
+the success and error properties. The example doesn't indicate that the fictitious activation ID
+resolves or that the operation succeeds.
 
 ## PARAMETERS
 
@@ -389,7 +391,7 @@ HelpMessage: ''
 ### -Rearm
 
 Selects a rearm operation. If you omit **RearmID**, the command rearms Windows. Use **RearmID** to
-target a licensing SKU or application. The success result sets **RestartRequired** to `true`.
+target a licensing SKU or application. A successful operation sets **RestartRequired** to `$true`.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -434,8 +436,8 @@ HelpMessage: ''
 ### -ReinstallSystemLicenses
 
 Selects the operation that reinstalls `.xrm-ms` files from the Windows system licensing-token and
-OEM directories. The command continues after an individual file fails and reports installed and
-failed file counts and paths in the result object.
+OEM directories. The command continues after a file fails and reports counts and paths for
+installed and failed files in the result object.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -534,12 +536,12 @@ You can't pipe objects to this cmdlet.
 ### System.Management.Automation.PSCustomObject
 
 A direct operation returns a structured result object. Every operation result includes **Success**
-and **Operation**. Successful operations can also include these properties:
+and **Operation**. Successful results include additional properties that depend on the operation:
 
 - Product-key installation: **ProductKey**.
 - License-file installation: **LicenseFile**.
 - System-license reinstallation: **LicensesInstalled**, **LicensesFailed**, **InstalledFiles**, and
-  **FailedFiles**. **Success** is `true` only when no individual license file fails.
+  **FailedFiles**. **Success** is `$true` only when no individual license file fails.
 - Rearm: **Target** and **RestartRequired**.
 - Product-key removal: **ActivationID**.
 - Online activation: **ActivationID** and **ProductName**.
@@ -547,10 +549,11 @@ and **Operation**. Successful operations can also include these properties:
 - Token activation: **CertificateThumbprint**.
 - Token-license removal: **ILID** and **ILvID**.
 
-A caught failure returns **Success** set to `false`, **Operation**, **ErrorCode**, and
-**ErrorMessage**. **ErrorCode** is a hexadecimal Windows HRESULT when the CIM exception provides
-one; otherwise, its value is `null`. If an online or offline activation operation resolved a
-product before the failure, the object also includes **ActivationID** and **ProductName**.
+When the cmdlet catches a failure, it returns a result where **Success** is `$false`. The result
+also includes **Operation**, **ErrorCode**, and **ErrorMessage**. **ErrorCode** is a hexadecimal
+Windows HRESULT when the CIM exception provides one; otherwise, its value is `$null`. If an online
+or offline activation operation resolved a product before the failure, the object also includes
+**ActivationID** and **ProductName**.
 
 The command returns no object when you don't select an operation or when you provide an incomplete
 token-license removal combination that doesn't reach the operation.
@@ -566,15 +569,15 @@ Run this cmdlet from an elevated PowerShell session. Its operations can change t
 activation state, installed license files, token licenses, or rearm state of the local computer.
 Confirm the target and back up any required licensing information before you run an operation.
 
-The operation parameters aren't declared mandatory in the target function. Therefore, PowerShell
-can bind a parameter set even when the selector needed to perform that operation is absent. In
+The target function doesn't declare the operation parameters as mandatory. Therefore, PowerShell
+might bind a parameter set even when you omit the selector that the operation needs. In
 particular, token activation requires **TokenCertThumbprint**, token-license removal requires both
 **ILID** and **ILvID**, and offline activation requires **ConfirmationID**.
 
 After product-key installation, product-key removal, and activation operations, the command requests
 a best-effort licensing-status refresh. A refresh failure doesn't replace the result of the primary
 operation. System-license reinstallation continues across individual file failures and reports the
-aggregate result. A successful rearm result indicates that a restart is required.
+aggregate result. A successful rearm result indicates that you must restart the computer.
 
 The direct function catches operation errors and returns them as structured objects. Inspect
 **Success**, **ErrorCode**, and **ErrorMessage** instead of relying on console output. Protect

--- a/docset/winserver2025-ps/OSLicense/Invoke-SubscriptionLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-SubscriptionLicense.md
@@ -1,0 +1,225 @@
+---
+document type: cmdlet
+external help file: OSLicense-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: OSLicense
+ms.date: 09/07/2026
+PlatyPS schema version: 2024-05-01
+title: Invoke-SubscriptionLicense
+---
+
+# Invoke-SubscriptionLicense
+
+## SYNOPSIS
+Invokes a Windows subscription licensing operation.
+
+## SYNTAX
+
+### Remove
+
+```
+Invoke-SubscriptionLicense [-Remove] [-AsJob] [<CommonParameters>]
+```
+
+### Refresh
+
+```
+Invoke-SubscriptionLicense [-Refresh] [-AsJob] [<CommonParameters>]
+```
+
+### Acquire
+
+```
+Invoke-SubscriptionLicense [-Acquire] [-AsJob] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Invoke-SubscriptionLicense` invokes a Windows subscription licensing operation on the local
+computer. Select **Remove**, **Refresh**, or **Acquire**. The function reads the
+**SubscriptionType** property from the `SoftwareLicensingService` CIM class and uses the matching
+entry in its internal tool map.
+
+For subscription type `0`, the source maps **Remove** to `removesubscription` and **Refresh** to
+`refreshsubscription`. It maps **Acquire** to `$null`. Every helper call includes `noshow`, so the
+current **Acquire** path starts `%SystemRoot%\System32\ClipRenew.exe` with only `noshow`. The source
+doesn't establish an acquisition command for this configuration.
+
+The cmdlet discards native tool output and catches all errors. It returns a success object only
+when the native tool exits with code `0`. It returns no object when no operation is selected or
+when configuration lookup, tool startup, or the requested operation fails.
+
+The cmdlet is available through an applicable Windows update. The KB number for that update is
+pending confirmation.
+
+## EXAMPLES
+
+### Example 1: Request a subscription license refresh
+
+This example shows a refresh request and checks for the `$null` result that the cmdlet uses for
+failures. Automation shouldn't treat the absence of an error record as proof of success.
+
+```powershell
+$result = Invoke-SubscriptionLicense -Refresh
+
+if ($null -eq $result) {
+    Write-Warning 'The refresh did not return a success result.'
+    return
+}
+
+$result | Select-Object Success, Operation
+```
+
+A non-null result has **Success** set to `$true` and **Operation** set to
+`RefreshSubscription`.
+
+### Example 2: Remove a subscription license
+
+The following command shows the syntax for removing the subscription license from the device.
+
+> [!CAUTION]
+> The function doesn't implement `SupportsShouldProcess`, so `-WhatIf` and `-Confirm` aren't
+> available. Use **Remove** only after you assess the device's licensing requirements and have a
+> recovery plan.
+
+```powershell
+Invoke-SubscriptionLicense -Remove
+```
+
+## PARAMETERS
+
+### -Acquire
+
+Selects the acquire operation. For subscription type `0`, the current tool map sets the acquire
+command to `$null`. The helper therefore starts `ClipRenew.exe` with only the `noshow` argument.
+The source doesn't establish that this invocation requests a new subscription license.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Acquire
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -AsJob
+
+Runs the command as a background job when you invoke it through an implicit-remoting wrapper. This
+parameter is supplied by the wrapper and isn't declared by the local `OSLicense` module function.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Refresh
+
+Requests a subscription license refresh. For subscription type `0`, the cmdlet passes
+`refreshsubscription noshow` to `ClipRenew.exe`.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Refresh
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Remove
+
+Removes the subscription license. For subscription type `0`, the cmdlet passes
+`removesubscription noshow` to `ClipRenew.exe`.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Remove
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+## INPUTS
+
+### None
+
+This cmdlet doesn't accept pipeline input.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+When the native tool exits with code `0`, the cmdlet returns an object with **Success** set to
+`$true`. The **Operation** value is `RemoveSubscription`, `RefreshSubscription`, or
+`AcquireSubscription`, based on the selected operation.
+
+The cmdlet returns no object when no operation is selected, the subscription type isn't supported,
+the native tool isn't present, the native tool exits with a nonzero code, or another caught error
+occurs.
+
+### System.Management.Automation.Job
+
+When you use **AsJob** through an implicit-remoting wrapper, the cmdlet returns a job object. Use
+`Receive-Job` to retrieve the operation result after the job completes.
+
+## NOTES
+
+Run this cmdlet from an elevated PowerShell session. The operations change subscription licensing
+state on the target device.
+
+The current source defines a tool mapping only for subscription type `0`. An unsupported
+**SubscriptionType** value causes the configuration lookup to fail, and the cmdlet catches that
+failure and returns no object.
+
+The native tool's standard output is discarded. The cmdlet uses only the process exit code to
+decide whether to return a success object. It doesn't return an error object or write an error
+record when an operation fails.
+
+The current **Acquire** mapping is `$null`. Until the implementation defines an acquisition
+command, don't interpret an `AcquireSubscription` success object as evidence that the source
+requested acquisition through a named `ClipRenew.exe` command.
+
+## RELATED LINKS
+
+- [Windows subscription activation](/windows/deployment/windows-subscription-activation)
+- [SoftwareLicensingService class](/previous-versions/windows/desktop/sppwmi/softwarelicensingservice)
+- [about_Remote_Jobs](/powershell/module/microsoft.powershell.core/about/about_remote_jobs)

--- a/docset/winserver2025-ps/OSLicense/Invoke-SubscriptionLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-SubscriptionLicense.md
@@ -4,7 +4,7 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/07/2026
+ms.date: 09/09/2026
 PlatyPS schema version: 2024-05-01
 title: Invoke-SubscriptionLicense
 ---
@@ -38,7 +38,7 @@ Invoke-SubscriptionLicense [-Acquire] [-AsJob] [<CommonParameters>]
 
 `Invoke-SubscriptionLicense` invokes a Windows subscription licensing operation on the local
 computer. Select **Remove**, **Refresh**, or **Acquire**. The function reads the
-**SubscriptionType** property from the `SoftwareLicensingService` CIM class and uses the matching
+**SubscriptionType** property from the **SoftwareLicensingService** CIM class and uses the matching
 entry in its internal tool map.
 
 For subscription type `0`, the source maps **Remove** to `removesubscription` and **Refresh** to
@@ -47,18 +47,19 @@ current **Acquire** path starts `%SystemRoot%\System32\ClipRenew.exe` with only 
 doesn't establish an acquisition command for this configuration.
 
 The cmdlet discards native tool output and catches all errors. It returns a success object only
-when the native tool exits with code `0`. It returns no object when no operation is selected or
-when configuration lookup, tool startup, or the requested operation fails.
+if the native tool exits with code `0`. It returns no object if you don't select an operation or
+if configuration lookup, tool startup, or the requested operation fails.
 
-The cmdlet is available through an applicable Windows update. The KB number for that update is
-pending confirmation.
+> [!NOTE]
+> `Invoke-SubscriptionLicense` is available in [Windows Server vNext Preview Build 29651](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29651/4549702)
+> and the [2026-09 security update for Windows 11 (KB5124008)](https://support.microsoft.com/help/5124008).
 
 ## EXAMPLES
 
 ### Example 1: Request a subscription license refresh
 
-This example shows a refresh request and checks for the `$null` result that the cmdlet uses for
-failures. Automation shouldn't treat the absence of an error record as proof of success.
+This example requests a refresh and checks whether the cmdlet returns `$null` for a failure. Don't
+treat the absence of an error record as proof of success.
 
 ```powershell
 $result = Invoke-SubscriptionLicense -Refresh
@@ -71,12 +72,11 @@ if ($null -eq $result) {
 $result | Select-Object Success, Operation
 ```
 
-A non-null result has **Success** set to `$true` and **Operation** set to
-`RefreshSubscription`.
+For a non-null result, **Success** is `$true`, and **Operation** is `RefreshSubscription`.
 
 ### Example 2: Remove a subscription license
 
-The following command shows the syntax for removing the subscription license from the device.
+The following command removes the subscription license from the device.
 
 > [!CAUTION]
 > The function doesn't implement `SupportsShouldProcess`, so `-WhatIf` and `-Confirm` aren't
@@ -115,7 +115,7 @@ HelpMessage: ''
 ### -AsJob
 
 Runs the command as a background job when you invoke it through an implicit-remoting wrapper. This
-parameter is supplied by the wrapper and isn't declared by the local `OSLicense` module function.
+wrapper supplies this parameter, but the local `OSLicense` module function doesn't declare it.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -210,9 +210,9 @@ The current source defines a tool mapping only for subscription type `0`. An uns
 **SubscriptionType** value causes the configuration lookup to fail, and the cmdlet catches that
 failure and returns no object.
 
-The native tool's standard output is discarded. The cmdlet uses only the process exit code to
-decide whether to return a success object. It doesn't return an error object or write an error
-record when an operation fails.
+The cmdlet discards the native tool's standard output and uses only the process exit code to decide
+whether to return a success object. It doesn't return an error object or write an error record when
+an operation fails.
 
 The current **Acquire** mapping is `$null`. Until the implementation defines an acquisition
 command, don't interpret an `AcquireSubscription` success object as evidence that the source

--- a/docset/winserver2025-ps/OSLicense/OSLicense.md
+++ b/docset/winserver2025-ps/OSLicense/OSLicense.md
@@ -1,0 +1,61 @@
+---
+document type: module
+Help Version: 1.0.0.0
+HelpInfoUri:
+Locale: en-US
+Module Guid: b3e5a5c8-7d2f-4e1a-9c3b-8f6d4a2e1b0c
+Module Name: OSLicense
+ms.date: 09/07/2026
+PlatyPS schema version: 2024-05-01
+title: OSLicense Module
+---
+
+# OSLicense Module
+
+## Description
+
+The OSLicense module provides commands for managing Windows operating system licensing. You can
+use the module to retrieve licensing information, configure activation, and perform operating
+system, Active Directory-based, Key Management Service (KMS), and subscription licensing
+operations.
+
+The module requires Windows PowerShell 5.1 and is installed with Windows on supported systems. The
+applicable Windows update KB number for module availability is pending confirmation.
+
+## OSLicense
+
+### [Get-ADLicenseInfo](Get-ADLicenseInfo.md)
+
+Gets Active Directory-based activation information.
+
+### [Get-OSLicenseInfo](Get-OSLicenseInfo.md)
+
+Gets Windows operating system licensing information.
+
+### [Invoke-ADLicense](Invoke-ADLicense.md)
+
+Performs Active Directory-based activation operations.
+
+### [Invoke-KmsLicense](Invoke-KmsLicense.md)
+
+Clears Key Management Service (KMS) licensing configuration.
+
+### [Invoke-OSLicense](Invoke-OSLicense.md)
+
+Performs Windows operating system product key, activation, and license management operations.
+
+### [Invoke-SubscriptionLicense](Invoke-SubscriptionLicense.md)
+
+Performs Windows subscription license refresh and removal operations.
+
+### [Set-KmsLicenseInfo](Set-KmsLicenseInfo.md)
+
+Configures Key Management Service (KMS) licensing settings.
+
+### [Set-OSLicenseInfo](Set-OSLicenseInfo.md)
+
+Sets the Windows operating system license activation type.
+
+### [Set-SubscriptionLicenseInfo](Set-SubscriptionLicenseInfo.md)
+
+Enables or disables Windows subscription licensing.

--- a/docset/winserver2025-ps/OSLicense/OSLicense.md
+++ b/docset/winserver2025-ps/OSLicense/OSLicense.md
@@ -5,7 +5,7 @@ HelpInfoUri:
 Locale: en-US
 Module Guid: b3e5a5c8-7d2f-4e1a-9c3b-8f6d4a2e1b0c
 Module Name: OSLicense
-ms.date: 09/07/2026
+ms.date: 09/09/2026
 PlatyPS schema version: 2024-05-01
 title: OSLicense Module
 ---
@@ -14,13 +14,12 @@ title: OSLicense Module
 
 ## Description
 
-The OSLicense module provides commands for managing Windows operating system licensing. You can
-use the module to retrieve licensing information, configure activation, and perform operating
-system, Active Directory-based, Key Management Service (KMS), and subscription licensing
-operations.
+The `OSLicense` module provides commands to retrieve Windows licensing information, configure
+activation, and manage operating system, Active Directory-based, Key Management Service (KMS),
+and subscription licensing.
 
-The module requires Windows PowerShell 5.1 and is installed with Windows on supported systems. The
-applicable Windows update KB number for module availability is pending confirmation.
+The module requires Windows PowerShell 5.1. Windows includes it on supported systems. The applicable
+Windows update KB number for module availability still needs confirmation.
 
 ## OSLicense
 
@@ -34,7 +33,7 @@ Gets Windows operating system licensing information.
 
 ### [Invoke-ADLicense](Invoke-ADLicense.md)
 
-Performs Active Directory-based activation operations.
+Manages Active Directory-based activation.
 
 ### [Invoke-KmsLicense](Invoke-KmsLicense.md)
 
@@ -42,11 +41,11 @@ Clears Key Management Service (KMS) licensing configuration.
 
 ### [Invoke-OSLicense](Invoke-OSLicense.md)
 
-Performs Windows operating system product key, activation, and license management operations.
+Manages Windows operating system product keys, activation, and licenses.
 
 ### [Invoke-SubscriptionLicense](Invoke-SubscriptionLicense.md)
 
-Performs Windows subscription license refresh and removal operations.
+Refreshes or removes Windows subscription licenses.
 
 ### [Set-KmsLicenseInfo](Set-KmsLicenseInfo.md)
 

--- a/docset/winserver2025-ps/OSLicense/Set-KmsLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Set-KmsLicenseInfo.md
@@ -1,0 +1,356 @@
+---
+document type: cmdlet
+external help file: OSLicense-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: OSLicense
+ms.date: 09/07/2026
+PlatyPS schema version: 2024-05-01
+title: Set-KmsLicenseInfo
+---
+
+# Set-KmsLicenseInfo
+
+## SYNOPSIS
+Sets Key Management Services (KMS) license configuration.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Set-KmsLicenseInfo [[-ServerName] <String>] [[-Port] <Int32>] [[-Domain] <String>]
+ [[-ActivationInterval] <Int32>] [[-RenewalInterval] <Int32>]
+ [[-ListeningPort] <Int32>] [[-Priority] <String>] [[-DnsPublishing] <Boolean>]
+ [[-HostCaching] <Boolean>] [-AsJob] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Set-KmsLicenseInfo` cmdlet changes Key Management Services (KMS) client and host settings on
+the local computer. Specify only the settings that you want to change. Settings for omitted
+parameters remain unchanged.
+
+The cmdlet returns a structured object that indicates whether the operation succeeded. When an
+operation fails, the object includes the available Windows error code and error message instead of
+writing an error to the console.
+
+The applicable Windows update KB number that makes this cmdlet available is pending confirmation.
+
+## EXAMPLES
+
+### Example 1: Configure a specific KMS host
+
+This command configures the local KMS client to contact the fictitious host `kms01.example.com` on
+TCP port `1688`. Setting a specific host disables KMS host autodiscovery. This command changes the
+local computer's licensing configuration, so confirm the host name and port before you run it.
+
+```powershell
+Set-KmsLicenseInfo -ServerName 'kms01.example.com' -Port 1688
+```
+
+The returned object has a **Success** property that indicates whether the licensing service applied
+the configuration.
+
+### Example 2: Configure KMS host behavior
+
+This command configures a KMS host to publish its DNS record, use normal priority, and listen on TCP
+port `1688`. It also provides activation and renewal intervals to clients. The interval values are
+in minutes.
+Changing these settings can affect KMS discovery and activation across the environment, so review
+the values before you run the command.
+
+```powershell
+$kmsConfiguration = @{
+  DnsPublishing    = $true
+  Priority         = 'Normal'
+  ListeningPort    = 1688
+  ActivationInterval = 120
+  RenewalInterval  = 10080
+}
+
+Set-KmsLicenseInfo @kmsConfiguration
+```
+
+The KMS default activation interval is `120` minutes, and the default renewal interval is `10080`
+minutes (seven days).
+
+## PARAMETERS
+
+### -ActivationInterval
+
+Specifies, in minutes, how often unactivated KMS clients try to connect to a KMS host. KMS supports
+values from `15` through `43200` minutes (30 days), and the default is `120` minutes (two hours).
+
+The cmdlet doesn't define a range-validation attribute for this parameter. The licensing service
+validates the value and returns failure details in the result object when it rejects a value. If you
+omit this parameter, the current setting remains unchanged.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 3
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -AsJob
+
+Runs the command as a background job. The command returns a job object that you can use with the
+PowerShell job cmdlets. This parameter is provided by the implicit remoting proxy.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -DnsPublishing
+
+Specifies whether the KMS host publishes its service resource (SRV) record in Domain Name System
+(DNS). Specify `$true` to enable publishing or `$false` to disable it. DNS publishing is enabled by
+default for a KMS host. If you omit this parameter, the current setting remains unchanged.
+
+```yaml
+Type: System.Boolean
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 7
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Domain
+
+Specifies the DNS domain in which the KMS client searches for KMS SRV records. This setting has no
+effect when a specific KMS host is configured with **ServerName**. If you omit this parameter, the
+current setting remains unchanged.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 2
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -HostCaching
+
+Specifies whether a KMS client caches a discovered KMS host. Specify `$true` to enable caching or
+`$false` to disable it. Host caching is enabled by default. If you omit this parameter, the current
+setting remains unchanged.
+
+```yaml
+Type: System.Boolean
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 8
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ListeningPort
+
+Specifies the TCP port on which a KMS host listens for client activation requests. The KMS default
+listening port is `1688`. The cmdlet doesn't define a range-validation attribute for this parameter;
+the licensing service validates the value. If you omit this parameter, the current setting remains
+unchanged.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 5
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Port
+
+Specifies the TCP port that the KMS client uses to contact the KMS host specified by **ServerName**.
+The KMS default port is `1688`. The cmdlet doesn't define a range-validation attribute for this
+parameter; the licensing service validates the value. If you omit this parameter, the current
+setting remains unchanged.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 1
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Priority
+
+Specifies the process priority for the KMS host. The default is `Normal`. Use `Low` with care
+because other active applications or server roles can prevent a low-priority KMS host from
+responding in a timely manner. If you omit this parameter, the current setting remains unchanged.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 6
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues:
+- Normal
+- Low
+HelpMessage: ''
+```
+
+### -RenewalInterval
+
+Specifies, in minutes, how often activated KMS clients try to renew their activation. KMS supports
+values from `15` through `43200` minutes (30 days), and the default is `10080` minutes (seven days).
+
+The cmdlet doesn't define a range-validation attribute for this parameter. The licensing service
+validates the value and returns failure details in the result object when it rejects a value. If you
+omit this parameter, the current setting remains unchanged.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 4
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ServerName
+
+Specifies the host name of the KMS host that the client contacts. Configuring a specific KMS host
+disables KMS host autodiscovery. If you omit this parameter, the current setting remains unchanged.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 0
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+## INPUTS
+
+### None
+
+This cmdlet doesn't accept input from the pipeline.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+When you run the cmdlet synchronously, it returns a structured result object. A successful result
+contains **Success** set to `$true`. A failed result contains **Success** set to `$false`, an
+**ErrorCode** value formatted as a hexadecimal Windows error code when one is available, and an
+**ErrorMessage** value. The cmdlet can return `$null` if it can't obtain the licensing service.
+
+### System.Management.Automation.Job
+
+When you use **AsJob**, the implicit remoting proxy returns a job object that contains the command
+result.
+
+## NOTES
+
+This cmdlet changes persistent KMS configuration on the local computer. Run it from an elevated
+PowerShell session. Before changing settings, record the current configuration with
+`Get-KmsLicenseInfo` so that you can restore it if necessary.
+
+All configuration parameters are optional, and the cmdlet changes only parameters that you
+specify. The integer parameters don't have `ValidateRange` attributes. **Priority** is the only
+parameter with explicit value validation and accepts `Normal` or `Low`.
+
+The source function doesn't define an **AsJob** parameter. **AsJob** is retained here because the
+published command surface uses an implicit remoting proxy that adds the parameter.
+
+## RELATED LINKS
+
+- [Key Management Services (KMS) activation planning for Windows Server](/windows-server/get-started/kms-activation-planning)
+- [Activate using Key Management Service](/windows/deployment/volume-activation/activate-using-key-management-service-vamt)
+- [Slmgr.vbs Options for Obtaining Volume Activation Information](/windows-server/get-started/activation-slmgr-vbs-options)
+- [about_Jobs](/powershell/module/microsoft.powershell.core/about/about_jobs)

--- a/docset/winserver2025-ps/OSLicense/Set-KmsLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Set-KmsLicenseInfo.md
@@ -4,7 +4,7 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/07/2026
+ms.date: 09/09/2026
 PlatyPS schema version: 2024-05-01
 title: Set-KmsLicenseInfo
 ---
@@ -12,7 +12,7 @@ title: Set-KmsLicenseInfo
 # Set-KmsLicenseInfo
 
 ## SYNOPSIS
-Sets Key Management Services (KMS) license configuration.
+Sets the Key Management Services (KMS) license configuration.
 
 ## SYNTAX
 
@@ -32,10 +32,12 @@ the local computer. Specify only the settings that you want to change. Settings 
 parameters remain unchanged.
 
 The cmdlet returns a structured object that indicates whether the operation succeeded. When an
-operation fails, the object includes the available Windows error code and error message instead of
-writing an error to the console.
+operation fails, the cmdlet includes the available Windows error code and error message in the
+object instead of writing an error to the console.
 
-The applicable Windows update KB number that makes this cmdlet available is pending confirmation.
+> [!NOTE]
+> `Set-KmsLicenseInfo` is available in [Windows Server vNext Preview Build 29651](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29651/4549702)
+> and the [2026-09 security update for Windows 11 (KB5124008)](https://support.microsoft.com/help/5124008).
 
 ## EXAMPLES
 
@@ -49,8 +51,8 @@ local computer's licensing configuration, so confirm the host name and port befo
 Set-KmsLicenseInfo -ServerName 'kms01.example.com' -Port 1688
 ```
 
-The returned object has a **Success** property that indicates whether the licensing service applied
-the configuration.
+The command returns an object with a **Success** property that indicates whether the licensing service
+applied the configuration.
 
 ### Example 2: Configure KMS host behavior
 
@@ -106,7 +108,7 @@ HelpMessage: ''
 ### -AsJob
 
 Runs the command as a background job. The command returns a job object that you can use with the
-PowerShell job cmdlets. This parameter is provided by the implicit remoting proxy.
+PowerShell job cmdlets. The implicit remoting proxy provides this parameter.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -128,8 +130,8 @@ HelpMessage: ''
 ### -DnsPublishing
 
 Specifies whether the KMS host publishes its service resource (SRV) record in Domain Name System
-(DNS). Specify `$true` to enable publishing or `$false` to disable it. DNS publishing is enabled by
-default for a KMS host. If you omit this parameter, the current setting remains unchanged.
+(DNS). Specify `$true` to enable publishing or `$false` to disable it. By default, a KMS host
+publishes its SRV record in DNS. If you omit this parameter, the current setting remains unchanged.
 
 ```yaml
 Type: System.Boolean
@@ -151,7 +153,7 @@ HelpMessage: ''
 ### -Domain
 
 Specifies the DNS domain in which the KMS client searches for KMS SRV records. This setting has no
-effect when a specific KMS host is configured with **ServerName**. If you omit this parameter, the
+effect when you configure a specific KMS host with **ServerName**. If you omit this parameter, the
 current setting remains unchanged.
 
 ```yaml
@@ -174,8 +176,8 @@ HelpMessage: ''
 ### -HostCaching
 
 Specifies whether a KMS client caches a discovered KMS host. Specify `$true` to enable caching or
-`$false` to disable it. Host caching is enabled by default. If you omit this parameter, the current
-setting remains unchanged.
+`$false` to disable it. The KMS client enables host caching by default. If you omit this parameter,
+the current setting remains unchanged.
 
 ```yaml
 Type: System.Boolean
@@ -220,10 +222,10 @@ HelpMessage: ''
 
 ### -Port
 
-Specifies the TCP port that the KMS client uses to contact the KMS host specified by **ServerName**.
-The KMS default port is `1688`. The cmdlet doesn't define a range-validation attribute for this
-parameter; the licensing service validates the value. If you omit this parameter, the current
-setting remains unchanged.
+Specifies the TCP port that the KMS client uses to contact the KMS host that **ServerName**
+specifies. The KMS default port is `1688`. The cmdlet doesn't define a range-validation attribute
+for this parameter; the licensing service validates the value. If you omit this parameter, the
+current setting remains unchanged.
 
 ```yaml
 Type: System.Int32
@@ -345,8 +347,8 @@ All configuration parameters are optional, and the cmdlet changes only parameter
 specify. The integer parameters don't have `ValidateRange` attributes. **Priority** is the only
 parameter with explicit value validation and accepts `Normal` or `Low`.
 
-The source function doesn't define an **AsJob** parameter. **AsJob** is retained here because the
-published command surface uses an implicit remoting proxy that adds the parameter.
+The source function doesn't define an **AsJob** parameter. The published command surface retains
+**AsJob** because its implicit remoting proxy adds the parameter.
 
 ## RELATED LINKS
 

--- a/docset/winserver2025-ps/OSLicense/Set-OSLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Set-OSLicenseInfo.md
@@ -1,0 +1,152 @@
+---
+document type: cmdlet
+external help file: OSLicense-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: OSLicense
+ms.date: 09/07/2026
+PlatyPS schema version: 2024-05-01
+title: Set-OSLicenseInfo
+---
+
+# Set-OSLicenseInfo
+
+## SYNOPSIS
+Sets the Windows volume activation type.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Set-OSLicenseInfo [-ActivationType] <Int32> [-AsJob] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Set-OSLicenseInfo` cmdlet changes the volume activation type used by the Windows software
+licensing service on the local computer. You can use the default activation behavior or require
+Active Directory-based, Key Management Services (KMS), or token-based activation.
+
+The cmdlet returns a structured object that indicates whether the operation succeeded. A runtime
+CIM failure is returned in the object with the available Windows error code and error message; the
+cmdlet doesn't write the failure to the error stream.
+
+The applicable Windows update KB number that makes this cmdlet available is pending confirmation.
+
+## EXAMPLES
+
+### Example 1: Require Active Directory-based activation
+
+This command configures the local computer to use Active Directory-based activation. Changing the
+activation type can prevent activation if the required activation infrastructure isn't available,
+so confirm your organization's activation configuration before you run the command.
+
+```powershell
+$result = Set-OSLicenseInfo -ActivationType 1
+$result
+```
+
+Inspect the **Success** property to determine whether the licensing service applied the change. If
+**Success** is `$false`, inspect **ErrorCode** and **ErrorMessage** for failure details.
+
+### Example 2: Restore the default activation behavior
+
+This command restores the default volume activation behavior. This operation changes the local
+computer's licensing configuration, so verify that the default behavior is appropriate before you
+run the command.
+
+```powershell
+Set-OSLicenseInfo -ActivationType 0
+```
+
+## PARAMETERS
+
+### -ActivationType
+
+Specifies the volume activation type. The supported values are:
+
+- `0` - Use the default activation type.
+- `1` - Use Active Directory-based activation.
+- `2` - Use KMS activation.
+- `3` - Use token-based activation.
+
+This parameter is required. PowerShell rejects values outside the range `0` through `3` before the
+cmdlet changes the licensing configuration.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 0
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues:
+- 0
+- 1
+- 2
+- 3
+HelpMessage: ''
+```
+
+### -AsJob
+
+Runs the command as a background job when you invoke it through an implicit-remoting wrapper. This
+parameter is supplied by the wrapper and isn't declared by the local `OSLicense` module function.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+## INPUTS
+
+### None
+
+This cmdlet doesn't accept pipeline input.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+When the licensing service applies the activation type, the cmdlet returns an object with
+**Success** set to `$true` and **ActivationType** set to the requested value.
+
+When a runtime CIM operation fails, the cmdlet returns an object with **Success** set to `$false`,
+**ErrorCode** set to the available Windows HRESULT formatted as a hexadecimal value, and
+**ErrorMessage** set to the available Windows error message. The cmdlet returns no object if it
+can't find the software licensing service.
+
+### System.Management.Automation.Job
+
+When you use **AsJob** through an implicit-remoting wrapper, the cmdlet returns a job object. Use
+`Receive-Job` to retrieve the structured result from the completed job.
+
+## NOTES
+
+Run this cmdlet from an elevated PowerShell session. Parameter-binding and validation failures,
+including an **ActivationType** value outside the supported range, occur before the cmdlet invokes
+the licensing service and aren't returned as structured result objects.
+
+## RELATED LINKS
+
+- [Slmgr.vbs options for volume activation](/windows-server/get-started/activation-slmgr-vbs-options)
+- [SoftwareLicensingService class](/previous-versions/windows/desktop/sppwmi/softwarelicensingservice)

--- a/docset/winserver2025-ps/OSLicense/Set-OSLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Set-OSLicenseInfo.md
@@ -4,7 +4,7 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/07/2026
+ms.date: 09/09/2026
 PlatyPS schema version: 2024-05-01
 title: Set-OSLicenseInfo
 ---
@@ -24,15 +24,17 @@ Set-OSLicenseInfo [-ActivationType] <Int32> [-AsJob] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The `Set-OSLicenseInfo` cmdlet changes the volume activation type used by the Windows software
-licensing service on the local computer. You can use the default activation behavior or require
+The `Set-OSLicenseInfo` cmdlet changes the volume activation type that the Windows software
+licensing service uses on the local computer. Use the default activation behavior or require
 Active Directory-based, Key Management Services (KMS), or token-based activation.
 
-The cmdlet returns a structured object that indicates whether the operation succeeded. A runtime
-CIM failure is returned in the object with the available Windows error code and error message; the
-cmdlet doesn't write the failure to the error stream.
+The cmdlet returns a structured object that indicates whether the operation succeeded. If a runtime
+Common Information Model (CIM) failure occurs, the object includes the available Windows error code
+and error message. The cmdlet doesn't write the failure to the error stream.
 
-The applicable Windows update KB number that makes this cmdlet available is pending confirmation.
+> [!NOTE]
+> `Set-OSLicenseInfo` is available in [Windows Server vNext Preview Build 29651](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29651/4549702)
+> and the [2026-09 security update for Windows 11 (KB5124008)](https://support.microsoft.com/help/5124008).
 
 ## EXAMPLES
 
@@ -64,15 +66,15 @@ Set-OSLicenseInfo -ActivationType 0
 
 ### -ActivationType
 
-Specifies the volume activation type. The supported values are:
+Specifies the volume activation type. The parameter supports these values:
 
 - `0` - Use the default activation type.
 - `1` - Use Active Directory-based activation.
 - `2` - Use KMS activation.
 - `3` - Use token-based activation.
 
-This parameter is required. PowerShell rejects values outside the range `0` through `3` before the
-cmdlet changes the licensing configuration.
+You must specify this parameter. PowerShell rejects values outside the range `0` through `3`
+before the cmdlet changes the licensing configuration.
 
 ```yaml
 Type: System.Int32
@@ -98,7 +100,7 @@ HelpMessage: ''
 ### -AsJob
 
 Runs the command as a background job when you invoke it through an implicit-remoting wrapper. This
-parameter is supplied by the wrapper and isn't declared by the local `OSLicense` module function.
+wrapper supplies the parameter, and the local `OSLicense` module function doesn't declare it.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -127,24 +129,24 @@ This cmdlet doesn't accept pipeline input.
 
 ### System.Management.Automation.PSCustomObject
 
-When the licensing service applies the activation type, the cmdlet returns an object with
-**Success** set to `$true` and **ActivationType** set to the requested value.
+When the licensing service applies the activation type, the cmdlet returns an object. Its
+**Success** property is `$true`, and its **ActivationType** property contains the requested value.
 
-When a runtime CIM operation fails, the cmdlet returns an object with **Success** set to `$false`,
-**ErrorCode** set to the available Windows HRESULT formatted as a hexadecimal value, and
-**ErrorMessage** set to the available Windows error message. The cmdlet returns no object if it
-can't find the software licensing service.
+When a runtime CIM operation fails, the cmdlet returns an object. The **Success** property is
+`$false`, the **ErrorCode** property contains the available Windows HRESULT in hexadecimal format,
+and the **ErrorMessage** property contains the available Windows error message. The cmdlet returns
+no object if it can't find the software licensing service.
 
 ### System.Management.Automation.Job
 
-When you use **AsJob** through an implicit-remoting wrapper, the cmdlet returns a job object. Use
-`Receive-Job` to retrieve the structured result from the completed job.
+When you specify the **AsJob** parameter through an implicit-remoting wrapper, the cmdlet returns a
+job object. Use `Receive-Job` to retrieve the structured result from the completed job.
 
 ## NOTES
 
 Run this cmdlet from an elevated PowerShell session. Parameter-binding and validation failures,
 including an **ActivationType** value outside the supported range, occur before the cmdlet invokes
-the licensing service and aren't returned as structured result objects.
+the licensing service. The cmdlet doesn't return these failures as structured result objects.
 
 ## RELATED LINKS
 

--- a/docset/winserver2025-ps/OSLicense/Set-SubscriptionLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Set-SubscriptionLicenseInfo.md
@@ -1,0 +1,143 @@
+---
+document type: cmdlet
+external help file: OSLicense-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: OSLicense
+ms.date: 09/07/2026
+PlatyPS schema version: 2024-05-01
+title: Set-SubscriptionLicenseInfo
+---
+
+# Set-SubscriptionLicenseInfo
+
+## SYNOPSIS
+Sets subscription license configuration.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Set-SubscriptionLicenseInfo [-Enabled] <Boolean> [-AsJob] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Set-SubscriptionLicenseInfo` cmdlet enables or disables Windows subscription licensing.
+Set **Enabled** to `$true` to enable subscription licensing or `$false` to disable it.
+
+This cmdlet is available on systems that include the OSLicense module. The applicable Windows
+update KB number is pending confirmation.
+
+## EXAMPLES
+
+### Example 1: Enable subscription licensing
+
+This command requests that Windows enable subscription licensing.
+
+> [!CAUTION]
+> This operation changes the system's subscription licensing configuration. Confirm the intended
+> state before you run the command.
+
+```powershell
+Set-SubscriptionLicenseInfo -Enabled $true
+```
+
+### Example 2: Disable subscription licensing
+
+This command requests that Windows disable subscription licensing.
+
+> [!CAUTION]
+> This operation changes the system's subscription licensing configuration. Confirm the intended
+> state before you run the command.
+
+```powershell
+Set-SubscriptionLicenseInfo -Enabled $false
+```
+
+## PARAMETERS
+
+### -AsJob
+
+Runs the command as a background job. This parameter is added by the implicit-remoting wrapper and
+isn't declared by the underlying `Set-SubscriptionLicenseInfo` function.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Enabled
+
+Specifies whether to enable or disable Windows subscription licensing. Set this parameter to `$true`
+to enable subscription licensing or `$false` to disable it.
+
+```yaml
+Type: System.Boolean
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 0
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+## INPUTS
+
+### None
+
+This cmdlet doesn't accept pipeline input.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+When the operation succeeds, the cmdlet returns an object whose **Success** property is `$true`.
+The **Operation** property is `EnableSubscription` or `DisableSubscription`, depending on the value
+of **Enabled**.
+
+If an exception occurs, the cmdlet returns `$null` and doesn't write an error record.
+
+### System.Management.Automation.Job
+
+When you use **AsJob** through an implicit-remoting wrapper, the cmdlet returns a job object. Use
+`Receive-Job` to retrieve the operation result after the job completes.
+
+## NOTES
+
+Run this cmdlet from an elevated PowerShell session because it changes system licensing
+configuration.
+
+The cmdlet reads the subscription type from the `SoftwareLicensingService` CIM instance. The current
+implementation supports subscription type `0`. It invokes `ClipRenew.exe` with either the
+`enablesubscription` or `disablesubscription` operation and suppresses the native command's output.
+An unsupported subscription type, a CIM error, a missing tool, or a nonzero native exit code causes
+the cmdlet to return `$null`.
+
+The source function doesn't define **AsJob**. This parameter is retained because the
+implicit-remoting wrapper adds it to the command surface.
+
+## RELATED LINKS
+
+- [Windows subscription activation](/windows/deployment/windows-subscription-activation)
+- [about_Jobs](/powershell/module/microsoft.powershell.core/about/about_jobs)

--- a/docset/winserver2025-ps/OSLicense/Set-SubscriptionLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Set-SubscriptionLicenseInfo.md
@@ -4,7 +4,7 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/07/2026
+ms.date: 09/09/2026
 PlatyPS schema version: 2024-05-01
 title: Set-SubscriptionLicenseInfo
 ---
@@ -12,7 +12,7 @@ title: Set-SubscriptionLicenseInfo
 # Set-SubscriptionLicenseInfo
 
 ## SYNOPSIS
-Sets subscription license configuration.
+Sets the subscription license configuration.
 
 ## SYNTAX
 
@@ -27,8 +27,11 @@ Set-SubscriptionLicenseInfo [-Enabled] <Boolean> [-AsJob] [<CommonParameters>]
 The `Set-SubscriptionLicenseInfo` cmdlet enables or disables Windows subscription licensing.
 Set **Enabled** to `$true` to enable subscription licensing or `$false` to disable it.
 
-This cmdlet is available on systems that include the OSLicense module. The applicable Windows
-update KB number is pending confirmation.
+This cmdlet is available on systems that include the OSLicense module.
+
+> [!NOTE]
+> `Set-SubscriptionLicenseInfo` is available in [Windows Server vNext Preview Build 29651](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29651/4549702)
+> and the [2026-09 security update for Windows 11 (KB5124008)](https://support.microsoft.com/help/5124008).
 
 ## EXAMPLES
 
@@ -60,8 +63,8 @@ Set-SubscriptionLicenseInfo -Enabled $false
 
 ### -AsJob
 
-Runs the command as a background job. This parameter is added by the implicit-remoting wrapper and
-isn't declared by the underlying `Set-SubscriptionLicenseInfo` function.
+Runs the command as a background job. The implicit-remoting wrapper adds this parameter, but the
+underlying `Set-SubscriptionLicenseInfo` function doesn't declare it.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -82,7 +85,7 @@ HelpMessage: ''
 
 ### -Enabled
 
-Specifies whether to enable or disable Windows subscription licensing. Set this parameter to `$true`
+Enables or disables Windows subscription licensing. Set this parameter to `$true`
 to enable subscription licensing or `$false` to disable it.
 
 ```yaml
@@ -128,14 +131,14 @@ When you use **AsJob** through an implicit-remoting wrapper, the cmdlet returns 
 Run this cmdlet from an elevated PowerShell session because it changes system licensing
 configuration.
 
-The cmdlet reads the subscription type from the `SoftwareLicensingService` CIM instance. The current
+The cmdlet reads the subscription type from the **SoftwareLicensingService** CIM instance. The current
 implementation supports subscription type `0`. It invokes `ClipRenew.exe` with either the
 `enablesubscription` or `disablesubscription` operation and suppresses the native command's output.
 An unsupported subscription type, a CIM error, a missing tool, or a nonzero native exit code causes
 the cmdlet to return `$null`.
 
-The source function doesn't define **AsJob**. This parameter is retained because the
-implicit-remoting wrapper adds it to the command surface.
+The implicit-remoting wrapper adds the **AsJob** parameter to the command surface even though the
+source function doesn't define it.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
# PR Summary

Adds the initial OSLicense PowerShell reference for Windows Server 2025. The new module page and nine cmdlet pages document licensing information, activation, KMS configuration, and subscription licensing operations that supplement `slmgr.vbs` workflows.

The reference includes source-grounded syntax, parameter descriptions, examples, inputs, outputs, operational cautions, and related links. It was validated against the approved OSLicense engineering surface and follows the PlatyPS command-help structure.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide