### PR TITLE
Add OSLicense online help metadata

### DIFF
--- a/docset/winserver2025-ps/OSLicense/Get-ADLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Get-ADLicenseInfo.md
@@ -4,7 +4,8 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/09/2026
+ms.date: 09/10/2026
+online version: https://learn.microsoft.com/powershell/module/oslicense/get-adlicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Get-ADLicenseInfo
 ---

--- a/docset/winserver2025-ps/OSLicense/Get-OSLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Get-OSLicenseInfo.md
@@ -4,7 +4,8 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/09/2026
+ms.date: 09/10/2026
+online version: https://learn.microsoft.com/powershell/module/oslicense/get-oslicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Get-OSLicenseInfo
 ---

--- a/docset/winserver2025-ps/OSLicense/Invoke-ADLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-ADLicense.md
@@ -4,7 +4,8 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/09/2026
+ms.date: 09/10/2026
+online version: https://learn.microsoft.com/powershell/module/oslicense/invoke-adlicense?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Invoke-ADLicense
 ---

--- a/docset/winserver2025-ps/OSLicense/Invoke-KmsLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-KmsLicense.md
@@ -4,7 +4,8 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/09/2026
+ms.date: 09/10/2026
+online version: https://learn.microsoft.com/powershell/module/oslicense/invoke-kmslicense?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Invoke-KmsLicense
 ---

--- a/docset/winserver2025-ps/OSLicense/Invoke-OSLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-OSLicense.md
@@ -4,7 +4,8 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/09/2026
+ms.date: 09/10/2026
+online version: https://learn.microsoft.com/powershell/module/oslicense/invoke-oslicense?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Invoke-OSLicense
 ---

--- a/docset/winserver2025-ps/OSLicense/Invoke-SubscriptionLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-SubscriptionLicense.md
@@ -4,7 +4,8 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/09/2026
+ms.date: 09/10/2026
+online version: https://learn.microsoft.com/powershell/module/oslicense/invoke-subscriptionlicense?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Invoke-SubscriptionLicense
 ---

--- a/docset/winserver2025-ps/OSLicense/OSLicense.md
+++ b/docset/winserver2025-ps/OSLicense/OSLicense.md
@@ -1,11 +1,12 @@
 ---
 document type: module
+Download Help Link: https://aka.ms/winsvr-2025-pshelp
 Help Version: 1.0.0.0
 HelpInfoUri:
 Locale: en-US
 Module Guid: b3e5a5c8-7d2f-4e1a-9c3b-8f6d4a2e1b0c
 Module Name: OSLicense
-ms.date: 09/09/2026
+ms.date: 09/10/2026
 PlatyPS schema version: 2024-05-01
 title: OSLicense Module
 ---

--- a/docset/winserver2025-ps/OSLicense/Set-KmsLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Set-KmsLicenseInfo.md
@@ -4,7 +4,8 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/09/2026
+ms.date: 09/10/2026
+online version: https://learn.microsoft.com/powershell/module/oslicense/set-kmslicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Set-KmsLicenseInfo
 ---

--- a/docset/winserver2025-ps/OSLicense/Set-OSLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Set-OSLicenseInfo.md
@@ -4,7 +4,8 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/09/2026
+ms.date: 09/10/2026
+online version: https://learn.microsoft.com/powershell/module/oslicense/set-oslicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Set-OSLicenseInfo
 ---

--- a/docset/winserver2025-ps/OSLicense/Set-SubscriptionLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Set-SubscriptionLicenseInfo.md
@@ -4,7 +4,8 @@ external help file: OSLicense-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: OSLicense
-ms.date: 09/09/2026
+ms.date: 09/10/2026
+online version: https://learn.microsoft.com/powershell/module/oslicense/set-subscriptionlicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Set-SubscriptionLicenseInfo
 ---


### PR DESCRIPTION
# PR Summary

Adds the online-help metadata omitted from the OSLicense reference added in #4128.

- Adds the canonical `online version` URL to all nine OSLicense cmdlet pages so `Get-Help -Online` can open the published reference.
- Adds the Windows Server 2025 `Download Help Link` to the OSLicense module page.
- Updates `ms.date` on the ten affected pages.

Related work: [User Story 617456](https://dev.azure.com/msft-skilling/Content/_workitems/edit/617456)

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide