### PR TITLE
Add missing OSLicense getter references

### DIFF
--- a/docset/winserver2025-ps/OSLicense/Get-KmsLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Get-KmsLicenseInfo.md
@@ -1,0 +1,116 @@
+---
+document type: cmdlet
+external help file: OSLicense-Help.xml
+HelpUri: https://learn.microsoft.com/powershell/module/oslicense/get-kmslicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
+Locale: en-US
+Module Name: OSLicense
+ms.date: 09/11/2026
+PlatyPS schema version: 2024-05-01
+title: Get-KmsLicenseInfo
+---
+
+# Get-KmsLicenseInfo
+
+## SYNOPSIS
+Gets Key Management Service (KMS) licensing information.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Get-KmsLicenseInfo [<CommonParameters>]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+The `Get-KmsLicenseInfo` cmdlet queries the local software licensing service for KMS client and KMS
+host configuration, activation intervals, discovery information, and request counts. The cmdlet is
+read-only and doesn't change the licensing configuration.
+
+The cmdlet returns KMS service properties for the local computer. When it finds a Windows operating
+system licensing product with a partial product key, it also returns activation and renewal
+intervals and information about the discovered KMS host.
+
+> [!NOTE]
+> `Get-KmsLicenseInfo` is available in [Windows Server vNext Preview Build 29651](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29651/4549702)
+> and the [2026-09 security update for Windows 11 (KB5124008)](https://support.microsoft.com/help/5124008).
+
+## EXAMPLES
+
+### Example 1: Get KMS client configuration
+
+```powershell
+Get-KmsLicenseInfo |
+    Select-Object KeyManagementServiceMachine, KeyManagementServicePort,
+        KeyManagementServiceLookupDomain, KeyManagementServiceHostCaching
+```
+
+This example gets the configured KMS client host, port, lookup domain, and host-caching setting.
+
+### Example 2: Review KMS host request counts
+
+```powershell
+Get-KmsLicenseInfo |
+    Select-Object IsKeyManagementServiceMachine, KeyManagementServiceListeningPort,
+        KeyManagementServiceCurrentCount, KeyManagementServiceLicensedRequests,
+        KeyManagementServiceFailedRequests, KeyManagementServiceTotalRequests
+```
+
+This example selects KMS host configuration and request-count properties from the returned object.
+
+## PARAMETERS
+
+## INPUTS
+
+### None
+
+This cmdlet doesn't accept input from the pipeline.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+The cmdlet returns an object with the following KMS service properties:
+
+- **KeyManagementServiceMachine**
+- **KeyManagementServicePort**
+- **KeyManagementServiceLookupDomain**
+- **IsKeyManagementServiceMachine**
+- **KeyManagementServiceListeningPort**
+- **KeyManagementServiceDnsPublishing**
+- **KeyManagementServiceHostCaching**
+- **KeyManagementServiceLowPriority**
+- **KeyManagementServiceCurrentCount**
+- **KeyManagementServiceUnlicensedRequests**
+- **KeyManagementServiceLicensedRequests**
+- **KeyManagementServiceOOBGraceRequests**
+- **KeyManagementServiceOOTGraceRequests**
+- **KeyManagementServiceNonGenuineGraceRequests**
+- **KeyManagementServiceTotalRequests**
+- **KeyManagementServiceNotificationRequests**
+- **KeyManagementServiceFailedRequests**
+
+When a Windows operating system licensing product is available, the object also includes
+**VLActivationInterval**, **VLRenewalInterval**, **DiscoveredKeyManagementServiceMachineName**, and
+**DiscoveredKeyManagementServiceMachinePort**.
+
+## NOTES
+
+The cmdlet returns no object when it can't obtain the local **SoftwareLicensingService** CIM
+instance or when a CIM query fails.
+
+When KMS request-count or current-count data isn't available, the cmdlet returns `N/A` instead of
+the numeric value that the licensing service uses to indicate unavailable data.
+
+## RELATED LINKS
+
+- [Key Management Services (KMS) activation planning for Windows Server](/windows-server/get-started/kms-activation-planning)
+- [Activate using Key Management Service](/windows/deployment/volume-activation/activate-using-key-management-service-vamt)
+- [Monitor activation](/windows/deployment/volume-activation/monitor-activation-client)
+- [SoftwareLicensingService class](/previous-versions/windows/desktop/sppwmi/softwarelicensingservice)
+- [SoftwareLicensingProduct class](/previous-versions/windows/desktop/sppwmi/softwarelicensingproduct)

--- a/docset/winserver2025-ps/OSLicense/Get-SubscriptionLicenseInfo.md
+++ b/docset/winserver2025-ps/OSLicense/Get-SubscriptionLicenseInfo.md
@@ -1,0 +1,103 @@
+---
+document type: cmdlet
+external help file: OSLicense-Help.xml
+HelpUri: https://learn.microsoft.com/powershell/module/oslicense/get-subscriptionlicenseinfo?view=windowsserver2025-ps&wt.mc_id=ps-gethelp
+Locale: en-US
+Module Name: OSLicense
+ms.date: 09/11/2026
+PlatyPS schema version: 2024-05-01
+title: Get-SubscriptionLicenseInfo
+---
+
+# Get-SubscriptionLicenseInfo
+
+## SYNOPSIS
+Gets Windows subscription licensing information.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Get-SubscriptionLicenseInfo [<CommonParameters>]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+The `Get-SubscriptionLicenseInfo` cmdlet queries the local software licensing service for the
+Windows subscription type, status, expiration value, and edition. It returns both localized type
+and status text and their underlying numeric values.
+
+This cmdlet is read-only and doesn't enable, disable, refresh, acquire, or remove a subscription
+license.
+
+> [!NOTE]
+> `Get-SubscriptionLicenseInfo` is available in [Windows Server vNext Preview Build 29651](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29651/4549702)
+> and the [2026-09 security update for Windows 11 (KB5124008)](https://support.microsoft.com/help/5124008).
+
+## EXAMPLES
+
+### Example 1: Get subscription licensing information
+
+```powershell
+Get-SubscriptionLicenseInfo
+```
+
+This example gets the subscription type, status, expiration value, and edition for the local
+computer.
+
+### Example 2: Check whether subscription licensing is active
+
+```powershell
+$subscription = Get-SubscriptionLicenseInfo
+
+if ($subscription.SubscriptionStatusValue -eq 1) {
+    'Subscription licensing is active.'
+}
+```
+
+This example checks the underlying numeric status value. A value of `1` represents an active
+subscription.
+
+## PARAMETERS
+
+## INPUTS
+
+### None
+
+This cmdlet doesn't accept input from the pipeline.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+The cmdlet returns an object with the following properties:
+
+- **SubscriptionType** - Localized text for the subscription type.
+- **SubscriptionTypeValue** - The underlying numeric subscription type.
+- **SubscriptionStatus** - Localized text for the subscription status.
+- **SubscriptionStatusValue** - The underlying numeric subscription status.
+- **SubscriptionExpiry** - The subscription expiration value returned by the licensing service.
+- **SubscriptionEdition** - The Windows edition associated with the subscription.
+
+For **SubscriptionTypeValue**, the cmdlet maps `0` to `User Based Subscription`, `9999` to
+`Invalid`, and `120` to `Not Installed`. It formats other values as `Unknown (<value>)`.
+
+For **SubscriptionStatusValue**, the cmdlet maps `0` to `Not Active`, `1` to `Active`, `100` to
+`Disabled`, `110` to `Expired`, and `120` to `Not Installed`. It formats other values as
+`Unknown (<value>)`.
+
+## NOTES
+
+The cmdlet returns no object when it can't obtain the local **SoftwareLicensingService** CIM
+instance or when the query fails. It returns **SubscriptionExpiry** without converting the value
+that the licensing service provides.
+
+## RELATED LINKS
+
+- [Windows subscription activation](/windows/deployment/windows-subscription-activation)
+- [SoftwareLicensingService class](/previous-versions/windows/desktop/sppwmi/softwarelicensingservice)

--- a/docset/winserver2025-ps/OSLicense/OSLicense.md
+++ b/docset/winserver2025-ps/OSLicense/OSLicense.md
@@ -5,7 +5,7 @@ Help Version: 1.0.0.0
 Locale: en-US
 Module Guid: b3e5a5c8-7d2f-4e1a-9c3b-8f6d4a2e1b0c
 Module Name: OSLicense
-ms.date: 09/10/2026
+ms.date: 09/11/2026
 PlatyPS schema version: 2024-05-01
 title: OSLicense Module
 ---
@@ -27,9 +27,17 @@ Windows update KB number for module availability still needs confirmation.
 
 Gets Active Directory-based activation information.
 
+### [Get-KmsLicenseInfo](Get-KmsLicenseInfo.md)
+
+Gets Key Management Service (KMS) licensing information.
+
 ### [Get-OSLicenseInfo](Get-OSLicenseInfo.md)
 
 Gets Windows operating system licensing information.
+
+### [Get-SubscriptionLicenseInfo](Get-SubscriptionLicenseInfo.md)
+
+Gets Windows subscription licensing information.
 
 ### [Invoke-ADLicense](Invoke-ADLicense.md)
 


### PR DESCRIPTION
# PR Summary

Adds the two OSLicense getter reference pages omitted from the original module publication:

- `Get-KmsLicenseInfo`
- `Get-SubscriptionLicenseInfo`

The pages were authored manually against the engineering `.psm1` sources and runtime `Get-Command` output. Microsoft.PowerShell.PlatyPS 1.0.3 couldn't generate these parameterless commands because `Get-Help -Full` exposes the empty parameter collection as `System.String`; PlatyPS then attempts to access `.parameters.parameter` in `GetParameterDefaultValueFromHelp` and throws a `RuntimeBinderException`.

The module page now links both commands. Static validation confirms schema `2024-05-01` heading order, canonical `HelpUri` metadata, common-parameter-only syntax, source-backed output properties, link integrity, and no `AsJob` parameter.

Related work:

- [User Story 617456](https://dev.azure.com/msft-skilling/Content/_workitems/edit/617456)
- Original OSLicense reference: #4128
- Canonical help URI metadata: #4132

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide