### PR TITLE
Use canonical OSLicense help URI metadata

### DIFF
--- a/docset/winserver2025-ps/OSLicense/Get-ADLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Get-ADLicenseInfo.md
@@ -1,11 +1,10 @@
 ---
 document type: cmdlet
 external help file: OSLicense-Help.xml
-HelpUri: ''
+HelpUri: https://learn.microsoft.com/powershell/module/oslicense/get-adlicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 Locale: en-US
 Module Name: OSLicense
 ms.date: 09/10/2026
-online version: https://learn.microsoft.com/powershell/module/oslicense/get-adlicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Get-ADLicenseInfo
 ---

--- a/docset/winserver2025-ps/OSLicense/Get-OSLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Get-OSLicenseInfo.md
@@ -1,11 +1,10 @@
 ---
 document type: cmdlet
 external help file: OSLicense-Help.xml
-HelpUri: ''
+HelpUri: https://learn.microsoft.com/powershell/module/oslicense/get-oslicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 Locale: en-US
 Module Name: OSLicense
 ms.date: 09/10/2026
-online version: https://learn.microsoft.com/powershell/module/oslicense/get-oslicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Get-OSLicenseInfo
 ---

--- a/docset/winserver2025-ps/OSLicense/Invoke-ADLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-ADLicense.md
@@ -1,11 +1,10 @@
 ---
 document type: cmdlet
 external help file: OSLicense-Help.xml
-HelpUri: ''
+HelpUri: https://learn.microsoft.com/powershell/module/oslicense/invoke-adlicense?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 Locale: en-US
 Module Name: OSLicense
 ms.date: 09/10/2026
-online version: https://learn.microsoft.com/powershell/module/oslicense/invoke-adlicense?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Invoke-ADLicense
 ---

--- a/docset/winserver2025-ps/OSLicense/Invoke-KmsLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-KmsLicense.md
@@ -1,11 +1,10 @@
 ---
 document type: cmdlet
 external help file: OSLicense-Help.xml
-HelpUri: ''
+HelpUri: https://learn.microsoft.com/powershell/module/oslicense/invoke-kmslicense?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 Locale: en-US
 Module Name: OSLicense
 ms.date: 09/10/2026
-online version: https://learn.microsoft.com/powershell/module/oslicense/invoke-kmslicense?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Invoke-KmsLicense
 ---

--- a/docset/winserver2025-ps/OSLicense/Invoke-OSLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-OSLicense.md
@@ -1,11 +1,10 @@
 ---
 document type: cmdlet
 external help file: OSLicense-Help.xml
-HelpUri: ''
+HelpUri: https://learn.microsoft.com/powershell/module/oslicense/invoke-oslicense?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 Locale: en-US
 Module Name: OSLicense
 ms.date: 09/10/2026
-online version: https://learn.microsoft.com/powershell/module/oslicense/invoke-oslicense?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Invoke-OSLicense
 ---

--- a/docset/winserver2025-ps/OSLicense/Invoke-SubscriptionLicense.md
+++ b/docset/winserver2025-ps/OSLicense/Invoke-SubscriptionLicense.md
@@ -1,11 +1,10 @@
 ---
 document type: cmdlet
 external help file: OSLicense-Help.xml
-HelpUri: ''
+HelpUri: https://learn.microsoft.com/powershell/module/oslicense/invoke-subscriptionlicense?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 Locale: en-US
 Module Name: OSLicense
 ms.date: 09/10/2026
-online version: https://learn.microsoft.com/powershell/module/oslicense/invoke-subscriptionlicense?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Invoke-SubscriptionLicense
 ---

--- a/docset/winserver2025-ps/OSLicense/OSLicense.md
+++ b/docset/winserver2025-ps/OSLicense/OSLicense.md
@@ -1,8 +1,7 @@
 ---
 document type: module
-Download Help Link: https://aka.ms/winsvr-2025-pshelp
+HelpInfoUri: https://aka.ms/winsvr-2025-pshelp
 Help Version: 1.0.0.0
-HelpInfoUri:
 Locale: en-US
 Module Guid: b3e5a5c8-7d2f-4e1a-9c3b-8f6d4a2e1b0c
 Module Name: OSLicense

--- a/docset/winserver2025-ps/OSLicense/Set-KmsLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Set-KmsLicenseInfo.md
@@ -1,11 +1,10 @@
 ---
 document type: cmdlet
 external help file: OSLicense-Help.xml
-HelpUri: ''
+HelpUri: https://learn.microsoft.com/powershell/module/oslicense/set-kmslicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 Locale: en-US
 Module Name: OSLicense
 ms.date: 09/10/2026
-online version: https://learn.microsoft.com/powershell/module/oslicense/set-kmslicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Set-KmsLicenseInfo
 ---

--- a/docset/winserver2025-ps/OSLicense/Set-OSLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Set-OSLicenseInfo.md
@@ -1,11 +1,10 @@
 ---
 document type: cmdlet
 external help file: OSLicense-Help.xml
-HelpUri: ''
+HelpUri: https://learn.microsoft.com/powershell/module/oslicense/set-oslicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 Locale: en-US
 Module Name: OSLicense
 ms.date: 09/10/2026
-online version: https://learn.microsoft.com/powershell/module/oslicense/set-oslicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Set-OSLicenseInfo
 ---

--- a/docset/winserver2025-ps/OSLicense/Set-SubscriptionLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Set-SubscriptionLicenseInfo.md
@@ -1,11 +1,10 @@
 ---
 document type: cmdlet
 external help file: OSLicense-Help.xml
-HelpUri: ''
+HelpUri: https://learn.microsoft.com/powershell/module/oslicense/set-subscriptionlicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 Locale: en-US
 Module Name: OSLicense
 ms.date: 09/10/2026
-online version: https://learn.microsoft.com/powershell/module/oslicense/set-subscriptionlicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
 PlatyPS schema version: 2024-05-01
 title: Set-SubscriptionLicenseInfo
 ---


### PR DESCRIPTION
# PR Summary

Moves the OSLicense help URLs into the canonical PlatyPS metadata fields.

- Populates `HelpUri` on all nine cmdlet pages using their existing Learn URLs.
- Populates module-level `HelpInfoUri` with `https://aka.ms/winsvr-2025-pshelp`.
- Removes the superseded `online version` and `Download Help Link` fields.

This addresses the Updatable Help failure:

```text
MakeHelpInfoXml: Cannot bind argument to parameter 'URI' because it is an empty string.
```

- Onward publish PR: #4130
- Original content PR: #4128
- Initial metadata PR: #4131

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide